### PR TITLE
clickhouse-c-rs: support global allocator, use with mimalloc

### DIFF
--- a/clickhouse-c-rs/Cargo.toml
+++ b/clickhouse-c-rs/Cargo.toml
@@ -13,8 +13,6 @@ path = "src/lib.rs"
 default = ["lz4"]
 lz4 = []
 tokio = ["dep:tokio"]
-# rustls TLS for the blocking Client (tls::TlsIo) and, when `tokio` is also
-# on, AsyncClient::connect_tls.
 tls = ["dep:rustls", "dep:webpki-roots", "dep:tokio-rustls"]
 zstd = []
 

--- a/clickhouse-c-rs/src/alloc.rs
+++ b/clickhouse-c-rs/src/alloc.rs
@@ -1,7 +1,5 @@
-//! Allocator wrapper. Only the stdlib `malloc`/`realloc`/`free` allocator is
-//! exposed; PG-extension consumers wire `palloc` themselves in C.
-//!
-//! Cheap to construct (a few function pointers); not Drop-managed.
+use core::alloc::GlobalAlloc;
+use core::ffi::c_void;
 
 use crate::sys;
 
@@ -15,6 +13,21 @@ impl Allocator {
     pub fn stdlib() -> Self {
         let raw = unsafe { sys::chc_alloc_stdlib() };
         Self { raw }
+    }
+
+    /// Bridge any [`GlobalAlloc`] into a `chc_alloc` vtable. The reference
+    /// travels through the vtable's `ud` slot, so the allocator must outlive
+    /// every object parsed through it, hence `'static`. Alignment is fixed at
+    /// `align_of::<u128>()`, the max_align_t that `stdlib()`'s malloc gives.
+    pub fn global<A: GlobalAlloc>(a: &'static A) -> Self {
+        Self {
+            raw: sys::chc_alloc {
+                ud: a as *const A as *mut c_void,
+                alloc: Some(vtable::alloc::<A>),
+                realloc: Some(vtable::realloc::<A>),
+                free: Some(vtable::free::<A>),
+            },
+        }
     }
 
     #[inline]
@@ -31,3 +44,40 @@ impl Default for Allocator {
 
 unsafe impl Send for Allocator {}
 unsafe impl Sync for Allocator {}
+
+mod vtable {
+    use core::alloc::{GlobalAlloc, Layout};
+    use core::ffi::c_void;
+
+    // clickhouse-c allocates up to 16-byte scalars (Int128/UUID/Decimal128);
+    // matches the max_align_t that stdlib()'s malloc guarantees.
+    const ALIGN: usize = core::mem::align_of::<u128>();
+
+    // ALIGN is a fixed power of two; sizes here never approach isize::MAX.
+    #[inline]
+    fn layout(bytes: usize) -> Layout {
+        unsafe { Layout::from_size_align_unchecked(bytes, ALIGN) }
+    }
+
+    pub extern "C" fn alloc<A: GlobalAlloc>(ud: *mut c_void, bytes: usize) -> *mut c_void {
+        let a = unsafe { &*ud.cast::<A>() };
+        unsafe { a.alloc(layout(bytes)).cast() }
+    }
+
+    // GlobalAlloc::realloc reads only the alignment from the old layout; the
+    // allocator tracks the block size internally.
+    pub extern "C" fn realloc<A: GlobalAlloc>(
+        ud: *mut c_void,
+        p: *mut c_void,
+        _old_bytes: usize,
+        new_bytes: usize,
+    ) -> *mut c_void {
+        let a = unsafe { &*ud.cast::<A>() };
+        unsafe { a.realloc(p.cast(), layout(0), new_bytes).cast() }
+    }
+
+    pub extern "C" fn free<A: GlobalAlloc>(ud: *mut c_void, p: *mut c_void, _bytes: usize) {
+        let a = unsafe { &*ud.cast::<A>() };
+        unsafe { a.dealloc(p.cast(), layout(0)) }
+    }
+}

--- a/src/pipeline/inserter.rs
+++ b/src/pipeline/inserter.rs
@@ -177,7 +177,7 @@ pub async fn spawn_pool(
         let client = connect_client(config).await?;
         let inserter = Inserter {
             client,
-            alloc: Allocator::stdlib(),
+            alloc: Allocator::global(&mimalloc::MiMalloc),
             config: config.clone(),
             asts: HashMap::new(),
             ack: ack.clone(),

--- a/src/pipeline/tail.rs
+++ b/src/pipeline/tail.rs
@@ -126,7 +126,7 @@ pub async fn spawn(
             byte_budget: emitter.byte_budget,
             flush_timeout,
         },
-        Allocator::stdlib(),
+        Allocator::global(&mimalloc::MiMalloc),
         fatal,
         stats.clone(),
     );

--- a/src/toast.rs
+++ b/src/toast.rs
@@ -275,7 +275,7 @@ impl ClickHouseChunkStore {
         Self {
             conn,
             database,
-            alloc: Allocator::stdlib(),
+            alloc: Allocator::global(&mimalloc::MiMalloc),
             state: Mutex::new(ChState {
                 client: None,
                 created: HashSet::new(),


### PR DESCRIPTION
consolidates on mimalloc with rest of Rust code