### PR TITLE
Bump rows_emitted only after EndOfStream ack

### DIFF
--- a/src/ch_emitter.rs
+++ b/src/ch_emitter.rs
@@ -1575,13 +1575,11 @@ impl Emitter {
             return Ok(());
         };
         let alloc = self.alloc;
-        if let Some(enc) = self.tables.get_mut(&key) {
-            let n = enc.flush_block(&mut self.client, alloc, BlockOpts::default())?;
-            if n > 0 {
-                self.stats.rows_emitted += n as u64;
-                self.stats.blocks_sent += 1;
-            }
-        }
+        let n = if let Some(enc) = self.tables.get_mut(&key) {
+            enc.flush_block(&mut self.client, alloc, BlockOpts::default())?
+        } else {
+            0
+        };
         self.client.send_data(None)?;
         loop {
             let mut pkt = self.client.recv_packet()?;
@@ -1600,8 +1598,13 @@ impl Emitter {
             }
         }
         // EndOfStream confirmed: the INSERT is durable on CH, so the
-        // rows just sealed are now safe to drop. Until this point the
-        // buffer is the only replay source if the connection bounced.
+        // rows just sealed are now safe to count and drop. Until this
+        // point the buffer is the only replay source if the connection
+        // bounced.
+        if n > 0 {
+            self.stats.rows_emitted += n as u64;
+            self.stats.blocks_sent += 1;
+        }
         if let Some(enc) = self.tables.get_mut(&key) {
             enc.clear();
         }


### PR DESCRIPTION
close_current_wire bumped self.stats.rows_emitted right after flush_block, before send_data(None) and the EndOfStream drain. CH treats the wire as one atomic unit: if the connection drops or CH sends an Exception mid-INSERT, the whole wire rolls back. With the counter bumped pre-ack, every rolled-back wire over-counted by its block's worth of rows, and a successful retry would bump again on top.

Move the bump (and blocks_sent) past the drain loop so the stat reflects only confirmed-durable rows.