### PR TITLE
Fix dockerfile to contain bench

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /src
 COPY Cargo.toml Cargo.lock ./
 COPY clickhouse-c-rs ./clickhouse-c-rs
 COPY wal-rs ./wal-rs
+COPY bench ./bench
 COPY src ./src
 RUN cargo build --release --bin walshadow-stream
 


### PR DESCRIPTION
New cargo crate caused the docker build to fail because bench/ was not copied. 