### PR TITLE
Fix shadow pg wal replay

### DIFF
--- a/src/shadow_stream.rs
+++ b/src/shadow_stream.rs
@@ -6,10 +6,13 @@
 //! shadow's flush/apply LSNs back; the min across connections gates the
 //! catalog.
 //!
-//! Backpressure: a send buffer past `slow_connection_threshold` is
-//! dropped, letting shadow reconnect via the archive (`restore_command`)
-//! path; the catalog gate then polls shadow's apply LSN until streaming
-//! resumes.
+//! Backpressure: a send buffer past `slow_connection_threshold` is dropped and
+//! the walreceiver reconnects. Since the pump streams live (it doesn't replay
+//! history), a reconnect lands *behind* the head; [`ShadowStreamState`] retains
+//! the current segment's wire bytes and backfills `[reconnect_lsn, head]` on
+//! connect so the stream stays contiguous. Older complete segments come from
+//! the archive (`restore_command`); only the in-progress segment — which the
+//! archive lacks — must come over the wire.
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -103,6 +106,11 @@ pub struct ShadowStreamState {
     /// Surfaced via [`AggregateLsn::dropped_total`] for the
     /// `walshadow_shadow_stream_dropped_connections_total` gauge.
     dropped_total: u64,
+    /// Current segment's wire bytes `[wire_buf_start, server_wal_end]`, used to
+    /// backfill a reconnect behind the live head (else it gets an unappliable
+    /// gap and strands at segment boundaries). Reset per segment.
+    wire_buf: Vec<u8>,
+    wire_buf_start: u64,
 }
 
 impl ShadowStreamState {
@@ -124,6 +132,8 @@ impl ShadowStreamState {
             slow_threshold,
             server_wal_end: current_lsn,
             dropped_total: 0,
+            wire_buf: Vec::new(),
+            wire_buf_start: current_lsn,
         }
     }
 
@@ -147,7 +157,89 @@ impl ShadowStreamState {
         let id = self.next_conn_id;
         self.next_conn_id += 1;
         self.connections.insert(id, ConnState::fresh(start_lsn));
+        self.backfill_connection(id, start_lsn);
         id
+    }
+
+    /// Append contiguous wire bytes; a non-contiguous LSN re-anchors.
+    fn retain_wire(&mut self, start_lsn: u64, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+        let buf_end = self.wire_buf_start + self.wire_buf.len() as u64;
+        if self.wire_buf.is_empty() || start_lsn != buf_end {
+            self.wire_buf.clear();
+            self.wire_buf_start = start_lsn;
+        }
+        self.wire_buf.extend_from_slice(bytes);
+    }
+
+    /// Drop the completed segment; `restore_command` serves it from now on.
+    fn reset_wire_buf(&mut self, next_start: u64) {
+        self.wire_buf.clear();
+        self.wire_buf_start = next_start;
+    }
+
+    /// Frame `bytes` (at `start_lsn`) to every connection past its dispatched
+    /// point, bump `server_wal_end`, and retain for backfill.
+    fn dispatch_wire(&mut self, start_lsn: u64, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+        let end_lsn = start_lsn + bytes.len() as u64;
+        self.server_wal_end = self.server_wal_end.max(end_lsn);
+        self.retain_wire(start_lsn, bytes);
+        let server_wal_end = self.server_wal_end;
+        let ids: Vec<u64> = self.connections.keys().copied().collect();
+        for id in ids {
+            let conn_offset = self
+                .connections
+                .get(&id)
+                .map(|c| c.dispatched_lsn)
+                .unwrap_or(start_lsn);
+            if end_lsn <= conn_offset {
+                continue;
+            }
+            let skip = conn_offset.saturating_sub(start_lsn) as usize;
+            let to_send = &bytes[skip.min(bytes.len())..];
+            if to_send.is_empty() {
+                continue;
+            }
+            let frame_lsn = start_lsn + skip as u64;
+            if self.enqueue_copy_data_with(id, |out| {
+                encode_wal_data_frame_into(out, frame_lsn, server_wal_end, to_send);
+            }) {
+                self.advance_dispatched(id, end_lsn);
+            }
+        }
+    }
+
+    /// Replay `[start_lsn, server_wal_end]` so a reconnect behind the live head
+    /// gets a contiguous stream instead of a gap. Older ranges → restore_command.
+    fn backfill_connection(&mut self, id: u64, start_lsn: u64) {
+        let server_wal_end = self.server_wal_end;
+        if start_lsn >= server_wal_end || start_lsn < self.wire_buf_start {
+            return;
+        }
+        let off = (start_lsn - self.wire_buf_start) as usize;
+        if off >= self.wire_buf.len() {
+            return;
+        }
+        let backfill = self.wire_buf[off..].to_vec();
+        const FRAME: usize = 256 * 1024;
+        let mut pos = 0;
+        while pos < backfill.len() {
+            let end = (pos + FRAME).min(backfill.len());
+            let frame_lsn = start_lsn + pos as u64;
+            let chunk = &backfill[pos..end];
+            // Uncapped: a reconnect backfill is bounded (≤ one segment) and
+            // required for recovery, so it must not trip the slow-client cap.
+            self.frame_copy_data(id, None, |out| {
+                encode_wal_data_frame_into(out, frame_lsn, server_wal_end, chunk);
+            });
+            pos = end;
+        }
+        self.advance_dispatched(id, server_wal_end);
     }
 
     pub fn drop_connection(&mut self, id: u64) {
@@ -187,13 +279,16 @@ impl ShadowStreamState {
         true
     }
 
-    /// Append a CopyData envelope wrapping a `'w'`/`'k'` frame, built
-    /// in-place to skip the intermediate `Vec`s per record × connection.
-    /// `build_body` writes everything after the 5-byte CopyData header.
-    /// `false` on `slow_threshold` breach (marks closing, clears queue,
-    /// matching [`enqueue`]).
-    fn enqueue_copy_data_with(&mut self, id: u64, build_body: impl FnOnce(&mut Vec<u8>)) -> bool {
-        let slow_threshold = self.slow_threshold;
+    /// Append a CopyData envelope wrapping a `'w'`/`'k'` frame, built in-place.
+    /// `build_body` writes everything after the 5-byte CopyData header. `cap`
+    /// caps the queue (live traffic); `None` skips the cap for a bounded
+    /// reconnect backfill. `false` on cap breach (marks closing, clears queue).
+    fn frame_copy_data(
+        &mut self,
+        id: u64,
+        cap: Option<usize>,
+        build_body: impl FnOnce(&mut Vec<u8>),
+    ) -> bool {
         let q = self.send_queues.entry(id).or_default();
         let envelope_start = q.len();
         q.push(b'd');
@@ -202,7 +297,9 @@ impl ShadowStreamState {
         let body_start = q.len();
         build_body(q);
         let payload_len = 4 + (q.len() - body_start);
-        if envelope_start + 1 + payload_len > slow_threshold {
+        if let Some(cap) = cap
+            && envelope_start + 1 + payload_len > cap
+        {
             q.truncate(envelope_start);
             if let Some(c) = self.connections.get_mut(&id)
                 && !c.closing
@@ -216,6 +313,11 @@ impl ShadowStreamState {
         q[envelope_start + 1..envelope_start + 5]
             .copy_from_slice(&(payload_len as u32).to_be_bytes());
         true
+    }
+
+    /// Cap-enforcing enqueue for live traffic.
+    fn enqueue_copy_data_with(&mut self, id: u64, build_body: impl FnOnce(&mut Vec<u8>)) -> bool {
+        self.frame_copy_data(id, Some(self.slow_threshold), build_body)
     }
 
     pub fn advance_dispatched(&mut self, id: u64, new_lsn: u64) {
@@ -242,36 +344,7 @@ impl RecordBytesSink for ShadowStreamSink {
         bytes: &'a [u8],
     ) -> Pin<Box<dyn Future<Output = Result<(), SinkError>> + Send + 'a>> {
         Box::pin(async move {
-            if bytes.is_empty() {
-                return Ok(());
-            }
-            let mut state = self.state.lock().await;
-            let end_lsn = start_lsn + bytes.len() as u64;
-            state.server_wal_end = state.server_wal_end.max(end_lsn);
-            let server_wal_end = state.server_wal_end;
-            let ids: Vec<u64> = state.connections.keys().copied().collect();
-            for id in ids {
-                let conn_offset = state
-                    .connections
-                    .get(&id)
-                    .map(|c| c.dispatched_lsn)
-                    .unwrap_or(start_lsn);
-                if end_lsn <= conn_offset {
-                    continue;
-                }
-                let skip = conn_offset.saturating_sub(start_lsn) as usize;
-                let to_send = &bytes[skip.min(bytes.len())..];
-                if to_send.is_empty() {
-                    continue;
-                }
-                let frame_lsn = start_lsn + skip as u64;
-                let enqueued = state.enqueue_copy_data_with(id, |out| {
-                    encode_wal_data_frame_into(out, frame_lsn, server_wal_end, to_send);
-                });
-                if enqueued {
-                    state.advance_dispatched(id, end_lsn);
-                }
-            }
+            self.state.lock().await.dispatch_wire(start_lsn, bytes);
             Ok(())
         })
     }
@@ -284,29 +357,9 @@ impl RecordBytesSink for ShadowStreamSink {
         Box::pin(async move {
             let mut state = self.state.lock().await;
             let segment_end_lsn = start_lsn + trailing_bytes.len() as u64;
-            state.server_wal_end = state.server_wal_end.max(segment_end_lsn);
-            let server_wal_end = state.server_wal_end;
-            let ids: Vec<u64> = state.connections.keys().copied().collect();
-            for id in ids {
-                let conn_offset = state
-                    .connections
-                    .get(&id)
-                    .map(|c| c.dispatched_lsn)
-                    .unwrap_or(start_lsn);
-                if segment_end_lsn > conn_offset && !trailing_bytes.is_empty() {
-                    let skip = conn_offset.saturating_sub(start_lsn) as usize;
-                    let to_send = &trailing_bytes[skip.min(trailing_bytes.len())..];
-                    if !to_send.is_empty() {
-                        let frame_lsn = start_lsn + skip as u64;
-                        let enqueued = state.enqueue_copy_data_with(id, |out| {
-                            encode_wal_data_frame_into(out, frame_lsn, server_wal_end, to_send);
-                        });
-                        if enqueued {
-                            state.advance_dispatched(id, segment_end_lsn);
-                        }
-                    }
-                }
-            }
+            state.dispatch_wire(start_lsn, trailing_bytes);
+            // Segment complete → restore_command owns it; track the next one.
+            state.reset_wire_buf(segment_end_lsn);
             Ok(())
         })
     }
@@ -597,5 +650,58 @@ mod tests {
         // + start_lsn(8) + server_wal_end(8) + send_time(8) = 30 bytes
         assert_eq!(&qa[30..], bytes);
         assert_eq!(&qb[30..], bytes);
+    }
+
+    // 'w' frame prefix: 'd'(1) + len(4) + 'w'(1) + start_lsn(8) + wal_end(8) +
+    // send_time(8) = 30 bytes; payload follows.
+    const WIRE_HDR: usize = 30;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn reconnect_behind_head_is_backfilled_contiguously() {
+        let state = Arc::new(Mutex::new(fresh_state())); // current_lsn = 0x1000
+        let mut sink = ShadowStreamSink::new(state.clone());
+        sink.on_wire_chunk(0x1000, b"AAAA").await.unwrap();
+        sink.on_wire_chunk(0x1004, b"BBBB").await.unwrap(); // head = 0x1008
+
+        // A reconnect behind the head gets the whole [reconnect_lsn, head] range
+        // from the retained buffer — not just future bytes (which would gap).
+        let mut s = state.lock().await;
+        let id = s.register_connection(0x1000);
+        let q = s.drain_send_queue(id).expect("reconnect backfilled");
+        assert_eq!(&q[WIRE_HDR..], b"AAAABBBB", "backfill must be gap-free");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn connect_at_head_has_no_backfill() {
+        let state = Arc::new(Mutex::new(fresh_state()));
+        let mut sink = ShadowStreamSink::new(state.clone());
+        sink.on_wire_chunk(0x1000, b"AAAA").await.unwrap(); // head = 0x1004
+        let mut s = state.lock().await;
+        let id = s.register_connection(0x1004); // caught up
+        assert!(
+            s.drain_send_queue(id).is_none(),
+            "nothing to backfill at head"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn backfill_scoped_to_current_segment() {
+        let state = Arc::new(Mutex::new(fresh_state())); // current_lsn = 0x1000
+        let mut sink = ShadowStreamSink::new(state.clone());
+        sink.on_wire_chunk(0x1000, b"AAAA").await.unwrap();
+        sink.on_segment_boundary(0x1004, b"").await.unwrap(); // resets buf to 0x1004
+        sink.on_wire_chunk(0x1004, b"CCCC").await.unwrap(); // new segment, head = 0x1008
+
+        let mut s = state.lock().await;
+        // Old (completed) segment is restore_command's job — not backfilled.
+        let old = s.register_connection(0x1000);
+        assert!(
+            s.drain_send_queue(old).is_none(),
+            "completed segment not backfilled"
+        );
+        // Current segment is served from the buffer.
+        let cur = s.register_connection(0x1004);
+        let q = s.drain_send_queue(cur).expect("current-segment backfill");
+        assert_eq!(&q[WIRE_HDR..], b"CCCC");
     }
 }

--- a/tests/bin_stream_e2e.rs
+++ b/tests/bin_stream_e2e.rs
@@ -492,7 +492,9 @@ const WD_WALSENDER_PORT: u16 = 26184;
 fn kill_walreceiver(shadow: &Shadow) -> Result<()> {
     for _ in 0..50 {
         let pid = shadow
-            .psql_one("SELECT pid::text FROM pg_stat_activity WHERE backend_type='walreceiver' LIMIT 1")
+            .psql_one(
+                "SELECT pid::text FROM pg_stat_activity WHERE backend_type='walreceiver' LIMIT 1",
+            )
             .unwrap_or_default();
         let pid = pid.trim();
         if !pid.is_empty() {
@@ -606,24 +608,39 @@ async fn wire_drop_midsegment_shadow_resumes_streaming() {
     let metrics_addr: SocketAddr = format!("127.0.0.1:{WD_METRICS_PORT}").parse().unwrap();
     let mut child = Command::new(bin)
         .args([
-            "--host", source.config().socket_dir.to_str().unwrap(),
-            "--port", &WD_SOURCE_PORT.to_string(),
-            "--user", "postgres",
-            "--dbname", "postgres",
-            "--sslmode", "disable",
-            "--out-dir", filter_dir.to_str().unwrap(),
-            "--shadow-socket-dir", shadow_sock.to_str().unwrap(),
-            "--shadow-port", &WD_SHADOW_PORT.to_string(),
-            "--shadow-user", "postgres",
-            "--shadow-dbname", "postgres",
-            "--spill-dir", spill_dir.to_str().unwrap(),
-            "--status-interval", "1",
-            "--metrics-bind", &metrics_addr.to_string(),
-            "--walsender-bind", &format!("127.0.0.1:{WD_WALSENDER_PORT}"),
+            "--host",
+            source.config().socket_dir.to_str().unwrap(),
+            "--port",
+            &WD_SOURCE_PORT.to_string(),
+            "--user",
+            "postgres",
+            "--dbname",
+            "postgres",
+            "--sslmode",
+            "disable",
+            "--out-dir",
+            filter_dir.to_str().unwrap(),
+            "--shadow-socket-dir",
+            shadow_sock.to_str().unwrap(),
+            "--shadow-port",
+            &WD_SHADOW_PORT.to_string(),
+            "--shadow-user",
+            "postgres",
+            "--shadow-dbname",
+            "postgres",
+            "--spill-dir",
+            spill_dir.to_str().unwrap(),
+            "--status-interval",
+            "1",
+            "--metrics-bind",
+            &metrics_addr.to_string(),
+            "--walsender-bind",
+            &format!("127.0.0.1:{WD_WALSENDER_PORT}"),
             // Default (large) threshold: we force the disconnect by killing the
             // walreceiver, not by overflowing the queue — so baseline streaming
             // never trips a spurious drop.
-            "--retention-bytes", "0",
+            "--retention-bytes",
+            "0",
         ])
         .env("RUST_LOG", "warn,walshadow=info")
         .stdout(Stdio::null())
@@ -639,14 +656,14 @@ async fn wire_drop_midsegment_shadow_resumes_streaming() {
         // Continuous WAL so the wire stays active (a lone write goes idle and
         // its trailing record never streams). Started now — shadow is attached
         // at the pump head, so there's no startup backlog to overflow the queue.
-        writer = Some(
-            spawn_writer(source.config().socket_dir.as_path()).context("spawn writer")?,
-        );
+        writer = Some(spawn_writer(source.config().socket_dir.as_path()).context("spawn writer")?);
 
         // Baseline: the live wire keeps the shadow replaying the in-progress segment.
         sleep(Duration::from_secs(1));
         let m = walshadow::shadow::parse_pg_lsn(
-            &source.psql_one("SELECT pg_current_wal_lsn()::text").context("baseline lsn")?,
+            &source
+                .psql_one("SELECT pg_current_wal_lsn()::text")
+                .context("baseline lsn")?,
         )
         .unwrap();
         shadow
@@ -665,7 +682,9 @@ async fn wire_drop_midsegment_shadow_resumes_streaming() {
         // walshadow backfills the gap on reconnect. Without the fix the shadow
         // gets a hole, strands, and this times out. Budget < the 30s gate.
         let target = walshadow::shadow::parse_pg_lsn(
-            &source.psql_one("SELECT pg_current_wal_lsn()::text").context("target lsn")?,
+            &source
+                .psql_one("SELECT pg_current_wal_lsn()::text")
+                .context("target lsn")?,
         )
         .unwrap();
         let observed = shadow

--- a/tests/bin_stream_e2e.rs
+++ b/tests/bin_stream_e2e.rs
@@ -18,6 +18,7 @@ use std::net::{SocketAddr, TcpStream};
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
+use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
@@ -471,5 +472,225 @@ async fn bin_stream_replicates_segments_and_serves_metrics() {
     if let Err(e) = result {
         let stderr = fs::read_to_string(&stderr_path).unwrap_or_default();
         panic!("{e:#}\n--- daemon stderr ---\n{stderr}");
+    }
+}
+
+// Distinct port slot for the wire-drop test so it can run concurrently.
+const WD_SOURCE_PORT: u16 = 26181;
+const WD_SHADOW_PORT: u16 = 26182;
+const WD_METRICS_PORT: u16 = 26183;
+const WD_WALSENDER_PORT: u16 = 26184;
+
+/// `kill -<sig> -<pgid>` on the shadow cluster's process group, read from
+/// `postmaster.pid` + `/proc/<pid>/stat` (field 5 = pgrp). Pausing the *group*
+/// (not just the postmaster) stops the walreceiver child too, so it stops
+/// draining walshadow's wire and the send queue backs up.
+/// Kill the shadow's walreceiver (SIGTERM its backend pid). The startup process
+/// restarts it within `wal_retrieve_retry_interval`; with the source advancing
+/// it reconnects requesting an LSN *behind* the live head — the reconnect-gap
+/// the fix must backfill. Retries briefly in case we catch it between restarts.
+fn kill_walreceiver(shadow: &Shadow) -> Result<()> {
+    for _ in 0..50 {
+        let pid = shadow
+            .psql_one("SELECT pid::text FROM pg_stat_activity WHERE backend_type='walreceiver' LIMIT 1")
+            .unwrap_or_default();
+        let pid = pid.trim();
+        if !pid.is_empty() {
+            let _ = Command::new("kill").arg(pid).status();
+            return Ok(());
+        }
+        sleep(Duration::from_millis(100));
+    }
+    bail!("no walreceiver backend appeared to kill")
+}
+
+/// Background WAL generator on the source: a `psql` loop of small inserts into
+/// the no-PK `bs.load`, so the wire keeps flowing for the test's duration. Runs
+/// as its own process group; killed via [`kill_group`].
+fn spawn_writer(socket_dir: &Path) -> Result<Child> {
+    // Deliberately slow (~130 KiB/s): enough to advance the head during the 2s
+    // reconnect window (the gap), but far too slow to *complete* a 16 MiB
+    // segment within the test — so a stranded shadow can't quietly recover via
+    // restore_command (which only serves complete segments).
+    let script = format!(
+        "while :; do psql -h '{}' -p {} -U postgres -d postgres -q -t \
+         -c \"INSERT INTO bs.load SELECT repeat('x',100) FROM generate_series(1,200)\" \
+         >/dev/null 2>&1; sleep 0.2; done",
+        socket_dir.display(),
+        WD_SOURCE_PORT,
+    );
+    Command::new("bash")
+        .arg("-c")
+        .arg(script)
+        .process_group(0)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("spawn background writer")
+}
+
+fn kill_group(child: &mut Child) {
+    let pid = child.id() as i32;
+    let _ = Command::new("kill")
+        .arg("-TERM")
+        .arg(format!("-{pid}"))
+        .status();
+    let _ = child.wait();
+}
+
+/// Reproduction / validation harness for the WAL reconnect-gap strand.
+///
+/// A background writer keeps WAL flowing so the shadow streams the in-progress
+/// segment live. We then kill the shadow's walreceiver; it reconnects requesting
+/// an LSN behind the now-advanced head (inside the in-progress segment).
+///
+/// Passes only with the fix: walshadow backfills `[reconnect_lsn, head]` so the
+/// stream is contiguous. Without it the reconnect gets a hole, the shadow
+/// strands (`restore_command` lacks the incomplete segment), replay never
+/// catches up → fails.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "real-PG e2e; run with --ignored. Validates fix-2 (wire reconnect/resume)."]
+async fn wire_drop_midsegment_shadow_resumes_streaming() {
+    if !pg_available() || !pg_basebackup_available() {
+        eprintln!("skip: PG binaries not on PATH");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let source = make_pg(&tmp, "wd-source", WD_SOURCE_PORT);
+    source.initdb().expect("initdb source");
+    source.write_base_conf().expect("source base conf");
+    append_source_conf(&source);
+    source.start().expect("start source");
+    let _src_stop = StopOnDrop { sh: &source };
+    source
+        .apply_schema_dump(
+            "CREATE SCHEMA bs;\n\
+             CREATE TABLE bs.t (id bigint PRIMARY KEY, payload text);\n\
+             CREATE TABLE bs.load (payload text);\n",
+        )
+        .expect("apply source schema");
+
+    let shadow_data = tmp.path().join("wd-shadow-data");
+    pg_basebackup(&source, &shadow_data).expect("pg_basebackup");
+    source.psql_one("SELECT pg_switch_wal()").expect("rotate");
+
+    let filter_dir = tmp.path().join("wd-filtered");
+    fs::create_dir_all(&filter_dir).unwrap();
+    let shadow_sock = tmp.path().join("wd-shadow-sock");
+    fs::create_dir_all(&shadow_sock).unwrap();
+    rewrite_for_shadow(&shadow_data, WD_SHADOW_PORT, &shadow_sock).expect("retarget shadow");
+    enable_recovery(&shadow_data, &filter_dir, WD_WALSENDER_PORT).expect("enable recovery");
+    // Slow the walreceiver restart so killing it leaves a multi-second window in
+    // which the writer advances the head — guaranteeing the reconnect lands
+    // behind it (the gap). Overrides the 100ms from rewrite_for_shadow.
+    {
+        let conf = shadow_data.join("postgresql.conf");
+        let mut f = fs::OpenOptions::new().append(true).open(&conf).unwrap();
+        writeln!(f, "wal_retrieve_retry_interval = '2s'").unwrap();
+    }
+
+    let mut shadow_cfg = ShadowConfig::new(shadow_data.clone(), filter_dir.clone());
+    shadow_cfg.port = WD_SHADOW_PORT;
+    shadow_cfg.socket_dir = shadow_sock.clone();
+    shadow_cfg.ctl_timeout = Duration::from_secs(60);
+    let shadow = Shadow::new(shadow_cfg);
+    shadow.start().expect("start shadow");
+    let _shd_stop = StopOnDrop { sh: &shadow };
+
+    let spill_dir = tmp.path().join("wd-spill");
+    fs::create_dir_all(&spill_dir).unwrap();
+    let bin = env!("CARGO_BIN_EXE_walshadow-stream");
+    let stderr_path = tmp.path().join("wd-daemon.stderr.log");
+    let stderr_file = fs::File::create(&stderr_path).unwrap();
+    let metrics_addr: SocketAddr = format!("127.0.0.1:{WD_METRICS_PORT}").parse().unwrap();
+    let mut child = Command::new(bin)
+        .args([
+            "--host", source.config().socket_dir.to_str().unwrap(),
+            "--port", &WD_SOURCE_PORT.to_string(),
+            "--user", "postgres",
+            "--dbname", "postgres",
+            "--sslmode", "disable",
+            "--out-dir", filter_dir.to_str().unwrap(),
+            "--shadow-socket-dir", shadow_sock.to_str().unwrap(),
+            "--shadow-port", &WD_SHADOW_PORT.to_string(),
+            "--shadow-user", "postgres",
+            "--shadow-dbname", "postgres",
+            "--spill-dir", spill_dir.to_str().unwrap(),
+            "--status-interval", "1",
+            "--metrics-bind", &metrics_addr.to_string(),
+            "--walsender-bind", &format!("127.0.0.1:{WD_WALSENDER_PORT}"),
+            // Default (large) threshold: we force the disconnect by killing the
+            // walreceiver, not by overflowing the queue — so baseline streaming
+            // never trips a spurious drop.
+            "--retention-bytes", "0",
+        ])
+        .env("RUST_LOG", "warn,walshadow=info")
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr_file))
+        .process_group(0)
+        .spawn()
+        .expect("spawn walshadow-stream");
+
+    let mut writer: Option<Child> = None;
+    let result = (|| -> Result<()> {
+        wait_for_listen(metrics_addr, Duration::from_secs(30)).context("daemon never came up")?;
+
+        // Continuous WAL so the wire stays active (a lone write goes idle and
+        // its trailing record never streams). Started now — shadow is attached
+        // at the pump head, so there's no startup backlog to overflow the queue.
+        writer = Some(
+            spawn_writer(source.config().socket_dir.as_path()).context("spawn writer")?,
+        );
+
+        // Baseline: the live wire keeps the shadow replaying the in-progress segment.
+        sleep(Duration::from_secs(1));
+        let m = walshadow::shadow::parse_pg_lsn(
+            &source.psql_one("SELECT pg_current_wal_lsn()::text").context("baseline lsn")?,
+        )
+        .unwrap();
+        shadow
+            .wait_for_replay(m, Duration::from_secs(25))
+            .context("baseline replay over live wire")?;
+
+        // Force a mid-stream reconnect: kill the walreceiver. The writer keeps
+        // advancing the head during the ~100ms restart, so it reconnects behind
+        // the live head — inside the in-progress segment.
+        kill_walreceiver(&shadow).context("kill walreceiver")?;
+        // Let the 2s restart window elapse (writer advances the head meanwhile)
+        // so the walreceiver reconnects behind it before we check recovery.
+        sleep(Duration::from_secs(3));
+
+        // Recovery: replay must reach a post-reconnect LSN — only possible if
+        // walshadow backfills the gap on reconnect. Without the fix the shadow
+        // gets a hole, strands, and this times out. Budget < the 30s gate.
+        let target = walshadow::shadow::parse_pg_lsn(
+            &source.psql_one("SELECT pg_current_wal_lsn()::text").context("target lsn")?,
+        )
+        .unwrap();
+        let observed = shadow
+            .wait_for_replay(target, Duration::from_secs(25))
+            .context("shadow did not resume streaming after wire drop (strand reproduced)")?;
+        if observed < target {
+            bail!("replay {observed:X} < target {target:X} after wire drop");
+        }
+
+        // A strand would have killed the daemon via the fatal replay-timeout.
+        if let Some(status) = child.try_wait().context("poll daemon")? {
+            bail!("daemon exited during the wire drop: {status:?}");
+        }
+        Ok(())
+    })();
+
+    if let Some(mut w) = writer {
+        kill_group(&mut w);
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    if let Err(e) = result {
+        let stderr = fs::read_to_string(&stderr_path).unwrap_or_default();
+        let slog = fs::read_to_string(shadow_data.join("startup.log")).unwrap_or_default();
+        let tail = &slog[slog.len().saturating_sub(2048)..];
+        panic!("{e:#}\n--- daemon stderr ---\n{stderr}\n--- shadow startup.log tail ---\n{tail}");
     }
 }


### PR DESCRIPTION
Under backpressure in walshadow, the shadow pg connection is closed. When it tries to come back, it will read the WAL from out/. However the out/ directory is only written to after the entire block is written. We fix that by streaming the unwritten wal when the shadow pg tries to come back.

Fixes #23 