### PR TITLE
Atomic stats counters; wire Prometheus emitter metrics

### DIFF
--- a/src/atomic_stats.rs
+++ b/src/atomic_stats.rs
@@ -1,0 +1,21 @@
+//! Single source of truth for atomic-fielded stats structs. `atomic_stats!`
+//! declares a `#[derive(Debug, Default)]` struct of `AtomicU64` counters;
+//! call sites bump via `.fetch_add(_, Relaxed)` and read via `.load(Relaxed)`.
+//! No mirror / snapshot type — the live struct is the API, so the
+//! memory-ordering choice stays visible at every read site.
+
+#[macro_export]
+macro_rules! atomic_stats {
+    (
+        $(#[$smeta:meta])*
+        $svis:vis struct $name:ident {
+            $($(#[$fmeta:meta])* $fvis:vis $field:ident,)*
+        }
+    ) => {
+        $(#[$smeta])*
+        #[derive(::core::fmt::Debug, ::core::default::Default)]
+        $svis struct $name {
+            $($(#[$fmeta])* $fvis $field: ::core::sync::atomic::AtomicU64,)*
+        }
+    };
+}

--- a/src/bin/stream.rs
+++ b/src/bin/stream.rs
@@ -156,7 +156,10 @@ struct DaemonSinks {
     /// Shared with the `BufferingDecoderSink` running on the queueing
     /// worker; the status loop polls counters here without contending
     /// on the worker.
-    decoder_stats: Arc<std::sync::Mutex<walshadow::decoder_sink::DecoderStats>>,
+    decoder_stats: Arc<walshadow::decoder_sink::DecoderStats>,
+    /// Shared with the [`Emitter`] running inside the queueing-worker's
+    /// observer. `None` when the daemon runs without a CH emitter wired.
+    emitter_stats: Option<Arc<walshadow::ch_emitter::EmitterStats>>,
 }
 
 impl RecordSink for DaemonSinks {
@@ -746,9 +749,7 @@ async fn run(args: Args) -> Result<()> {
     // read/write vtable), so we `into_std()` + `set_nonblocking(false)`
     // right before construction.
     let mut mapping_handle: Option<MappingHandle> = None;
-    let mut emitter_stats_handle: Option<
-        Arc<std::sync::Mutex<walshadow::ch_emitter::EmitterStats>>,
-    > = None;
+    let mut emitter_stats_handle: Option<Arc<walshadow::ch_emitter::EmitterStats>> = None;
     let inner_observer: Box<dyn TupleObserver> = match initial_ch_config {
         Some(emitter_cfg) => {
             let addr = format!("{}:{}", emitter_cfg.host, emitter_cfg.port);
@@ -788,9 +789,9 @@ async fn run(args: Args) -> Result<()> {
             .context("init DDL applicator")?;
             let emitter = emitter.with_applicator(applicator);
             tracing::info!(target: "walshadow::ch_emitter", addr = %addr, "ch emitter + DDL applicator connected");
-            let emitter_observer = EmitterObserver::new(emitter);
-            emitter_stats_handle = Some(emitter_observer.stats_handle());
-            Box::new(emitter_observer)
+            let observer = EmitterObserver::new(emitter);
+            emitter_stats_handle = Some(observer.stats_handle());
+            Box::new(observer)
         }
         None => Box::new(MetricsTupleObserver::default()),
     };
@@ -834,6 +835,7 @@ async fn run(args: Args) -> Result<()> {
         metrics: MetricsRecordSink::default(),
         decoder_xact,
         decoder_stats: decoder_stats_handle,
+        emitter_stats: emitter_stats_handle,
     };
     let mut segment_sink = DirSegmentSink::new(args.out_dir.clone()).context("open out-dir")?;
     let mut chunk_buf = Vec::with_capacity(64 * 1024);
@@ -1049,19 +1051,14 @@ async fn run(args: Args) -> Result<()> {
             let line = stats.summary();
             (stats, line)
         };
-        let (oracle_stats, oracle_line) = match &oracle {
-            Some(o) => {
-                let s = o.stats.lock().await.clone();
-                let line = s.summary();
-                (Some(s), line)
-            }
-            None => (None, String::new()),
+        let oracle_line = match &oracle {
+            Some(o) => o.stats.summary(),
+            None => String::new(),
         };
-        let decoder_stats = record_sink
-            .decoder_stats
-            .lock()
-            .expect("decoder stats mutex poisoned")
-            .clone();
+        let oracle_stats = oracle.as_ref().map(|o| o.stats.as_ref());
+        let decoder_stats: &walshadow::decoder_sink::DecoderStats = &record_sink.decoder_stats;
+        let emitter_stats: Option<&walshadow::ch_emitter::EmitterStats> =
+            record_sink.emitter_stats.as_deref();
         let shadow_apply_lsn = shadow_agg.min_apply_lsn.unwrap_or(0);
         let lag_bytes = received.saturating_sub(shadow_apply_lsn);
         rate_estimator.observe(Instant::now(), received);
@@ -1071,14 +1068,6 @@ async fn run(args: Args) -> Result<()> {
         // drained, not the snapshot taken at the top of this iteration.
         let emitter_ack_for_metric = xact_stats.emitter_ack_lsn;
         let drain_for_metric = xact_stats.drain_lsn;
-        // Emitter counters live inside the QueueingRecordSink worker; the
-        // observer mirrors them into this shared handle after each
-        // dispatch. `None` when running without `--ch-config` (metrics-
-        // only observer never bumps emitter counters).
-        let emitter_stats = emitter_stats_handle
-            .as_ref()
-            .map(|h| h.lock().expect("emitter stats mutex poisoned").clone())
-            .unwrap_or_default();
         populate_metrics(
             &metrics,
             received,
@@ -1088,9 +1077,9 @@ async fn run(args: Args) -> Result<()> {
             emitter_ack_for_metric,
             &record_sink.metrics,
             &xact_stats,
-            &decoder_stats,
-            &emitter_stats,
-            oracle_stats.as_ref(),
+            decoder_stats,
+            emitter_stats,
+            oracle_stats,
             start_instant.elapsed().as_secs(),
             ShadowMetricsView {
                 apply_lag_bytes: lag_bytes,
@@ -1385,7 +1374,7 @@ async fn populate_metrics(
     rec_metrics: &MetricsRecordSink,
     xact_stats: &walshadow::xact_buffer::XactBufferStats,
     decoder_stats: &walshadow::decoder_sink::DecoderStats,
-    emitter_stats: &walshadow::ch_emitter::EmitterStats,
+    emitter_stats: Option<&walshadow::ch_emitter::EmitterStats>,
     oracle_stats: Option<&walshadow::oracle::OracleStats>,
     uptime_secs: u64,
     shadow_view: ShadowMetricsView,
@@ -1417,19 +1406,37 @@ async fn populate_metrics(
         spill_evictions_total: xact_stats.spill_evictions_total,
         xacts_committed_total: xact_stats.committed_xacts_total,
         xacts_aborted_total: xact_stats.aborted_xacts_total,
-        decoder_decoded_total: decoder_stats.decoded,
-        decoder_partial_total: decoder_stats.partial,
-        decoder_toast_chunks_total: decoder_stats.toast_chunks_buffered,
-        decoder_toast_malformed_total: decoder_stats.toast_chunks_malformed,
-        emitter_rows_total: emitter_stats.rows_emitted,
-        emitter_blocks_total: emitter_stats.blocks_sent,
-        emitter_xacts_total: emitter_stats.xacts_committed,
-        emitter_unsupported_relations: emitter_stats.unsupported_relations,
-        oracle_resolved_total: oracle_stats.map(|s| s.resolved).unwrap_or(0),
-        oracle_fallback_raw_total: oracle_stats.map(|s| s.fallback_raw).unwrap_or(0),
-        oracle_validate_sampled_total: oracle_stats.map(|s| s.probes).unwrap_or(0),
-        oracle_validate_mismatches_total: oracle_stats.map(|s| s.mismatches).unwrap_or(0),
-        oracle_errors_total: oracle_stats.map(|s| s.errors).unwrap_or(0),
+        decoder_decoded_total: decoder_stats.decoded.load(Ordering::Relaxed),
+        decoder_partial_total: decoder_stats.partial.load(Ordering::Relaxed),
+        decoder_toast_chunks_total: decoder_stats.toast_chunks_buffered.load(Ordering::Relaxed),
+        decoder_toast_malformed_total: decoder_stats.toast_chunks_malformed.load(Ordering::Relaxed),
+        emitter_rows_total: emitter_stats
+            .map(|s| s.rows_emitted.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        emitter_blocks_total: emitter_stats
+            .map(|s| s.blocks_sent.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        emitter_xacts_total: emitter_stats
+            .map(|s| s.xacts_committed.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        emitter_unsupported_relations: emitter_stats
+            .map(|s| s.unsupported_relations.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        oracle_resolved_total: oracle_stats
+            .map(|s| s.resolved.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        oracle_fallback_raw_total: oracle_stats
+            .map(|s| s.fallback_raw.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        oracle_validate_sampled_total: oracle_stats
+            .map(|s| s.probes.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        oracle_validate_mismatches_total: oracle_stats
+            .map(|s| s.mismatches.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        oracle_errors_total: oracle_stats
+            .map(|s| s.errors.load(Ordering::Relaxed))
+            .unwrap_or(0),
         uptime_secs,
         shadow_apply_lag_bytes: shadow_view.apply_lag_bytes,
         shadow_apply_lag_seconds: shadow_view.apply_lag_seconds,
@@ -1597,10 +1604,11 @@ async fn run_bootstrap(
             walshadow::decoder_sink::TupleObserver::on_close(&mut observer)
                 .await
                 .context("bootstrap emitter shutdown flush")?;
+            use std::sync::atomic::Ordering;
             tracing::info!(
                 target: "walshadow::bootstrap",
-                rows_emitted = observer.emitter.stats.rows_emitted,
-                blocks_sent = observer.emitter.stats.blocks_sent,
+                rows_emitted = observer.emitter.stats.rows_emitted.load(Ordering::Relaxed),
+                blocks_sent = observer.emitter.stats.blocks_sent.load(Ordering::Relaxed),
                 "bootstrap emitter drained",
             );
             // Drop the transitional emitter so its CH TCP closes

--- a/src/ch_emitter.rs
+++ b/src/ch_emitter.rs
@@ -43,6 +43,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
 use clickhouse_c::{
@@ -1349,34 +1350,37 @@ pub struct Emitter {
     /// (code 101 "Unexpected packet Query"), so any wire activity for
     /// table B must call `close_current_wire` first if A is open.
     wire_open_key: Option<String>,
-    pub stats: EmitterStats,
+    pub stats: Arc<EmitterStats>,
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct EmitterStats {
-    pub rows_emitted: u64,
-    pub blocks_sent: u64,
-    pub xacts_committed: u64,
-    pub unsupported_relations: u64,
-    /// Rows whose filenode resolved to a foreign database (physical WAL
-    /// carries the whole cluster). Skipped, not an error.
-    pub foreign_db_rows_skipped: u64,
-    pub unsupported_values: u64,
-    /// Phase 10 retry bookkeeping. `reconnects` ticks on every fresh
-    /// CH socket the daemon hot-replaces; `retries_attempted` ticks on
-    /// every reconnect-triggered retry (one per failing operation,
-    /// not per attempt — so a single op that needed 3 retries adds 3).
-    pub reconnects: u64,
-    pub retries_attempted: u64,
-    /// `HeapOp::Truncate` events shipped to CH as `TRUNCATE TABLE`.
-    pub truncates_emitted: u64,
-    /// Number of times the hold-INSERT-open deadline tripped (i.e.
-    /// `flush_timeout` elapsed since the first row of a fresh INSERT
-    /// landed) and forced a multi-xact close. Stays at `0` when
-    /// `flush_timeout == 0` because the legacy close-per-xact path
-    /// fires through [`Self::close_all_open_inserts`] without setting
-    /// a deadline.
-    pub flush_deadline_trips: u64,
+crate::atomic_stats! {
+    /// CH emitter counters. Mutations via `fetch_add(_, Relaxed)`; the
+    /// daemon's status loop reads via `.load(Relaxed)` at the use site.
+    pub struct EmitterStats {
+        pub rows_emitted,
+        pub blocks_sent,
+        pub xacts_committed,
+        pub unsupported_relations,
+        /// Rows whose filenode resolved to a foreign database (physical WAL
+        /// carries the whole cluster). Skipped, not an error.
+        pub foreign_db_rows_skipped,
+        pub unsupported_values,
+        /// Phase 10 retry bookkeeping. `reconnects` ticks on every fresh
+        /// CH socket the daemon hot-replaces; `retries_attempted` ticks on
+        /// every reconnect-triggered retry (one per failing operation,
+        /// not per attempt — so a single op that needed 3 retries adds 3).
+        pub reconnects,
+        pub retries_attempted,
+        /// `HeapOp::Truncate` events shipped to CH as `TRUNCATE TABLE`.
+        pub truncates_emitted,
+        /// Number of times the hold-INSERT-open deadline tripped (i.e.
+        /// `flush_timeout` elapsed since the first row of a fresh INSERT
+        /// landed) and forced a multi-xact close. Stays at `0` when
+        /// `flush_timeout == 0` because the legacy close-per-xact path
+        /// fires through [`Emitter::close_all_open_inserts`] without setting
+        /// a deadline.
+        pub flush_deadline_trips,
+    }
 }
 
 impl Emitter {
@@ -1408,7 +1412,7 @@ impl Emitter {
             last_durable_commit_lsn: 0,
             applicator: None,
             wire_open_key: None,
-            stats: EmitterStats::default(),
+            stats: Arc::new(EmitterStats::default()),
         })
     }
 
@@ -1433,6 +1437,13 @@ impl Emitter {
         self.mapping.clone()
     }
 
+    /// Shared handle so the daemon's status loop (running on a different
+    /// task once the emitter is boxed into an observer) can snapshot
+    /// counters without coordinating with the emitter task.
+    pub fn stats_handle(&self) -> Arc<EmitterStats> {
+        self.stats.clone()
+    }
+
     /// Route one committed tuple. INSERT/UPDATE land via the `new`
     /// image; DELETE pulls from `old`. HOT_UPDATE is treated as UPDATE
     /// downstream (op-code 2) — CH's `ReplacingMergeTree` cares about
@@ -1450,7 +1461,9 @@ impl Emitter {
             // Foreign-DB WAL: skip like an unmapped relation (no append,
             // no poison), let the ack advance past it.
             Err(CatalogError::ForeignDatabase(_)) => {
-                self.stats.foreign_db_rows_skipped += 1;
+                self.stats
+                    .foreign_db_rows_skipped
+                    .fetch_add(1, Ordering::Relaxed);
                 return Ok(());
             }
             Err(e) => return Err(e.into()),
@@ -1460,7 +1473,9 @@ impl Emitter {
             match m.get(rel.qualified_name.as_ref()).cloned() {
                 Some(v) => v,
                 None => {
-                    self.stats.unsupported_relations += 1;
+                    self.stats
+                        .unsupported_relations
+                        .fetch_add(1, Ordering::Relaxed);
                     return Ok(());
                 }
             }
@@ -1497,7 +1512,7 @@ impl Emitter {
                     _ => {}
                 }
             }
-            self.stats.truncates_emitted += 1;
+            self.stats.truncates_emitted.fetch_add(1, Ordering::Relaxed);
             return Ok(());
         }
         // Lazily build the per-table encoder on first row. NO wire
@@ -1524,7 +1539,9 @@ impl Emitter {
             HeapOp::Truncate => return Ok(()),
         };
         if let Err(e) = enc.append_row(committed, &mapping, op) {
-            self.stats.unsupported_values += 1;
+            self.stats
+                .unsupported_values
+                .fetch_add(1, Ordering::Relaxed);
             return Err(e);
         }
         self.pending_max_commit_lsn = self.pending_max_commit_lsn.max(committed.commit_lsn);
@@ -1602,8 +1619,10 @@ impl Emitter {
         // point the buffer is the only replay source if the connection
         // bounced.
         if n > 0 {
-            self.stats.rows_emitted += n as u64;
-            self.stats.blocks_sent += 1;
+            self.stats
+                .rows_emitted
+                .fetch_add(n as u64, Ordering::Relaxed);
+            self.stats.blocks_sent.fetch_add(1, Ordering::Relaxed);
         }
         if let Some(enc) = self.tables.get_mut(&key) {
             enc.clear();
@@ -1637,7 +1656,9 @@ impl Emitter {
         let now = Instant::now();
         let deadline_tripped = self.flush_deadline.is_some_and(|d| now >= d);
         if deadline_tripped {
-            self.stats.flush_deadline_trips += 1;
+            self.stats
+                .flush_deadline_trips
+                .fetch_add(1, Ordering::Relaxed);
         }
         let must_close = self.config.flush_timeout.is_zero() || deadline_tripped;
         if must_close {
@@ -1663,7 +1684,7 @@ impl Emitter {
             self.pending_max_commit_lsn = 0;
         }
         self.current_xid = None;
-        self.stats.xacts_committed += 1;
+        self.stats.xacts_committed.fetch_add(1, Ordering::Relaxed);
         Ok(self.last_durable_commit_lsn)
     }
 
@@ -1714,7 +1735,9 @@ impl Emitter {
     /// `flush_deadline_trips` on close.
     pub fn flush_if_deadline_tripped(&mut self) -> Result<u64, EmitterError> {
         if self.flush_deadline.is_some_and(|d| Instant::now() >= d) {
-            self.stats.flush_deadline_trips += 1;
+            self.stats
+                .flush_deadline_trips
+                .fetch_add(1, Ordering::Relaxed);
             self.close_all_open_inserts()?;
         }
         Ok(self.last_durable_commit_lsn)
@@ -1730,7 +1753,7 @@ impl Emitter {
             match self.flush_if_deadline_tripped() {
                 Ok(ack) => return Ok(ack),
                 Err(e) if is_retryable(&e) && attempt < retry.max_attempts => {
-                    self.stats.retries_attempted += 1;
+                    self.stats.retries_attempted.fetch_add(1, Ordering::Relaxed);
                     attempt += 1;
                     tokio::time::sleep(backoff).await;
                     backoff = backoff.saturating_mul(2).min(retry.max_backoff);
@@ -1751,7 +1774,7 @@ impl Emitter {
             match self.flush_open_inserts() {
                 Ok(ack) => return Ok(ack),
                 Err(e) if is_retryable(&e) && attempt < retry.max_attempts => {
-                    self.stats.retries_attempted += 1;
+                    self.stats.retries_attempted.fetch_add(1, Ordering::Relaxed);
                     attempt += 1;
                     tokio::time::sleep(backoff).await;
                     backoff = backoff.saturating_mul(2).min(retry.max_backoff);
@@ -1806,7 +1829,7 @@ impl Emitter {
         let client = Client::init(&opts, self.alloc, io, codec)?;
         self.client = client;
         self.wire_open_key = None;
-        self.stats.reconnects += 1;
+        self.stats.reconnects.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
 
@@ -1826,7 +1849,7 @@ impl Emitter {
             match self.route(committed).await {
                 Ok(()) => return Ok(()),
                 Err(e) if is_retryable(&e) && attempt < retry.max_attempts => {
-                    self.stats.retries_attempted += 1;
+                    self.stats.retries_attempted.fetch_add(1, Ordering::Relaxed);
                     attempt += 1;
                     tokio::time::sleep(backoff).await;
                     backoff = backoff.saturating_mul(2).min(retry.max_backoff);
@@ -1900,7 +1923,7 @@ impl Emitter {
             match self.on_xact_end_with_lsn(commit_lsn) {
                 Ok(ack) => return Ok(ack),
                 Err(e) if is_retryable(&e) && attempt < retry.max_attempts => {
-                    self.stats.retries_attempted += 1;
+                    self.stats.retries_attempted.fetch_add(1, Ordering::Relaxed);
                     attempt += 1;
                     tokio::time::sleep(backoff).await;
                     backoff = backoff.saturating_mul(2).min(retry.max_backoff);
@@ -1937,33 +1960,15 @@ fn is_retryable(e: &EmitterError) -> bool {
 /// `XactRecordSink<EmitterObserver>` in `bin/stream.rs`.
 pub struct EmitterObserver {
     pub emitter: Emitter,
-    /// Shared mirror of `emitter.stats` the daemon status loop polls
-    /// while this observer runs on the `QueueingRecordSink` worker
-    /// task. Refreshed after every dispatch callback; lock never held
-    /// across `.await`.
-    stats: Arc<std::sync::Mutex<EmitterStats>>,
 }
 
 impl EmitterObserver {
     pub fn new(emitter: Emitter) -> Self {
-        Self {
-            emitter,
-            stats: Arc::new(std::sync::Mutex::new(EmitterStats::default())),
-        }
+        Self { emitter }
     }
 
-    /// Handle the daemon hands to its status loop so it reads live
-    /// emitter counters across the worker-task boundary (the emitter
-    /// itself is buried inside the worker).
-    pub fn stats_handle(&self) -> Arc<std::sync::Mutex<EmitterStats>> {
-        self.stats.clone()
-    }
-
-    /// Mirror the emitter's local counters into the shared handle.
-    /// Called at the tail of each callback so a poll never lags more
-    /// than one dispatch behind.
-    fn publish_stats(&self) {
-        *self.stats.lock().expect("emitter stats mutex poisoned") = self.emitter.stats.clone();
+    pub fn stats_handle(&self) -> Arc<EmitterStats> {
+        self.emitter.stats_handle()
     }
 }
 
@@ -1975,13 +1980,10 @@ impl TupleObserver for EmitterObserver {
         Box<dyn std::future::Future<Output = Result<(), DecoderSinkError>> + Send + 'a>,
     > {
         Box::pin(async move {
-            let r = self
-                .emitter
+            self.emitter
                 .route_with_retry(committed)
                 .await
-                .map_err(DecoderSinkError::from);
-            self.publish_stats();
-            r
+                .map_err(DecoderSinkError::from)
         })
     }
 
@@ -1992,13 +1994,10 @@ impl TupleObserver for EmitterObserver {
         Box<dyn std::future::Future<Output = Result<u64, DecoderSinkError>> + Send + 'a>,
     > {
         Box::pin(async move {
-            let r = self
-                .emitter
+            self.emitter
                 .on_xact_end_with_retry(commit_lsn)
                 .await
-                .map_err(DecoderSinkError::from);
-            self.publish_stats();
-            r
+                .map_err(DecoderSinkError::from)
         })
     }
 
@@ -2009,13 +2008,10 @@ impl TupleObserver for EmitterObserver {
         Box<dyn std::future::Future<Output = Result<(), DecoderSinkError>> + Send + 'a>,
     > {
         Box::pin(async move {
-            let r = self
-                .emitter
+            self.emitter
                 .dispatch_schema_event_with_retry(event)
                 .await
-                .map_err(DecoderSinkError::from);
-            self.publish_stats();
-            r
+                .map_err(DecoderSinkError::from)
         })
     }
 
@@ -2035,13 +2031,10 @@ impl TupleObserver for EmitterObserver {
         Box<dyn std::future::Future<Output = Result<u64, DecoderSinkError>> + Send + 'a>,
     > {
         Box::pin(async move {
-            let r = self
-                .emitter
+            self.emitter
                 .flush_if_deadline_tripped_with_retry()
                 .await
-                .map_err(DecoderSinkError::from);
-            self.publish_stats();
-            r
+                .map_err(DecoderSinkError::from)
         })
     }
 
@@ -2055,13 +2048,10 @@ impl TupleObserver for EmitterObserver {
         Box<dyn std::future::Future<Output = Result<(), DecoderSinkError>> + Send + 'a>,
     > {
         Box::pin(async move {
-            let r = self
-                .emitter
+            self.emitter
                 .flush_open_inserts_with_retry()
                 .await
-                .map_err(DecoderSinkError::from);
-            self.publish_stats();
-            r?;
+                .map_err(DecoderSinkError::from)?;
             Ok(())
         })
     }

--- a/src/decoder_sink.rs
+++ b/src/decoder_sink.rs
@@ -10,6 +10,7 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use thiserror::Error;
 
@@ -153,45 +154,48 @@ impl<T: TupleObserver + ?Sized> TupleObserver for Box<T> {
     }
 }
 
-/// Counter observer suitable for the production daemon. Discards the
-/// tuple payload; tracks counts by op kind so the daemon's status line
-/// surfaces decoded-tuple cadence.
-#[derive(Debug, Default, Clone)]
-pub struct DecoderStats {
-    pub decoded: u64,
-    pub inserts: u64,
-    pub updates: u64,
-    pub hot_updates: u64,
-    pub deletes: u64,
-    /// Decoded but the WAL elided some columns via
-    /// `XLH_UPDATE_PREFIX_FROM_OLD` / `..._SUFFIX_FROM_OLD`. Phase 6
-    /// reassembles from previous tuple image; Phase 5 emits as-is.
-    pub partial: u64,
-    /// `record.parsed.blocks` was empty — record references no
-    /// relation. Heap LOCK / INPLACE / TRUNCATE land here under the
-    /// decoder's silent-skip policy.
-    pub skipped_no_block: u64,
-    /// Heap record on a relation [`ShadowCatalog`] returned
-    /// `NotFoundByFilenode` for. Possible causes: replay-LSN gate
-    /// ahead of catalog mutation, mapping rotation, race with
-    /// `seed_from_source`. Counted, not retried — Phase 6's xact
-    /// buffer can reorder.
-    pub catalog_not_found: u64,
-    /// Record was on a `User` relation but the rmgr/info combo isn't
-    /// in the Phase 5 matrix (MULTI_INSERT, HEAP2 PRUNE, etc).
-    pub skipped_op: u64,
-    /// `XLOG_HEAP_TRUNCATE` records fanned out to per-relid
-    /// `HeapOp::Truncate` events. Counted by
-    /// [`BufferingDecoderSink::on_record`]'s pre-decode intercept.
-    pub truncates: u64,
-    /// TOAST chunks routed into the xact buffer's chunk slot. Distinct
-    /// from `inserts`, which only counts user-table writes.
-    pub toast_chunks_buffered: u64,
-    /// TOAST inserts the decoder couldn't reinterpret as a chunk
-    /// (missing chunk_id/seq/data columns, type mismatch). Surfaces
-    /// so a corrupt catalog or a future TOAST layout shows up as a
-    /// counter, not silent loss.
-    pub toast_chunks_malformed: u64,
+crate::atomic_stats! {
+    /// Counter observer suitable for the production daemon. Discards the
+    /// tuple payload; tracks counts by op kind so the daemon's status line
+    /// surfaces decoded-tuple cadence. Mutations use
+    /// `fetch_add(_, Relaxed)`; the daemon's status loop reads via
+    /// `.load(Relaxed)` at the use site.
+    pub struct DecoderStats {
+        pub decoded,
+        pub inserts,
+        pub updates,
+        pub hot_updates,
+        pub deletes,
+        /// Decoded but the WAL elided some columns via
+        /// `XLH_UPDATE_PREFIX_FROM_OLD` / `..._SUFFIX_FROM_OLD`. Phase 6
+        /// reassembles from previous tuple image; Phase 5 emits as-is.
+        pub partial,
+        /// `record.parsed.blocks` was empty — record references no
+        /// relation. Heap LOCK / INPLACE / TRUNCATE land here under the
+        /// decoder's silent-skip policy.
+        pub skipped_no_block,
+        /// Heap record on a relation [`ShadowCatalog`] returned
+        /// `NotFoundByFilenode` for. Possible causes: replay-LSN gate
+        /// ahead of catalog mutation, mapping rotation, race with
+        /// `seed_from_source`. Counted, not retried — Phase 6's xact
+        /// buffer can reorder.
+        pub catalog_not_found,
+        /// Record was on a `User` relation but the rmgr/info combo isn't
+        /// in the Phase 5 matrix (MULTI_INSERT, HEAP2 PRUNE, etc).
+        pub skipped_op,
+        /// `XLOG_HEAP_TRUNCATE` records fanned out to per-relid
+        /// `HeapOp::Truncate` events. Counted by
+        /// [`BufferingDecoderSink::on_record`]'s pre-decode intercept.
+        pub truncates,
+        /// TOAST chunks routed into the xact buffer's chunk slot. Distinct
+        /// from `inserts`, which only counts user-table writes.
+        pub toast_chunks_buffered,
+        /// TOAST inserts the decoder couldn't reinterpret as a chunk
+        /// (missing chunk_id/seq/data columns, type mismatch). Surfaces
+        /// so a corrupt catalog or a future TOAST layout shows up as a
+        /// counter, not silent loss.
+        pub toast_chunks_malformed,
+    }
 }
 
 #[derive(Debug, Default)]
@@ -236,20 +240,20 @@ impl DecoderStats {
     /// of truth for the `HeapOp → counter` mapping; every decoder
     /// dispatch site routes through here so new ops only add code in
     /// one place.
-    pub fn record(&mut self, decoded: &crate::heap_decoder::DecodedHeap) {
+    pub fn record(&self, decoded: &crate::heap_decoder::DecodedHeap) {
         use crate::heap_decoder::HeapOp;
-        self.decoded += 1;
+        self.decoded.fetch_add(1, Ordering::Relaxed);
         match decoded.op {
-            HeapOp::Insert => self.inserts += 1,
-            HeapOp::Update => self.updates += 1,
-            HeapOp::HotUpdate => self.hot_updates += 1,
-            HeapOp::Delete => self.deletes += 1,
-            HeapOp::Truncate => self.truncates += 1,
-        }
+            HeapOp::Insert => self.inserts.fetch_add(1, Ordering::Relaxed),
+            HeapOp::Update => self.updates.fetch_add(1, Ordering::Relaxed),
+            HeapOp::HotUpdate => self.hot_updates.fetch_add(1, Ordering::Relaxed),
+            HeapOp::Delete => self.deletes.fetch_add(1, Ordering::Relaxed),
+            HeapOp::Truncate => self.truncates.fetch_add(1, Ordering::Relaxed),
+        };
         let partial = decoded.new.as_ref().is_some_and(|t| t.partial)
             || decoded.old.as_ref().is_some_and(|t| t.partial);
         if partial {
-            self.partial += 1;
+            self.partial.fetch_add(1, Ordering::Relaxed);
         }
     }
 
@@ -257,26 +261,28 @@ impl DecoderStats {
     /// zero buckets so a quiet workload shows a tight format.
     pub fn summary(&self) -> String {
         use std::fmt::Write as _;
-        let mut s = format!("decoded={}", self.decoded);
+        let ld = |a: &AtomicU64| a.load(Ordering::Relaxed);
+        let mut s = format!("decoded={}", ld(&self.decoded));
         let pairs: [(&str, u64); 10] = [
-            ("ins", self.inserts),
-            ("upd", self.updates),
-            ("hot", self.hot_updates),
-            ("del", self.deletes),
-            ("trunc", self.truncates),
-            ("partial", self.partial),
-            ("no_blk", self.skipped_no_block),
-            ("not_found", self.catalog_not_found),
-            ("toast", self.toast_chunks_buffered),
-            ("toast_bad", self.toast_chunks_malformed),
+            ("ins", ld(&self.inserts)),
+            ("upd", ld(&self.updates)),
+            ("hot", ld(&self.hot_updates)),
+            ("del", ld(&self.deletes)),
+            ("trunc", ld(&self.truncates)),
+            ("partial", ld(&self.partial)),
+            ("no_blk", ld(&self.skipped_no_block)),
+            ("not_found", ld(&self.catalog_not_found)),
+            ("toast", ld(&self.toast_chunks_buffered)),
+            ("toast_bad", ld(&self.toast_chunks_malformed)),
         ];
         for (label, n) in pairs {
             if n > 0 {
                 write!(&mut s, " {label}={n}").unwrap();
             }
         }
-        if self.skipped_op > 0 {
-            write!(&mut s, " skip_op={}", self.skipped_op).unwrap();
+        let skip_op = ld(&self.skipped_op);
+        if skip_op > 0 {
+            write!(&mut s, " skip_op={skip_op}").unwrap();
         }
         s
     }
@@ -320,12 +326,14 @@ mod tests {
             obs.on_tuple(&wrap(mk(op, false))).await.unwrap();
         }
         obs.on_tuple(&wrap(mk(HeapOp::Update, true))).await.unwrap();
-        assert_eq!(obs.stats.decoded, 6);
-        assert_eq!(obs.stats.inserts, 2);
-        assert_eq!(obs.stats.updates, 2);
-        assert_eq!(obs.stats.hot_updates, 1);
-        assert_eq!(obs.stats.deletes, 1);
-        assert_eq!(obs.stats.partial, 1);
+        let s = &obs.stats;
+        let ld = |a: &AtomicU64| a.load(Ordering::Relaxed);
+        assert_eq!(ld(&s.decoded), 6);
+        assert_eq!(ld(&s.inserts), 2);
+        assert_eq!(ld(&s.updates), 2);
+        assert_eq!(ld(&s.hot_updates), 1);
+        assert_eq!(ld(&s.deletes), 1);
+        assert_eq!(ld(&s.partial), 1);
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -360,15 +368,11 @@ mod tests {
 
     #[test]
     fn stats_summary_skips_zero_buckets() {
-        let s = DecoderStats {
-            decoded: 5,
-            inserts: 3,
-            updates: 0,
-            hot_updates: 0,
-            deletes: 2,
-            partial: 1,
-            ..Default::default()
-        };
+        let s = DecoderStats::default();
+        s.decoded.store(5, Ordering::Relaxed);
+        s.inserts.store(3, Ordering::Relaxed);
+        s.deletes.store(2, Ordering::Relaxed);
+        s.partial.store(1, Ordering::Relaxed);
         let out = s.summary();
         assert!(out.starts_with("decoded=5"), "{out}");
         assert!(out.contains("ins=3"), "{out}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@
 //! Direct + ObjectStore impls, catalog-land + page-walk sinks, and the
 //! greenfield bootstrap orchestrator (`backfill_bootstrap`).
 
+#[macro_use]
+pub mod atomic_stats;
 pub mod backfill_bootstrap;
 pub mod backup_page_walk;
 pub mod backup_sink;

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -49,20 +49,23 @@ pub enum OracleError {
     Query(tokio_postgres::Error),
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct OracleStats {
-    /// `walshadow_decode_disk` calls that returned a text payload.
-    pub resolved: u64,
-    /// `walshadow_decode_disk` calls returning NULL or absent-extension.
-    pub fallback_raw: u64,
-    /// 1-in-N samples taken (Tier 3 hot types only).
-    pub probes: u64,
-    /// Probe outcomes that matched the local decoder.
-    pub matches: u64,
-    /// Probe outcomes where local decoder text != shadow PG text.
-    pub mismatches: u64,
-    /// SQL / connection errors collapsed into a single bucket.
-    pub errors: u64,
+crate::atomic_stats! {
+    /// Oracle resolver/validator counters. Mutations via
+    /// `fetch_add(_, Relaxed)`; reads via `.load(Relaxed)` at the use site.
+    pub struct OracleStats {
+        /// `walshadow_decode_disk` calls that returned a text payload.
+        pub resolved,
+        /// `walshadow_decode_disk` calls returning NULL or absent-extension.
+        pub fallback_raw,
+        /// 1-in-N samples taken (Tier 3 hot types only).
+        pub probes,
+        /// Probe outcomes that matched the local decoder.
+        pub matches,
+        /// Probe outcomes where local decoder text != shadow PG text.
+        pub mismatches,
+        /// SQL / connection errors collapsed into a single bucket.
+        pub errors,
+    }
 }
 
 /// Sampler tracks 1-in-N selection across calls. Lock-free counter so
@@ -96,7 +99,7 @@ pub struct Oracle {
     client: Mutex<Option<Client>>,
     conninfo: String,
     has_extension: Mutex<Option<bool>>,
-    pub stats: Mutex<OracleStats>,
+    pub stats: Arc<OracleStats>,
     pub sampler: Sampler,
 }
 
@@ -116,7 +119,7 @@ impl Oracle {
             client: Mutex::new(Some(client)),
             conninfo: conninfo.to_owned(),
             has_extension: Mutex::new(Some(has_ext)),
-            stats: Mutex::new(OracleStats::default()),
+            stats: Arc::new(OracleStats::default()),
             sampler: Sampler::new(sample_rate),
         })
     }
@@ -155,7 +158,7 @@ impl Oracle {
         raw: &[u8],
     ) -> Result<Option<String>, OracleError> {
         if !self.has_extension().await {
-            self.stats.lock().await.fallback_raw += 1;
+            self.stats.fallback_raw.fetch_add(1, Ordering::Relaxed);
             return Ok(None);
         }
         let sql = "SELECT walshadow_decode_disk($1::oid, $2::bytea)";
@@ -172,11 +175,10 @@ impl Oracle {
             match row {
                 Ok(r) => {
                     let txt: Option<String> = r.try_get(0).ok();
-                    let mut stats = self.stats.lock().await;
                     if txt.is_some() {
-                        stats.resolved += 1;
+                        self.stats.resolved.fetch_add(1, Ordering::Relaxed);
                     } else {
-                        stats.fallback_raw += 1;
+                        self.stats.fallback_raw.fetch_add(1, Ordering::Relaxed);
                     }
                     return Ok(txt);
                 }
@@ -185,7 +187,7 @@ impl Oracle {
                     let _ = self.reconnect().await;
                 }
                 Err(_) => {
-                    self.stats.lock().await.errors += 1;
+                    self.stats.errors.fetch_add(1, Ordering::Relaxed);
                     return Ok(None);
                 }
             }
@@ -232,18 +234,17 @@ impl Oracle {
                 Err(_) => break None,
             }
         };
-        let mut stats = self.stats.lock().await;
-        stats.probes += 1;
+        self.stats.probes.fetch_add(1, Ordering::Relaxed);
         let Some(r) = res else {
-            stats.errors += 1;
+            self.stats.errors.fetch_add(1, Ordering::Relaxed);
             return true;
         };
         let pg_text: Option<String> = r.try_get(0).ok();
         let matched = pg_text.as_deref() == Some(local_text);
         if matched {
-            stats.matches += 1;
+            self.stats.matches.fetch_add(1, Ordering::Relaxed);
         } else {
-            stats.mismatches += 1;
+            self.stats.mismatches.fetch_add(1, Ordering::Relaxed);
         }
         true
     }
@@ -312,13 +313,14 @@ pub async fn maybe_validate_tuple(oracle: &Oracle, columns: &[Option<ColumnValue
 impl OracleStats {
     pub fn summary(&self) -> String {
         use std::fmt::Write as _;
-        let mut s = format!("oracle resolved={}", self.resolved);
+        let ld = |a: &AtomicU64| a.load(Ordering::Relaxed);
+        let mut s = format!("oracle resolved={}", ld(&self.resolved));
         let pairs: [(&str, u64); 5] = [
-            ("fallback", self.fallback_raw),
-            ("probes", self.probes),
-            ("match", self.matches),
-            ("mismatch", self.mismatches),
-            ("err", self.errors),
+            ("fallback", ld(&self.fallback_raw)),
+            ("probes", ld(&self.probes)),
+            ("match", ld(&self.matches)),
+            ("mismatch", ld(&self.mismatches)),
+            ("err", ld(&self.errors)),
         ];
         for (label, n) in pairs {
             if n > 0 {
@@ -455,14 +457,10 @@ mod tests {
 
     #[test]
     fn stats_summary_skips_zero_buckets() {
-        let s = OracleStats {
-            resolved: 4,
-            fallback_raw: 0,
-            probes: 2,
-            matches: 2,
-            mismatches: 0,
-            errors: 0,
-        };
+        let s = OracleStats::default();
+        s.resolved.store(4, Ordering::Relaxed);
+        s.probes.store(2, Ordering::Relaxed);
+        s.matches.store(2, Ordering::Relaxed);
         let out = s.summary();
         assert!(out.contains("resolved=4"));
         assert!(out.contains("probes=2"));

--- a/src/xact_buffer.rs
+++ b/src/xact_buffer.rs
@@ -1562,9 +1562,9 @@ pub struct BufferingDecoderSink {
     buffer: Arc<Mutex<XactBuffer>>,
     /// Shared so the daemon's status loop (or a `QueueingRecordSink`
     /// wrapper running this sink on a worker task) can read counters
-    /// without contending on `self`. Mutations stay short — the lock
-    /// is never held across `.await`.
-    stats: Arc<std::sync::Mutex<DecoderStats>>,
+    /// without locking. Mutations are `fetch_add(_, Relaxed)`; readers
+    /// `.load(Relaxed)` at the use site.
+    stats: Arc<DecoderStats>,
     /// PHASE15 §1 — schema events the catalog emits at descriptor
     /// fetch time. Drained inline after every `relation_at` so events
     /// land in the same xact buffer keyed on the current record's
@@ -1578,7 +1578,7 @@ impl BufferingDecoderSink {
         Self {
             catalog,
             buffer,
-            stats: Arc::new(std::sync::Mutex::new(DecoderStats::default())),
+            stats: Arc::new(DecoderStats::default()),
             schema_events: None,
         }
     }
@@ -1595,24 +1595,18 @@ impl BufferingDecoderSink {
         self
     }
 
-    /// Snapshot of the live counters. Cheap clone of the `DecoderStats`
-    /// struct (all `u64` fields).
-    pub fn stats(&self) -> DecoderStats {
-        self.stats
-            .lock()
-            .expect("decoder stats mutex poisoned")
-            .clone()
+    /// Borrow the live counters (for `.summary()` and ad-hoc field
+    /// `.load(Relaxed)` reads).
+    pub fn stats(&self) -> &DecoderStats {
+        &self.stats
     }
 
     /// Shared handle a wrapping `QueueingRecordSink` can hand back to
     /// the daemon's status loop so it polls live counters while the
-    /// sink itself runs on a separate worker task.
-    pub fn stats_handle(&self) -> Arc<std::sync::Mutex<DecoderStats>> {
+    /// sink itself runs on a separate worker task. Reads via
+    /// `.load(Relaxed)` on the returned struct's fields.
+    pub fn stats_handle(&self) -> Arc<DecoderStats> {
         self.stats.clone()
-    }
-
-    fn bump<F: FnOnce(&mut DecoderStats)>(&self, f: F) {
-        f(&mut self.stats.lock().expect("decoder stats mutex poisoned"))
     }
 
     /// PHASE15 §1 — drain any [`SchemaEvent`]s the catalog accumulated
@@ -1657,7 +1651,9 @@ impl BufferingDecoderSink {
     async fn handle_truncate(&mut self, record: &Record<'_>) -> std::result::Result<(), SinkError> {
         let Some(parsed) = crate::main_data::parse_xl_heap_truncate(&record.parsed.main_data)
         else {
-            self.bump(|s| s.skipped_op += 1);
+            self.stats
+                .skipped_op
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             return Ok(());
         };
         let xid = record.parsed.header.xact_id;
@@ -1676,7 +1672,9 @@ impl BufferingDecoderSink {
                 match cat.relation_by_oid(relid).await {
                     Ok(r) => r,
                     Err(CatalogError::NotFoundByOid(_)) => {
-                        self.bump(|s| s.catalog_not_found += 1);
+                        self.stats
+                            .catalog_not_found
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         continue;
                     }
                     Err(e) => return Err(DecoderSinkError::from(e).into()),
@@ -1700,7 +1698,7 @@ impl BufferingDecoderSink {
                 new: None,
                 old: None,
             };
-            self.bump(|s| s.record(&decoded));
+            self.stats.record(&decoded);
             let mut buf = self.buffer.lock().await;
             buf.on_heap(decoded).await.map_err(SinkError::from)?;
         }
@@ -1737,7 +1735,9 @@ impl RecordSink for BufferingDecoderSink {
             let rfn = match record.parsed.blocks.first() {
                 Some(b) => b.header.location.rel,
                 None => {
-                    self.bump(|s| s.skipped_no_block += 1);
+                    self.stats
+                        .skipped_no_block
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     return Ok(());
                 }
             };
@@ -1746,7 +1746,9 @@ impl RecordSink for BufferingDecoderSink {
                 match cat.relation_at(rfn, record.source_lsn).await {
                     Ok(r) => r,
                     Err(CatalogError::NotFoundByFilenode(_)) => {
-                        self.bump(|s| s.catalog_not_found += 1);
+                        self.stats
+                            .catalog_not_found
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         return Ok(());
                     }
                     Err(e) => {
@@ -1775,21 +1777,27 @@ impl RecordSink for BufferingDecoderSink {
                 Err(e) => return Err(DecoderSinkError::from(e).into()),
             };
             if decoded_set.is_empty() {
-                self.bump(|s| s.skipped_op += 1);
+                self.stats
+                    .skipped_op
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 return Ok(());
             }
             for decoded in decoded_set {
-                self.bump(|s| s.record(&decoded));
+                self.stats.record(&decoded);
                 if rel.kind == 't' {
                     let xid = decoded.xid;
                     if let Some(chunk) = toast_chunk_from_decoded(decoded, &rel) {
-                        self.bump(|s| s.toast_chunks_buffered += 1);
+                        self.stats
+                            .toast_chunks_buffered
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         let mut buf = self.buffer.lock().await;
                         buf.on_toast_chunk(chunk, xid)
                             .await
                             .map_err(SinkError::from)?;
                     } else {
-                        self.bump(|s| s.toast_chunks_malformed += 1);
+                        self.stats
+                            .toast_chunks_malformed
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     }
                 } else {
                     let mut buf = self.buffer.lock().await;

--- a/tests/emitter_budget_flush.rs
+++ b/tests/emitter_budget_flush.rs
@@ -184,10 +184,13 @@ async fn budget_trips_seal_complete_inserts() {
     assert_eq!(ack, 0xC0FFEE, "durable horizon must reach the commit lsn");
 
     // Two budget trips + the xact-end seal = 3 sealed INSERTs.
+    let blocks_sent = emitter
+        .stats
+        .blocks_sent
+        .load(std::sync::atomic::Ordering::Relaxed);
     assert!(
-        emitter.stats.blocks_sent >= 3,
-        "expected ≥3 sealed blocks, got {}",
-        emitter.stats.blocks_sent,
+        blocks_sent >= 3,
+        "expected ≥3 sealed blocks, got {blocks_sent}",
     );
 
     let count = ch
@@ -245,8 +248,9 @@ async fn observer_handle_mirrors_emitter_counters() {
 
     let mut observer = EmitterObserver::new(emitter);
     let handle = observer.stats_handle();
+    use std::sync::atomic::Ordering::Relaxed;
     assert_eq!(
-        handle.lock().unwrap().rows_emitted,
+        handle.rows_emitted.load(Relaxed),
         0,
         "fresh handle starts at zero",
     );
@@ -260,8 +264,18 @@ async fn observer_handle_mirrors_emitter_counters() {
     }
     observer.on_xact_end(0xBEEF).await.expect("on_xact_end");
 
-    let snap = handle.lock().unwrap().clone();
-    assert_eq!(snap.rows_emitted, N as u64, "rows reach the polled handle");
-    assert_eq!(snap.xacts_committed, 1, "xact commit reaches the handle");
-    assert!(snap.blocks_sent >= 1, "block seal reaches the handle");
+    assert_eq!(
+        handle.rows_emitted.load(Relaxed),
+        N as u64,
+        "rows reach the polled handle",
+    );
+    assert_eq!(
+        handle.xacts_committed.load(Relaxed),
+        1,
+        "xact commit reaches the handle",
+    );
+    assert!(
+        handle.blocks_sent.load(Relaxed) >= 1,
+        "block seal reaches the handle",
+    );
 }

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -135,9 +135,9 @@ async fn oracle_without_extension_falls_back_to_raw_bytes() {
         .await
         .expect("resolve_pending");
     assert!(out.is_none(), "expected fallback, got {out:?}");
-    let stats = oracle.stats.lock().await.clone();
-    assert_eq!(stats.fallback_raw, 1);
-    assert_eq!(stats.resolved, 0);
+    use std::sync::atomic::Ordering;
+    assert_eq!(oracle.stats.fallback_raw.load(Ordering::Relaxed), 1);
+    assert_eq!(oracle.stats.resolved.load(Ordering::Relaxed), 0);
     assert!(!oracle.has_extension().await);
 }
 
@@ -212,10 +212,10 @@ async fn oracle_with_extension_resolves_tier3_disk_bytes() {
         .expect("resolved Some");
     assert_eq!(txt, "{1,2,3}");
 
-    let stats = oracle.stats.lock().await.clone();
-    assert_eq!(stats.resolved, 4);
-    assert_eq!(stats.fallback_raw, 0);
-    assert_eq!(stats.errors, 0);
+    use std::sync::atomic::Ordering;
+    assert_eq!(oracle.stats.resolved.load(Ordering::Relaxed), 4);
+    assert_eq!(oracle.stats.fallback_raw.load(Ordering::Relaxed), 0);
+    assert_eq!(oracle.stats.errors.load(Ordering::Relaxed), 0);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -280,6 +280,6 @@ async fn oracle_observer_resolves_pg_pending_to_text() {
         Some(ColumnValue::Text(s)) => assert_eq!(s, "42"),
         other => panic!("expected Text(\"42\"), got {other:?}"),
     }
-    let stats = oracle.stats.lock().await.clone();
-    assert_eq!(stats.resolved, 1);
+    use std::sync::atomic::Ordering;
+    assert_eq!(oracle.stats.resolved.load(Ordering::Relaxed), 1);
 }


### PR DESCRIPTION
DecoderStats and OracleStats sat behind Arc<Mutex<...>>; the daemon status loop locked + cloned per scrape. EmitterStats had no cross-task read path at all, so the four Prometheus counters at stream.rs:1409-1412 were hardcoded to 0: emitter_rows_total, emitter_blocks_total, emitter_xacts_total,
emitter_unsupported_relations.

Add an atomic_stats! macro that declares a struct of AtomicU64 counters with derive(Debug, Default). Bumps use
fetch_add(_, Relaxed); reads use .load(Relaxed) at the use site, so the memory-ordering choice stays visible next to every read. Shared across tasks via Arc.

DecoderStats, EmitterStats, OracleStats now use the macro. Emitter::stats_handle() and EmitterObserver::stats_handle() let the daemon capture the Arc before the observer is boxed; populate_metrics reads the four emitter counters directly.