### PR TITLE
optimize wal rewrite to use less copies

### DIFF
--- a/docker/grafana/dashboards/walshadow.json
+++ b/docker/grafana/dashboards/walshadow.json
@@ -233,7 +233,7 @@
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "walshadow-prom" },
           "expr": "rate(walshadow_filter_records_total[$__rate_interval])",
-          "legendFormat": "{{rmgr}} · {{decision}}"
+          "legendFormat": "{{rmgr}} · {{route}}"
         }
       ]
     },

--- a/plans/ops.md
+++ b/plans/ops.md
@@ -70,8 +70,8 @@ Inventory by category:
 
 ### Counters
 
-- `walshadow_filter_records_total{rmgr,decision}` — labelled per
-  (rmgr name, "keep"|"drop")
+- `walshadow_filter_records_total{rmgr,route}` — labelled per
+  (rmgr name, "to_shadow"|"to_decoder")
 - `walshadow_xacts_{committed,aborted}_total`
 - `walshadow_decoder_{decoded,partial,toast_chunks,toast_malformed}_total`
 - `walshadow_emitter_{rows,blocks,xacts,unsupported_relations}_total`

--- a/src/bin/stream.rs
+++ b/src/bin/stream.rs
@@ -1405,12 +1405,12 @@ async fn populate_metrics(
     use std::collections::BTreeMap;
     use walshadow::classify::rmgr_label;
     let mut by_rm = BTreeMap::new();
-    for ((rm, decision), n) in &rec_metrics.by_rm_decision {
+    for ((rm, route), n) in &rec_metrics.by_rm_route {
         let key = (
             rmgr_label(*rm).to_string(),
-            match decision {
-                walshadow::filter::Decision::Keep => "keep",
-                walshadow::filter::Decision::Drop => "drop",
+            match route {
+                walshadow::filter::Route::ToShadow => "to_shadow",
+                walshadow::filter::Route::ToDecoder => "to_decoder",
             },
         );
         by_rm.insert(key, *n);
@@ -1421,7 +1421,7 @@ async fn populate_metrics(
         shadow_replay_lsn,
         decoder_commit_lsn,
         emitter_ack_lsn,
-        records_by_rm_decision: by_rm,
+        records_by_rm_route: by_rm,
         xact_active: xact_stats.xacts_active,
         xact_bytes_in_memory: xact_stats.bytes_in_memory,
         spill_xacts_active: xact_stats.spill_xacts_active,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,16 +1,19 @@
-//! Per-record keep/drop decision used by the WAL rewriter.
+//! Per-record routing decision used by the WAL rewriter: where each
+//! record goes, not whether it survives.
 //!
 //! Wraps `classify` + `CatalogTracker` + `main_data` reclassifier into
 //! a stateful `Filter` that callers feed each record in source order.
 //!
-//! Decision policy:
-//! * `Special` rmgr → Keep (recovery plumbing shadow needs verbatim)
-//! * `Catalog` class → Keep
-//! * `User` class → Drop (XLOG_NOOP placeholder of same length)
+//! Route policy:
+//! * `Special` rmgr → ToShadow (recovery plumbing shadow needs verbatim)
+//! * `Catalog` class → ToShadow
+//! * `User` class → ToDecoder (XLOG_NOOP placeholder of same length on
+//!   the shadow stream; original bytes feed the heap decoder)
 //! * `Empty` class → reclassify via `main_data::relation_for_empty`,
 //!   re-checking against `CatalogTracker`. Unrecognised Empty records
-//!   default to Keep (correctness over efficiency: false-keeping a
-//!   non-catalog record is wasted bytes; false-dropping breaks shadow).
+//!   default to ToShadow (correctness over efficiency: false-routing a
+//!   non-catalog record to shadow is wasted bytes; wrongly suppressing
+//!   a catalog record breaks shadow).
 
 use serde::{Deserialize, Serialize};
 use wal_rs::pg::walparser::{XLogRecord, XLogRecordBlock};
@@ -22,10 +25,16 @@ use crate::main_data;
 #[derive(
     Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
 )]
-pub enum Decision {
+pub enum Route {
+    /// Replay on shadow verbatim — catalog + recovery-plumbing records
+    /// shadow PG needs in its redo stream.
     #[default]
-    Keep,
-    Drop,
+    ToShadow,
+    /// Suppress on the shadow stream as an `XLOG_NOOP` of identical
+    /// length; the original bytes route to the heap decoder for CH
+    /// emission (heap rmgrs) or to nowhere (other user rmgrs, e.g.
+    /// user-index records, which are simply not replayed).
+    ToDecoder,
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -56,9 +65,9 @@ impl FilterStats {
         }
     }
 
-    pub fn record(&mut self, class: Class, decision: Decision, bytes: u64) {
-        match decision {
-            Decision::Keep => {
+    pub fn record(&mut self, class: Class, route: Route, bytes: u64) {
+        match route {
+            Route::ToShadow => {
                 self.kept += 1;
                 self.kept_bytes += bytes;
                 match class {
@@ -68,7 +77,7 @@ impl FilterStats {
                     Class::Empty => self.kept_empty += 1,
                 }
             }
-            Decision::Drop => {
+            Route::ToDecoder => {
                 self.dropped += 1;
                 self.dropped_bytes += bytes;
             }
@@ -77,9 +86,9 @@ impl FilterStats {
 }
 
 /// Stateful filter. Updates the catalog tracker on every record then
-/// returns Keep/Drop based on the *post-update* catalog set so an
+/// returns the `Route` based on the *post-update* catalog set so an
 /// XLOG_RELMAP_UPDATE that introduces a new mapped-catalog filenumber
-/// can immediately keep subsequent records on that filenumber.
+/// can immediately route subsequent records on that filenumber to shadow.
 pub struct Filter {
     pub tracker: CatalogTracker,
     pub stats: FilterStats,
@@ -93,34 +102,34 @@ impl Filter {
         }
     }
 
-    pub fn decide(&mut self, record: &XLogRecord) -> Decision {
+    pub fn decide(&mut self, record: &XLogRecord) -> Route {
         self.tracker.observe(record);
         let class = classify(record);
-        let decision = match class {
-            Class::Special | Class::Catalog => Decision::Keep,
+        let route = match class {
+            Class::Special | Class::Catalog => Route::ToShadow,
             Class::User => {
                 if any_block_is_catalog(&self.tracker, &record.blocks) {
                     // classify under-counted because tracker has newer
                     // filenodes than the bootstrap rule knew about
-                    Decision::Keep
+                    Route::ToShadow
                 } else {
-                    Decision::Drop
+                    Route::ToDecoder
                 }
             }
             Class::Empty => match main_data::relation_for_empty(record) {
                 Some(rel) => {
                     if self.tracker.is_catalog(rel.db_node, rel.rel_node) {
-                        Decision::Keep
+                        Route::ToShadow
                     } else {
-                        Decision::Drop
+                        Route::ToDecoder
                     }
                 }
-                None => Decision::Keep, // safe default
+                None => Route::ToShadow, // safe default
             },
         };
         self.stats
-            .record(class, decision, record.header.total_record_length as u64);
-        decision
+            .record(class, route, record.header.total_record_length as u64);
+        route
     }
 
     /// Per-rmgr label string for diagnostics.
@@ -181,28 +190,28 @@ mod tests {
     fn catalog_record_is_kept() {
         let mut f = Filter::new();
         let r = rec(RmId::Heap, &[(5, 1259)]);
-        assert_eq!(f.decide(&r), Decision::Keep);
+        assert_eq!(f.decide(&r), Route::ToShadow);
     }
 
     #[test]
     fn user_record_is_dropped() {
         let mut f = Filter::new();
         let r = rec(RmId::Heap, &[(5, 20000)]);
-        assert_eq!(f.decide(&r), Decision::Drop);
+        assert_eq!(f.decide(&r), Route::ToDecoder);
     }
 
     #[test]
     fn special_rmgr_is_kept() {
         let mut f = Filter::new();
         let r = rec(RmId::Xact, &[]);
-        assert_eq!(f.decide(&r), Decision::Keep);
+        assert_eq!(f.decide(&r), Route::ToShadow);
     }
 
     #[test]
     fn empty_unknown_is_kept_safe_default() {
         let mut f = Filter::new();
         let r = rec(RmId::Heap, &[]);
-        assert_eq!(f.decide(&r), Decision::Keep);
+        assert_eq!(f.decide(&r), Route::ToShadow);
     }
 
     #[test]
@@ -211,7 +220,7 @@ mod tests {
         // Manually inject a learned mapping (pg_class on db 5 rewritten to 50000)
         f.tracker.add(5, 50000);
         let r = rec(RmId::Heap, &[(5, 50000)]);
-        assert_eq!(f.decide(&r), Decision::Keep);
+        assert_eq!(f.decide(&r), Route::ToShadow);
     }
 
     #[test]
@@ -247,9 +256,9 @@ mod tests {
         }
         let mut f = Filter::new();
         // catalog filenode (1259 = pg_class) → Keep
-        assert_eq!(f.decide(&new_cid_record(5, 1259)), Decision::Keep);
+        assert_eq!(f.decide(&new_cid_record(5, 1259)), Route::ToShadow);
         // user filenode → Drop
-        assert_eq!(f.decide(&new_cid_record(5, 20000)), Decision::Drop);
+        assert_eq!(f.decide(&new_cid_record(5, 20000)), Route::ToDecoder);
     }
 
     #[test]

--- a/src/filter_segment.rs
+++ b/src/filter_segment.rs
@@ -1,10 +1,10 @@
-//! Drive a full segment: walk records, decide keep/drop, NOOP-rewrite
-//! dropped records in place, emit manifest sidecar.
+//! Drive a full segment: walk records, decide each record's `Route`,
+//! NOOP-rewrite ToDecoder records in place, emit manifest sidecar.
 
 use thiserror::Error;
 use wal_rs::pg::walparser::{ParseError, XLogRecord, parse_record_from_bytes};
 
-use crate::filter::{Decision, Filter};
+use crate::filter::{Filter, Route};
 use crate::manifest::{Entry, FILTER_VERSION, Kind, Manifest, ManifestStats};
 use crate::rewrite::{RewriteError, noop_replace};
 use crate::segment::{SegmentWalker, WalkError};
@@ -73,24 +73,36 @@ pub fn filter_segment(
                     source: e,
                 }
             })?;
-        let decision = filter.decide(&parsed);
-        let kind = match decision {
-            Decision::Keep => Kind::Kept,
-            Decision::Drop => Kind::Dropped,
+        let route = filter.decide(&parsed);
+        let kind = match route {
+            Route::ToShadow => Kind::Kept,
+            Route::ToDecoder => Kind::Dropped,
         };
 
-        if decision == Decision::Drop {
-            let mut buf = record.logical_bytes.clone();
-            // Preserve xl_prev from the original record (already in buf).
-            noop_replace(&mut buf).map_err(|e| FilterSegmentError::Rewrite {
-                offset: record.start_offset,
-                source: e,
-            })?;
-            // Scatter rewritten bytes back into `out` at the same ranges.
-            let mut cursor = 0;
-            for &(off, len) in &record.byte_ranges {
-                out[off..off + len].copy_from_slice(&buf[cursor..cursor + len]);
-                cursor += len;
+        if route == Route::ToDecoder {
+            if let [(off, len)] = record.byte_ranges.as_slice() {
+                // Single-page: record is contiguous in `out` (a copy of
+                // source) with its original xl_tot_len + xl_prev intact;
+                // NOOP in place, no clone + scatter-back.
+                noop_replace(&mut out[*off..*off + *len]).map_err(|e| {
+                    FilterSegmentError::Rewrite {
+                        offset: record.start_offset,
+                        source: e,
+                    }
+                })?;
+            } else {
+                // Cross-page: bytes are page-fragmented in `out`, so
+                // NOOP the contiguous logical copy then scatter back.
+                let mut buf = record.logical_bytes.clone();
+                noop_replace(&mut buf).map_err(|e| FilterSegmentError::Rewrite {
+                    offset: record.start_offset,
+                    source: e,
+                })?;
+                let mut cursor = 0;
+                for &(off, len) in &record.byte_ranges {
+                    out[off..off + len].copy_from_slice(&buf[cursor..cursor + len]);
+                    cursor += len;
+                }
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! walshadow — schema-only Postgres + WAL replay catalog mirror for CDC.
 //!
 //! Per-record classifier (`classify`).
-//! WAL filter + CRC rewrite. Per-record keep/drop decision
+//! WAL filter + CRC rewrite. Per-record routing decision
 //! (`filter`), byte-positioned walker (private `segment` reachable only
 //! via `filter_segment`), in-place rewrite + CRC32C (`rewrite`), live
 //! catalog tracking (`catalog_tracker`), `main_data` reclassifier

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -58,9 +58,9 @@ pub struct MetricsSnapshot {
     /// CH emitter ack-LSN. Same placeholder treatment as
     /// `decoder_commit_lsn`.
     pub emitter_ack_lsn: u64,
-    /// Per-(rmgr name, decision) record counters. `decision` is one of
-    /// `"keep"` / `"drop"`.
-    pub records_by_rm_decision: BTreeMap<(String, &'static str), u64>,
+    /// Per-(rmgr name, route) record counters. `route` is one of
+    /// `"to_shadow"` / `"to_decoder"`.
+    pub records_by_rm_route: BTreeMap<(String, &'static str), u64>,
     pub xact_active: u64,
     pub xact_bytes_in_memory: u64,
     pub spill_xacts_active: u64,
@@ -233,14 +233,14 @@ pub fn render(snap: &MetricsSnapshot) -> String {
     // Per-rmgr counters -------------------------------------------------
     writeln!(
         s,
-        "# HELP walshadow_filter_records_total Records observed by the filter, labeled by rmgr + decision."
+        "# HELP walshadow_filter_records_total Records observed by the filter, labeled by rmgr + route."
     )
     .unwrap();
     writeln!(s, "# TYPE walshadow_filter_records_total counter").unwrap();
-    for ((rm, decision), n) in &snap.records_by_rm_decision {
+    for ((rm, route), n) in &snap.records_by_rm_route {
         writeln!(
             s,
-            "walshadow_filter_records_total{{rmgr={rm:?},decision={decision:?}}} {n}"
+            "walshadow_filter_records_total{{rmgr={rm:?},route={route:?}}} {n}"
         )
         .unwrap();
     }
@@ -497,8 +497,8 @@ mod tests {
             uptime_secs: 42,
             ..MetricsSnapshot::default()
         };
-        snap.records_by_rm_decision
-            .insert(("Heap".into(), "drop"), 17);
+        snap.records_by_rm_route
+            .insert(("Heap".into(), "to_decoder"), 17);
 
         let body = render(&snap);
         assert!(body.contains("# HELP walshadow_source_received_lsn"));
@@ -506,7 +506,7 @@ mod tests {
         assert!(body.contains("walshadow_source_received_lsn 3405691582"));
         assert!(body.contains("walshadow_filter_lsn 12648430"));
         assert!(
-            body.contains("walshadow_filter_records_total{rmgr=\"Heap\",decision=\"drop\"} 17")
+            body.contains("walshadow_filter_records_total{rmgr=\"Heap\",route=\"to_decoder\"} 17")
         );
         assert!(body.contains("walshadow_xact_active 3"));
         assert!(body.contains("walshadow_uptime_seconds 42"));

--- a/src/queueing_record_sink.rs
+++ b/src/queueing_record_sink.rs
@@ -288,7 +288,7 @@ impl RecordSink for QueueingRecordSink {
                 parsed: record.parsed.clone().into_owned(),
                 source_lsn: record.source_lsn,
                 page_magic: record.page_magic,
-                decision: record.decision,
+                route: record.route,
             });
             if self.buf.len() >= self.batch_size {
                 self.flush_buf()?;
@@ -317,7 +317,7 @@ mod tests {
             parsed: XLogRecord::default(),
             source_lsn,
             page_magic: 0,
-            decision: crate::filter::Decision::Keep,
+            route: crate::filter::Route::ToShadow,
         }
     }
 

--- a/src/streaming_walker.rs
+++ b/src/streaming_walker.rs
@@ -262,6 +262,20 @@ impl StreamingWalker {
         debug_assert_eq!(cursor, new_logical.len());
     }
 
+    /// In-place variant of [`rewrite_record`](Self::rewrite_record) for a
+    /// single-page record whose `len` bytes are contiguous in the buffer
+    /// at `off` (`stitched_bytes: None`). Runs `rewrite` directly over
+    /// the segment buffer, skipping the copy-out + scatter-back the
+    /// fragmented (cross-page) path needs.
+    pub fn rewrite_record_in_place<E>(
+        &mut self,
+        off: usize,
+        len: usize,
+        rewrite: impl FnOnce(&mut [u8]) -> Result<(), E>,
+    ) -> Result<(), E> {
+        rewrite(&mut self.buf[off..off + len])
+    }
+
     /// Reset walker state for the next segment. Reuses the existing
     /// 16 MiB buffer allocation (`Vec::clear` retains capacity) so
     /// segment-cadence flushes don't churn the allocator — under

--- a/src/wal_stream.rs
+++ b/src/wal_stream.rs
@@ -17,8 +17,8 @@
 //!         Filter::decide
 //!         /     |        \
 //!        v      v         v
-//!   noop_replace (Drop)  rewrite_record  manifest
-//!              |          (in place)     entry
+//!   noop_replace (ToDecoder)  rewrite_record  manifest
+//!              |              (in place)      entry
 //!              v
 //!         RecordBytesSink  (shadow wire — §3)
 //!              v
@@ -43,7 +43,7 @@ use wal_rs::pg::wal::segment::SegmentName;
 use wal_rs::pg::walparser::{ParseError, XLogRecord, parse_record_from_bytes};
 
 use crate::classify::rmgr_label;
-use crate::filter::{Decision, Filter, FilterStats};
+use crate::filter::{Filter, FilterStats, Route};
 use crate::filter_segment::{FilterSegmentError, ParsedRecord, filter_segment};
 use crate::manifest::{Entry, FILTER_VERSION, Kind, Manifest, ManifestStats};
 use crate::rewrite::{RewriteError, noop_replace};
@@ -102,8 +102,8 @@ pub enum SinkError {
 }
 
 /// Per-record hand-off carrying the parsed `XLogRecord`, where it sits
-/// in the source LSN stream, and the keep/drop decision the filter
-/// computed. The heap-tuple decoder reads `parsed.header.xact_id`,
+/// in the source LSN stream, and the `Route` the filter computed. The
+/// heap-tuple decoder reads `parsed.header.xact_id`,
 /// `parsed.blocks[i].header.location.rel`, and `parsed.main_data`;
 /// `page_magic` selects PG-15-vs-PG-14 FPI bit semantics.
 ///
@@ -120,8 +120,8 @@ pub struct Record<'a> {
     pub source_lsn: u64,
     /// Magic of the page whose data area the record header sat on.
     pub page_magic: u16,
-    /// Keep/drop decision the filter computed.
-    pub decision: Decision,
+    /// Routing decision the filter computed.
+    pub route: Route,
 }
 
 impl Record<'static> {
@@ -134,15 +134,15 @@ impl Record<'static> {
         parsed: ParsedRecord,
         entry: &crate::manifest::Entry,
     ) -> Self {
-        let decision = match entry.kind {
-            Kind::Kept => Decision::Keep,
-            Kind::Dropped => Decision::Drop,
+        let route = match entry.kind {
+            Kind::Kept => Route::ToShadow,
+            Kind::Dropped => Route::ToDecoder,
         };
         Self {
             parsed: parsed.record,
             source_lsn: seg_start_lsn + entry.offset,
             page_magic: parsed.page_magic,
-            decision,
+            route,
         }
     }
 }
@@ -279,7 +279,7 @@ impl RecordSink for CollectingRecordSink {
                 parsed: record.parsed.clone().into_owned(),
                 source_lsn: record.source_lsn,
                 page_magic: record.page_magic,
-                decision: record.decision,
+                route: record.route,
             });
             Ok(())
         })
@@ -304,11 +304,11 @@ impl RecordSink for CountingRecordSink {
     }
 }
 
-/// `RecordSink` that maintains a per-`(rmid, decision)` counter and
+/// `RecordSink` that maintains a per-`(rmid, route)` counter and
 /// discards the record.
 #[derive(Debug, Default)]
 pub struct MetricsRecordSink {
-    pub by_rm_decision: BTreeMap<(u8, Decision), u64>,
+    pub by_rm_route: BTreeMap<(u8, Route), u64>,
     pub total: u64,
 }
 
@@ -317,12 +317,12 @@ impl MetricsRecordSink {
         use std::fmt::Write as _;
         let mut s = String::new();
         write!(&mut s, "total={}", self.total).unwrap();
-        for ((rm, decision), n) in &self.by_rm_decision {
-            let d = match decision {
-                Decision::Keep => "keep",
-                Decision::Drop => "drop",
+        for ((rm, route), n) in &self.by_rm_route {
+            let r = match route {
+                Route::ToShadow => "to_shadow",
+                Route::ToDecoder => "to_decoder",
             };
-            write!(&mut s, " {}/{}={}", rmgr_label(*rm), d, n).unwrap();
+            write!(&mut s, " {}/{}={}", rmgr_label(*rm), r, n).unwrap();
         }
         s
     }
@@ -335,10 +335,7 @@ impl RecordSink for MetricsRecordSink {
     ) -> Pin<Box<dyn Future<Output = Result<(), SinkError>> + Send + 'a>> {
         Box::pin(async move {
             let rm = record.parsed.header.resource_manager_id;
-            *self
-                .by_rm_decision
-                .entry((rm, record.decision))
-                .or_insert(0) += 1;
+            *self.by_rm_route.entry((rm, record.route)).or_insert(0) += 1;
             self.total += 1;
             Ok(())
         })
@@ -701,11 +698,11 @@ impl WalStream {
             // Parse + decide inside an inner scope so any slice
             // borrows back into the walker buffer (`parsed.main_data`,
             // per-block `image`/`data`) live only across the filter
-            // call. For the `Drop` path we materialise the parse to
-            // `'static` so the subsequent `rewrite_record` can take
-            // `&mut self.walker` without conflicting; the `Keep` path
-            // keeps the borrow zero-copy through `record_sink`.
-            let decision;
+            // call. We materialise the parse to `'static` so the
+            // `ToDecoder` in-place NOOP below can take `&mut self.walker`
+            // without conflicting, and so the decoder still reads the
+            // original bytes after the shadow stream is clobbered.
+            let route;
             let parsed_for_sink: XLogRecord<'static>;
             {
                 let parsed = parse_record_from_bytes(
@@ -716,29 +713,43 @@ impl WalStream {
                     offset: start_offset,
                     source,
                 })?;
-                decision = self.filter.decide(&parsed);
+                route = self.filter.decide(&parsed);
                 // Materialise here: `rewrite_record` below mutates
                 // walker.buf which `parsed`'s slices view; the dispatch
                 // below needs the *original* parse, not post-rewrite.
                 parsed_for_sink = parsed.into_owned();
             }
-            let kind = match decision {
-                Decision::Keep => Kind::Kept,
-                Decision::Drop => Kind::Dropped,
+            let kind = match route {
+                Route::ToShadow => Kind::Kept,
+                Route::ToDecoder => Kind::Dropped,
             };
-            if decision == Decision::Drop {
-                let mut bytes = match completed.stitched_bytes {
-                    Some(v) => v,
+            if route == Route::ToDecoder {
+                // `parsed_for_sink` already owns the original bytes the
+                // decoder reads, so clobbering the buffer with the NOOP
+                // here is safe.
+                match completed.stitched_bytes {
+                    // Cross-page: bytes are page-fragmented in the
+                    // buffer, so stitch → NOOP → scatter back across
+                    // `byte_ranges`.
+                    Some(mut bytes) => {
+                        noop_replace(&mut bytes).map_err(|source| WalStreamError::Rewrite {
+                            offset: start_offset,
+                            source,
+                        })?;
+                        self.walker.rewrite_record(&byte_ranges, &bytes);
+                    }
+                    // Single-page: record is contiguous in the buffer;
+                    // NOOP in place, no copy-out + scatter-back.
                     None => {
                         let (off, len) = byte_ranges[0];
-                        self.walker.buffer()[off..off + len].to_vec()
+                        self.walker
+                            .rewrite_record_in_place(off, len, noop_replace)
+                            .map_err(|source| WalStreamError::Rewrite {
+                                offset: start_offset,
+                                source,
+                            })?;
                     }
-                };
-                noop_replace(&mut bytes).map_err(|source| WalStreamError::Rewrite {
-                    offset: start_offset,
-                    source,
-                })?;
-                self.walker.rewrite_record(&byte_ranges, &bytes);
+                }
             }
 
             self.pending_entries.push(Entry {
@@ -765,7 +776,7 @@ impl WalStream {
                 parsed: parsed_for_sink,
                 source_lsn,
                 page_magic,
-                decision,
+                route,
             };
             record_sink.on_record(&record).await?;
         }
@@ -987,7 +998,7 @@ mod tests {
         assert_eq!(record.parsed.header.resource_manager_id, RmId::Xact as u8);
         assert_eq!(record.parsed.header.xact_id, 42);
         assert_eq!(record.page_magic, 0xD110);
-        assert_eq!(record.decision, Decision::Keep);
+        assert_eq!(record.route, Route::ToShadow);
     }
 
     #[test]
@@ -1183,26 +1194,26 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn metrics_sink_counts_per_rm_decision_and_discards() {
+    async fn metrics_sink_counts_per_rm_route_and_discards() {
         let mut sink = MetricsRecordSink::default();
         let mut heap_keep = synth_record(0, RmId::Heap as u8);
-        heap_keep.decision = Decision::Keep;
+        heap_keep.route = Route::ToShadow;
         let mut heap_drop = synth_record(64, RmId::Heap as u8);
-        heap_drop.decision = Decision::Drop;
+        heap_drop.route = Route::ToDecoder;
         let mut xact_keep = synth_record(128, RmId::Xact as u8);
-        xact_keep.decision = Decision::Keep;
+        xact_keep.route = Route::ToShadow;
         for r in [&heap_keep, &heap_keep, &heap_drop, &xact_keep] {
             sink.on_record(r).await.unwrap();
         }
         assert_eq!(sink.total, 4);
-        assert_eq!(sink.by_rm_decision[&(RmId::Heap as u8, Decision::Keep)], 2,);
-        assert_eq!(sink.by_rm_decision[&(RmId::Heap as u8, Decision::Drop)], 1,);
-        assert_eq!(sink.by_rm_decision[&(RmId::Xact as u8, Decision::Keep)], 1,);
+        assert_eq!(sink.by_rm_route[&(RmId::Heap as u8, Route::ToShadow)], 2,);
+        assert_eq!(sink.by_rm_route[&(RmId::Heap as u8, Route::ToDecoder)], 1,);
+        assert_eq!(sink.by_rm_route[&(RmId::Xact as u8, Route::ToShadow)], 1,);
         let summary = sink.summary();
         assert!(summary.starts_with("total=4"), "got {summary:?}");
-        assert!(summary.contains("heap/keep=2"), "got {summary:?}");
-        assert!(summary.contains("heap/drop=1"), "got {summary:?}");
-        assert!(summary.contains("xact/keep=1"), "got {summary:?}");
+        assert!(summary.contains("heap/to_shadow=2"), "got {summary:?}");
+        assert!(summary.contains("heap/to_decoder=1"), "got {summary:?}");
+        assert!(summary.contains("xact/to_shadow=1"), "got {summary:?}");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/xact_buffer.rs
+++ b/src/xact_buffer.rs
@@ -73,7 +73,7 @@ use tokio::sync::Mutex;
 use wal_rs::pg::walparser::RmId;
 
 use crate::decoder_sink::{DecoderSinkError, DecoderStats, TupleObserver};
-use crate::filter::Decision;
+use crate::filter::Route;
 use crate::heap_decoder::{
     ColumnValue, CommittedTuple, DecodedHeap, HeapOp, ToastPointer, decode_heap_record,
 };
@@ -1234,7 +1234,7 @@ fn reassemble(
 
 /// `RecordSink` that observes `RM_XACT_ID` records and drives the
 /// buffer's commit/abort path. Separate from [`BufferingDecoderSink`]
-/// because xact records are `Decision::Keep` (shadow PG needs them
+/// because xact records are `Route::ToShadow` (shadow PG needs them
 /// for CLOG) so the decoder sink skips them by contract.
 pub struct XactRecordSink<O: TupleObserver + Send> {
     buffer: Arc<Mutex<XactBuffer>>,
@@ -1547,7 +1547,7 @@ impl<O: TupleObserver + Send> RecordSink for XactRecordSink<O> {
 /// (`rel.kind == 't'`) are reinterpreted as
 /// [`ToastChunk`](crate::spill::ToastChunk)s and parked under their
 /// `(toast_relid, value_id)` slot for drain-time reassembly. Only
-/// `Decision::Drop` records reach this sink (catalog-keep stays on
+/// `Route::ToDecoder` records reach this sink (catalog-keep stays on
 /// the shadow-replay path); semantic errors absorb into
 /// [`DecoderStats`] rather than poisoning the stream.
 /// Shared schema-event receiver — wraps the catalog's
@@ -1714,7 +1714,7 @@ impl RecordSink for BufferingDecoderSink {
     {
         Box::pin(async move {
             let rm = record.parsed.header.resource_manager_id;
-            // TRUNCATE rides Decision::Keep (filter leaves it intact so
+            // TRUNCATE rides Route::ToShadow (filter leaves it intact so
             // shadow can replay the truncate against its own copy), but
             // the decoder still needs to fan out per-relid HeapOp::Truncate
             // for CH emission. Handle before the Drop gate so the
@@ -1726,7 +1726,7 @@ impl RecordSink for BufferingDecoderSink {
                     return self.handle_truncate(record).await;
                 }
             }
-            if record.decision != Decision::Drop {
+            if record.route != Route::ToDecoder {
                 return Ok(());
             }
             if rm != RmId::Heap as u8 && rm != RmId::Heap2 as u8 {

--- a/tests/filter_round_trip.rs
+++ b/tests/filter_round_trip.rs
@@ -8,7 +8,7 @@
 //! 2. Every record re-parses through wal-rs's `WalParser` without error.
 //! 3. Manifest record count equals source record count.
 //! 4. Filter dropped >0 user records on a non-DDL-heavy workload.
-//! 5. All `Decision::Drop` records show as `XLOG_NOOP` (rmid=0, info=0x20)
+//! 5. All `Route::ToDecoder` records show as `XLOG_NOOP` (rmid=0, info=0x20)
 //!    in the filtered output.
 
 use std::path::PathBuf;

--- a/tests/multi_segment_filter.rs
+++ b/tests/multi_segment_filter.rs
@@ -25,7 +25,7 @@ use wal_rs::pg::walparser::{
     RmId, X_LOG_RECORD_HEADER_SIZE, XLP_LONG_HEADER, XLP_PAGE_MAGIC_PG15, XLR_BLOCK_ID_DATA_LONG,
 };
 
-use walshadow::filter::Decision;
+use walshadow::filter::Route;
 use walshadow::manifest::Kind;
 use walshadow::rewrite::compute_crc;
 use walshadow::wal_stream::{
@@ -236,9 +236,9 @@ async fn catalog_tracker_state_survives_segment_boundary() {
     assert_eq!(filter.stats.dropped, 0);
     assert_eq!(filter.tracker.relmap_updates, 1);
 
-    // RecordSink decisions reflect the same outcome.
-    assert_eq!(records.records[0].decision, Decision::Keep);
-    assert_eq!(records.records[1].decision, Decision::Keep);
+    // RecordSink routes reflect the same outcome.
+    assert_eq!(records.records[0].route, Route::ToShadow);
+    assert_eq!(records.records[1].route, Route::ToShadow);
 }
 
 /// Every record bracketed by one BEGIN…COMMIT carries the
@@ -323,7 +323,7 @@ impl RecordSink for SharedCollectingSink {
                 parsed: r.parsed.clone().into_owned(),
                 source_lsn: r.source_lsn,
                 page_magic: r.page_magic,
-                decision: r.decision,
+                route: r.route,
             });
             Ok(())
         })
@@ -426,7 +426,7 @@ async fn composite_sink_fans_out_to_all_inner_sinks() {
             PG_CLASS_OID
         );
         assert_eq!(r.parsed.blocks[0].header.location.block_no, i as u32);
-        assert_eq!(r.decision, Decision::Keep);
+        assert_eq!(r.route, Route::ToShadow);
     }
 }
 

--- a/tests/wal_stream_chunk_boundary.rs
+++ b/tests/wal_stream_chunk_boundary.rs
@@ -30,7 +30,7 @@ struct RecordKey {
     info: u8,
     xact_id: u32,
     total_len: u32,
-    decision: walshadow::filter::Decision,
+    route: walshadow::filter::Route,
     page_magic: u16,
     block_locators: Vec<(u32, u32, u32)>,
 }
@@ -42,7 +42,7 @@ fn key(r: &Record) -> RecordKey {
         info: r.parsed.header.info,
         xact_id: r.parsed.header.xact_id,
         total_len: r.parsed.header.total_record_length,
-        decision: r.decision,
+        route: r.route,
         page_magic: r.page_magic,
         block_locators: r
             .parsed

--- a/tests/wal_stream_throughput.rs
+++ b/tests/wal_stream_throughput.rs
@@ -322,7 +322,7 @@ async fn pump_throughput_breakdown() {
                         parsed: r.parsed.clone().into_owned(),
                         source_lsn: r.source_lsn,
                         page_magic: r.page_magic,
-                        decision: r.decision,
+                        route: r.route,
                     };
                     // Push then immediately pop to drop, so we measure
                     // clone+drop without growing memory unboundedly.

--- a/tests/xact_buffer.rs
+++ b/tests/xact_buffer.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 use wal_rs::pg::walparser::{RelFileNode, RmId, XLogRecord, XLogRecordHeader};
 use walshadow::decoder_sink::{DecoderSinkError, TupleObserver};
-use walshadow::filter::Decision;
+use walshadow::filter::Route;
 use walshadow::heap_decoder::{
     ColumnValue, CommittedTuple, DecodedHeap, DecodedTuple, HeapOp, ToastPointer,
 };
@@ -453,7 +453,7 @@ fn xact_record(info_op: u8, xid: u32, xact_time: i64) -> Record<'static> {
         },
         source_lsn: 0,
         page_magic: 0xD110,
-        decision: Decision::Keep,
+        route: Route::ToShadow,
     }
 }
 


### PR DESCRIPTION
also rename Decision Keep/Drop to Route ToShadow/ToDecoder, avoiding misconception that records are actually dropped here