### PR TITLE
Stream commit drain

### DIFF
--- a/src/bin/stream.rs
+++ b/src/bin/stream.rs
@@ -1246,7 +1246,7 @@ async fn run(args: Args) -> Result<()> {
         }
         let now_dispatched = stream.dispatched_lsn();
         let advanced = now_dispatched != prev_dispatched;
-        let (xact_stats, xact_line) = {
+        let (xact_stats, drain_resident_bytes, xact_line) = {
             let b = xact_buffer.lock().await;
             let mut stats = b.stats().clone();
             // Pipeline mode: track the ack collector's watermark (real CH
@@ -1255,7 +1255,7 @@ async fn run(args: Args) -> Result<()> {
                 stats.emitter_ack_lsn = a.load(Ordering::Acquire);
             }
             let line = stats.summary();
-            (stats, line)
+            (stats, b.drain_resident_bytes(), line)
         };
         let oracle_line = oracle
             .as_ref()
@@ -1284,6 +1284,7 @@ async fn run(args: Args) -> Result<()> {
             record_sink.decoder_xact.in_flight(),
             record_sink.decoder_xact.processed(),
             &xact_stats,
+            drain_resident_bytes,
             decoder_stats,
             emitter_stats,
             oracle_stats,
@@ -1860,6 +1861,7 @@ async fn populate_metrics(
     pump_queue_depth: u64,
     queue_records_out_total: u64,
     xact_stats: &walshadow::xact_buffer::XactBufferStats,
+    drain_resident_bytes: u64,
     decoder_stats: &walshadow::decoder_sink::DecoderStats,
     emitter_stats: Option<&walshadow::ch_emitter::EmitterStats>,
     oracle_stats: Option<&walshadow::oracle::OracleStats>,
@@ -1893,6 +1895,7 @@ async fn populate_metrics(
         xact_bytes_in_memory: xact_stats.bytes_in_memory,
         spill_xacts_active: xact_stats.spill_xacts_active,
         spill_bytes_active: xact_stats.spill_bytes_active,
+        drain_resident_bytes,
         spill_evictions_total: xact_stats.spill_evictions_total,
         xacts_committed_total: xact_stats.committed_xacts_total,
         xacts_aborted_total: xact_stats.aborted_xacts_total,

--- a/src/ch_emitter.rs
+++ b/src/ch_emitter.rs
@@ -53,6 +53,13 @@ pub const OP_DELETE: i8 = 3;
 pub const DEFAULT_ROW_BUDGET: usize = 65_536;
 pub const DEFAULT_BYTE_BUDGET: usize = 1 << 20; // 1 MiB
 
+/// Default commit-drain slice budgets
+/// ([`crate::xact_buffer::CommittedDrain::next_batch`]). Bytes sized at
+/// half the default `xact_buffer_max`: a slice plus the one loading behind
+/// it stay within the ingest budget.
+pub const DEFAULT_DRAIN_BATCH_ROWS: usize = 65_536;
+pub const DEFAULT_DRAIN_BATCH_BYTES: usize = 32 << 20; // 32 MiB
+
 /// Default flush timeout (ms). `0` keeps serial emitter's
 /// close-INSERT-on-every-xact-end behaviour (bootstrap backfill only);
 /// live pipeline substitutes a 100ms partial-batch deadline for `0` so
@@ -157,6 +164,12 @@ pub struct EmitterConfig {
     /// batcher (`crate::pipeline::decode::DECODE_CHUNK_ROWS`). Tunable so
     /// tests can trip the mid-loop flush without a huge xact.
     pub decode_chunk_rows: usize,
+    /// Row / byte budget per commit-drain slice
+    /// ([`crate::xact_buffer::CommittedDrain::next_batch`]). Bounds decoded
+    /// heap rows resident while a spilled xact streams back; TOAST chunk
+    /// generations stay per-xact.
+    pub drain_batch_rows: usize,
+    pub drain_batch_bytes: usize,
     /// `[runtime_config] schema`: source-PG schema housing the `config_*`
     /// overlay tables. `None` (field empty or omitted) disables the whole
     /// overlay subsystem — no boot seed, no config_decoder, pure TOML+CLI.
@@ -210,6 +223,8 @@ impl Default for EmitterConfig {
             soft_delete: false,
             toast: crate::toast::ToastConfig::default(),
             decode_chunk_rows: crate::pipeline::decode::DECODE_CHUNK_ROWS,
+            drain_batch_rows: DEFAULT_DRAIN_BATCH_ROWS,
+            drain_batch_bytes: DEFAULT_DRAIN_BATCH_BYTES,
             runtime_config_schema: None,
         }
     }
@@ -405,6 +420,12 @@ impl EmitterConfig {
             }
             if let Some(v) = ch.get("byte_budget").and_then(Value::as_integer) {
                 out.byte_budget = usize::try_from(v).unwrap_or(DEFAULT_BYTE_BUDGET);
+            }
+            if let Some(v) = ch.get("drain_batch_rows").and_then(Value::as_integer) {
+                out.drain_batch_rows = usize::try_from(v).unwrap_or(DEFAULT_DRAIN_BATCH_ROWS);
+            }
+            if let Some(v) = ch.get("drain_batch_bytes").and_then(Value::as_integer) {
+                out.drain_batch_bytes = usize::try_from(v).unwrap_or(DEFAULT_DRAIN_BATCH_BYTES);
             }
             if let Some(v) = ch.get("flush_timeout_ms").and_then(Value::as_integer)
                 && let Ok(ms) = u64::try_from(v)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -49,6 +49,9 @@ pub struct MetricsSnapshot {
     pub xact_bytes_in_memory: u64,
     pub spill_xacts_active: u64,
     pub spill_bytes_active: u64,
+    /// Bytes resident inside an active commit drain (merge heads + in-mem
+    /// tail + unsealed chunk map), the drain-streaming bound
+    pub drain_resident_bytes: u64,
     pub spill_evictions_total: u64,
     pub xacts_committed_total: u64,
     pub xacts_aborted_total: u64,
@@ -262,6 +265,12 @@ pub fn render(snap: &MetricsSnapshot) -> String {
             "Bytes currently held across all active xact spill files.",
             "gauge",
             snap.spill_bytes_active,
+        ),
+        (
+            "walshadow_drain_resident_bytes",
+            "Bytes resident inside an active commit drain (merge heads + unsealed chunks).",
+            "gauge",
+            snap.drain_resident_bytes,
         ),
         (
             "walshadow_spill_evictions_total",

--- a/src/pipeline/ack.rs
+++ b/src/pipeline/ack.rs
@@ -13,6 +13,16 @@
 //! monotonic in seq, so the contiguous-done commit_lsn never claims
 //! durability for a later seq whose rows are still in flight.
 //!
+//! ## Commit groups
+//!
+//! One commit may span several seqs (drain-stream batches, DDL-barrier
+//! segments), all carrying the same `commit_lsn`. Only the commit's *final*
+//! seq publishes: a non-final slice registered via
+//! [`AckHandle::register_partial`] gates contiguity but never advances
+//! `emitter_ack` — else the first durable slice would claim the whole
+//! commit while later slices are still in flight, and a restart would
+//! resume past never-inserted rows.
+//!
 //! Invariant: inserter sends [`AckEvent::Acked`] only *after* drain-to-
 //! `EndOfStream`. A row placed but never acked pins the watermark forever;
 //! the daemon's stall watchdog escalates that.
@@ -25,10 +35,13 @@ use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 
 pub enum AckEvent {
-    /// In seq order, no gaps.
+    /// In seq order, no gaps. `publish: false` marks a non-final slice of a
+    /// multi-seq commit: done-ness gates contiguity, `commit_lsn` never
+    /// publishes.
     Register {
         seq: u64,
         commit_lsn: u64,
+        publish: bool,
     },
     Placed {
         seq: u64,
@@ -46,6 +59,7 @@ pub enum AckEvent {
 
 struct SeqState {
     commit_lsn: u64,
+    publish: bool,
     placed: Option<u64>,
     acked: u64,
 }
@@ -91,7 +105,11 @@ impl AckState {
 
     pub fn apply(&mut self, ev: AckEvent) {
         match ev {
-            AckEvent::Register { seq, commit_lsn } => self.register(seq, commit_lsn),
+            AckEvent::Register {
+                seq,
+                commit_lsn,
+                publish,
+            } => self.register(seq, commit_lsn, publish),
             AckEvent::Placed { seq, rows } => self.placed(seq, rows),
             AckEvent::Acked { counts } => {
                 for (seq, n) in counts {
@@ -102,11 +120,12 @@ impl AckState {
         }
     }
 
-    fn register(&mut self, seq: u64, commit_lsn: u64) {
+    fn register(&mut self, seq: u64, commit_lsn: u64, publish: bool) {
         self.map.insert(
             seq,
             SeqState {
                 commit_lsn,
+                publish,
                 placed: None,
                 acked: 0,
             },
@@ -137,14 +156,16 @@ impl AckState {
     }
 
     /// Drain the contiguous done prefix, advancing `emitter_ack` to the last
-    /// done seq's `commit_lsn` and publishing the new frontier.
+    /// done *publishing* seq's `commit_lsn` and publishing the new frontier.
     fn advance(&mut self) {
         let mut moved = false;
         while let Some(s) = self.map.get(&self.next_expected) {
             if !s.done() {
                 break;
             }
-            self.emitter_ack.fetch_max(s.commit_lsn, Ordering::Release);
+            if s.publish {
+                self.emitter_ack.fetch_max(s.commit_lsn, Ordering::Release);
+            }
             self.map.remove(&self.next_expected);
             self.next_expected += 1;
             moved = true;
@@ -197,8 +218,24 @@ pub struct AckHandle {
 }
 
 impl AckHandle {
+    /// Register a commit's final (or only) seq; its `commit_lsn` publishes
+    /// once the contiguous-done frontier passes it.
     pub fn register(&self, seq: u64, commit_lsn: u64) {
-        let _ = self.tx.send(AckEvent::Register { seq, commit_lsn });
+        let _ = self.tx.send(AckEvent::Register {
+            seq,
+            commit_lsn,
+            publish: true,
+        });
+    }
+
+    /// Register a non-final slice of a multi-seq commit: counts toward
+    /// contiguity but never advances `emitter_ack` (see module doc).
+    pub fn register_partial(&self, seq: u64, commit_lsn: u64) {
+        let _ = self.tx.send(AckEvent::Register {
+            seq,
+            commit_lsn,
+            publish: false,
+        });
     }
 
     pub fn placed(&self, seq: u64, rows: u64) {
@@ -282,7 +319,7 @@ mod tests {
     fn in_order_advances_to_each_commit() {
         let (mut s, ack) = state();
         for seq in 0..3u64 {
-            s.register(seq, (seq + 1) * 100);
+            s.register(seq, (seq + 1) * 100, true);
             s.placed(seq, 2);
             s.acked(seq, 2);
         }
@@ -293,9 +330,9 @@ mod tests {
     #[test]
     fn out_of_order_done_holds_watermark_until_gap_fills() {
         let (mut s, ack) = state();
-        s.register(0, 100);
-        s.register(1, 200);
-        s.register(2, 300);
+        s.register(0, 100, true);
+        s.register(1, 200, true);
+        s.register(2, 300, true);
         // seq 2 done first, watermark stays at 0
         s.placed(2, 1);
         s.acked(2, 1);
@@ -315,7 +352,7 @@ mod tests {
     #[test]
     fn empty_or_abort_seq_is_done_when_placed_zero() {
         let (mut s, ack) = state();
-        s.register(0, 100);
+        s.register(0, 100, true);
         s.placed(0, 0); // abort/empty
         assert_eq!(ack.load(Ordering::Acquire), 100);
         assert!(s.all_done());
@@ -324,7 +361,7 @@ mod tests {
     #[test]
     fn rows_split_across_batches_complete_at_total() {
         let (mut s, ack) = state();
-        s.register(0, 100);
+        s.register(0, 100, true);
         s.placed(0, 5);
         s.acked(0, 2);
         assert_eq!(ack.load(Ordering::Acquire), 0); // 2/5 acked
@@ -335,7 +372,7 @@ mod tests {
     #[test]
     fn acked_before_placed_still_completes() {
         let (mut s, ack) = state();
-        s.register(0, 100);
+        s.register(0, 100, true);
         s.acked(0, 3);
         assert_eq!(ack.load(Ordering::Acquire), 0); // placed still unknown
         s.placed(0, 3);
@@ -348,9 +385,9 @@ mod tests {
         let (ftx, _frx) = watch::channel(0u64);
         let (ptx, prx) = watch::channel(0u64);
         let mut s = AckState::new(ack, ftx, ptx);
-        s.register(0, 100);
-        s.register(1, 200);
-        s.register(2, 300);
+        s.register(0, 100, true);
+        s.register(1, 200, true);
+        s.register(2, 300, true);
         // Place 0 and 2 out of order; frontier stops at gap (1)
         s.placed(2, 1);
         assert_eq!(*prx.borrow(), 0);
@@ -370,7 +407,7 @@ mod tests {
         let (mut s, ack) = state();
         let n = 50_000u64;
         for seq in 0..n {
-            s.register(seq, (seq + 1) * 10);
+            s.register(seq, (seq + 1) * 10, true);
             s.placed(seq, 1); // nothing acked yet
         }
         assert_eq!(ack.load(Ordering::Acquire), 0);
@@ -382,10 +419,67 @@ mod tests {
         assert_eq!(ack.load(Ordering::Acquire), n * 10);
     }
 
+    /// First durable slice of a multi-slice commit must not publish the
+    /// commit LSN: a restart at that point would resume past rows still in
+    /// the later slices.
+    #[test]
+    fn partial_slices_never_publish_commit_lsn() {
+        let (mut s, ack) = state();
+        s.register(0, 500, false);
+        s.register(1, 500, false);
+        s.register(2, 500, true); // final slice
+        s.placed(0, 1);
+        s.acked(0, 1);
+        assert_eq!(ack.load(Ordering::Acquire), 0, "first slice durable");
+        s.placed(1, 1);
+        s.acked(1, 1);
+        assert_eq!(ack.load(Ordering::Acquire), 0, "second slice durable");
+        s.placed(2, 1);
+        s.acked(2, 1);
+        assert_eq!(ack.load(Ordering::Acquire), 500, "final slice publishes");
+        assert!(s.all_done());
+    }
+
+    /// Final slice done out of order still waits for earlier partial slices
+    /// (contiguity), then one advance publishes exactly once.
+    #[test]
+    fn final_slice_blocked_by_earlier_partial_gap() {
+        let (mut s, ack) = state();
+        s.register(0, 500, false);
+        s.register(1, 500, true);
+        s.placed(1, 1);
+        s.acked(1, 1);
+        assert_eq!(ack.load(Ordering::Acquire), 0, "gap at partial seq 0");
+        s.placed(0, 1);
+        s.acked(0, 1);
+        assert_eq!(ack.load(Ordering::Acquire), 500);
+    }
+
+    /// Barrier shape: data segments as partial seqs, trailing rows=0 final
+    /// marker carries the publication.
+    #[test]
+    fn rows_zero_final_marker_publishes_after_partial_segments() {
+        let (mut s, ack) = state();
+        s.register(0, 500, false);
+        s.register(1, 500, false);
+        s.register(2, 500, true);
+        s.placed(2, 0); // marker done immediately once placed
+        s.placed(0, 2);
+        s.acked(0, 2);
+        s.placed(1, 3);
+        assert_eq!(ack.load(Ordering::Acquire), 0, "segment 1 not acked");
+        s.acked(1, 3);
+        assert_eq!(ack.load(Ordering::Acquire), 500);
+        // Next commit publishes independently
+        s.register(3, 600, true);
+        s.placed(3, 0);
+        assert_eq!(ack.load(Ordering::Acquire), 600);
+    }
+
     #[test]
     fn trailing_advances_only_when_all_done() {
         let (mut s, ack) = state();
-        s.register(0, 100);
+        s.register(0, 100, true);
         s.placed(0, 1);
         // Not acked, trailing must not advance past the buffered row
         s.trailing(9_999);

--- a/src/pipeline/decode.rs
+++ b/src/pipeline/decode.rs
@@ -82,14 +82,17 @@ impl<V> RelCache<V> {
 /// Reassembled-TOAST chunk map: `(toast_relid, value_id) -> seq -> bytes`.
 pub type ToastChunks = HashMap<(u32, u32), BTreeMap<u32, Vec<u8>>>;
 
-/// `chunks` is `Arc` so the barrier coordinator can dispatch several data
-/// segments of one xact sharing the same TOAST chunk map without cloning.
+/// `chunks` holds the xact's chunk-map generations (oldest first), each
+/// immutable once sealed by the drain: batches / barrier segments of one
+/// xact share payloads via `Arc` while later slices are still loading. A
+/// heap's referenced value lives in exactly one generation (chunk WAL
+/// precedes referrer).
 pub struct DecodeJob {
     pub seq: u64,
     pub commit_ts: i64,
     pub commit_lsn: u64,
     pub heaps: Vec<DecodedHeap>,
-    pub chunks: Arc<ToastChunks>,
+    pub chunks: Vec<Arc<ToastChunks>>,
 }
 
 /// Shared dependencies a decode worker (or the barrier's inline data path)
@@ -147,15 +150,16 @@ pub async fn decode_and_route(
     commit_ts: i64,
     commit_lsn: u64,
     heaps: Vec<DecodedHeap>,
-    chunks: Arc<ToastChunks>,
+    chunks: Vec<Arc<ToastChunks>>,
     cache: &mut RelCache<(Arc<RelDescriptor>, Arc<TableMapping>)>,
 ) -> Result<u64, String> {
     cache.refresh();
+    let chunk_maps: Vec<&ToastChunks> = chunks.iter().map(Arc::as_ref).collect();
     let mut routed = 0u64;
     let mut buf: Vec<RoutedRow> = Vec::new();
     let mut buf_bytes = 0usize;
     for mut heap in heaps {
-        detoast_heap(&mut heap, &chunks, &ctx.catalog, true, &ctx.resolver)
+        detoast_heap(&mut heap, &chunk_maps, &ctx.catalog, true, &ctx.resolver)
             .await
             .map_err(|e| e.to_string())?;
         // Cache hit: no shared catalog lock, no mapping read. Skip/error arms

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -241,6 +241,8 @@ impl PipelineConfig {
             backfiller,
             fatal.clone(),
             span_registry,
+            emitter.drain_batch_rows,
+            emitter.drain_batch_bytes,
         );
 
         Ok((

--- a/src/pipeline/reorder.rs
+++ b/src/pipeline/reorder.rs
@@ -31,7 +31,7 @@ use crate::wal_stream::{Record, RecordSink, SinkError};
 use tracing::Instrument;
 
 use crate::xact_buffer::{
-    DrainEntry, DrainedXact, SchemaEventRx, SubxactTracker, TxnSpanRegistry, XLOG_XACT_ABORT,
+    DrainEntry, DrainedBatch, SchemaEventRx, SubxactTracker, TxnSpanRegistry, XLOG_XACT_ABORT,
     XLOG_XACT_ABORT_PREPARED, XLOG_XACT_ASSIGNMENT, XLOG_XACT_COMMIT, XLOG_XACT_COMMIT_PREPARED,
     XLOG_XACT_OPMASK, XactBuffer, drain_pending_schema_events, parse_xact_assignment,
     parse_xact_payload,
@@ -78,6 +78,11 @@ pub struct ReorderSink {
     backfiller: Option<Arc<CopyBackfiller>>,
     /// Dense commit-order counter; one seq per dispatched data unit.
     next_seq: u64,
+    /// Drain-slice budget: rows / bytes per [`DrainedBatch`] pulled from the
+    /// buffer. Bounds resident decoded rows while a spilled xact streams
+    /// back; the decode pool works one slice while the next loads.
+    batch_rows: usize,
+    batch_bytes: usize,
     /// Per-txn span map (shared with the pump + buffer). `Some` only when
     /// OTLP tracing is on; reorder parents `commit.drain`/`dispatch` under
     /// the `txn` and prunes the entry at commit (the buffer prunes at abort).
@@ -102,6 +107,8 @@ impl ReorderSink {
         backfiller: Option<Arc<CopyBackfiller>>,
         fatal: Fatal,
         span_registry: Option<TxnSpanRegistry>,
+        batch_rows: usize,
+        batch_bytes: usize,
     ) -> Self {
         Self {
             buffer,
@@ -119,6 +126,8 @@ impl ReorderSink {
             backfiller,
             fatal,
             next_seq: 0,
+            batch_rows,
+            batch_bytes,
             span_registry,
         }
     }
@@ -298,25 +307,27 @@ impl ReorderSink {
     }
 
     /// Dispatch accumulated barrier data rows as their own seq. No-op when
-    /// empty.
+    /// empty. Always a non-final slice: the commit's trailing rows=0 marker
+    /// carries the LSN publication, so a durable segment can't claim the
+    /// whole commit while later segments are in flight.
     async fn dispatch_segment(
         &mut self,
         pending: &mut Vec<DecodedHeap>,
         commit_ts: i64,
         commit_lsn: u64,
-        chunks: &Arc<ToastChunks>,
+        chunks: &[Arc<ToastChunks>],
     ) -> Result<(), SinkError> {
         if pending.is_empty() {
             return Ok(());
         }
         let seq = self.alloc_seq();
-        self.ack.register(seq, commit_lsn);
+        self.ack.register_partial(seq, commit_lsn);
         let job = DecodeJob {
             seq,
             commit_ts,
             commit_lsn,
             heaps: std::mem::take(pending),
-            chunks: chunks.clone(),
+            chunks: chunks.to_vec(),
         };
         self.dispatch_job(job).await
     }
@@ -354,19 +365,25 @@ impl ReorderSink {
         Ok(())
     }
 
-    /// Process a barrier xact in source_lsn order: data rows accumulate into
-    /// segments; each DDL event / TRUNCATE is preceded by dispatching the
-    /// pending segment + a fence (so earlier data is durable first).
-    async fn run_barrier(&mut self, drained: DrainedXact) -> Result<(), SinkError> {
-        let DrainedXact {
-            commit_ts,
-            commit_lsn,
+    /// Process one barrier slice in source_lsn order: data rows accumulate
+    /// into segments; each DDL event / TRUNCATE is preceded by dispatching
+    /// the pending segment + a fence (so earlier data is durable first).
+    /// The fence waits durability through `next_seq`, which covers every
+    /// seq of earlier slices too — no event is crossed by data from any
+    /// prior slice of the commit. Data-data ordering across slices needs no
+    /// fence (per-PK `_lsn` convergence).
+    async fn run_barrier_batch(
+        &mut self,
+        batch: DrainedBatch,
+        commit_ts: i64,
+        commit_lsn: u64,
+    ) -> Result<(), SinkError> {
+        let DrainedBatch {
             heaps,
-            chunks,
             ordered_events,
+            chunks,
             ..
-        } = drained;
-        let chunks = Arc::new(chunks);
+        } = batch;
         let mut pending: Vec<DecodedHeap> = Vec::new();
         let mut ev_cursor = 0usize;
         for (heap_idx, heap) in heaps.into_iter().enumerate() {
@@ -389,7 +406,7 @@ impl ReorderSink {
                 pending.push(heap);
             }
         }
-        // Trailing events: no heap follows them in the merge
+        // Trailing events: no heap follows them in this slice
         while ev_cursor < ordered_events.len() {
             self.dispatch_segment(&mut pending, commit_ts, commit_lsn, &chunks)
                 .await?;
@@ -400,7 +417,7 @@ impl ReorderSink {
             }
             ev_cursor += 1;
         }
-        // Trailing data flows async like a normal commit, already encoding
+        // Trailing data flows async like a normal slice, already encoding
         // against the post-DDL shape.
         self.dispatch_segment(&mut pending, commit_ts, commit_lsn, &chunks)
             .await
@@ -437,10 +454,9 @@ impl ReorderSink {
             xid = xid,
             commit_lsn = record.source_lsn,
         );
-        let drained = {
+        let mut drain = {
             let mut buf = self.buffer.lock().await;
             buf.drain_committed(xid, payload.xact_time, record.source_lsn, &payload.subxacts)
-                .instrument(drain_span)
                 .instrument(reorder_span)
                 .await
                 .map_err(SinkError::from)?
@@ -448,8 +464,6 @@ impl ReorderSink {
         self.subxact_tracker.lock().await.forget_tree(xid);
         // One per drained commit, incl. empty / unmapped-only
         self.stats.xacts_committed.fetch_add(1, Ordering::Relaxed);
-        txn.record("rows", drained.heaps.len() as u64);
-        txn.record("outcome", "committed");
         // Prune the committed tree's span handles (else the map grows
         // unbounded); the local `txn` clone keeps the span alive for dispatch.
         if let Some(r) = &self.span_registry {
@@ -459,55 +473,88 @@ impl ReorderSink {
             r.prune(&xids);
         }
 
-        // Persist this xact's chunks (disk / CH) before they're consumed by
-        // the decode pool, so a later re-emit of a pre-window referrer finds
-        // them. No-op when disabled or chunk-free. `commit_lsn` is the
-        // convergence `_lsn`; per-chunk LSN was dropped at merge.
-        if !drained.chunks.is_empty() {
-            self.resolver
-                .put_map(&drained.chunks, drained.commit_lsn)
+        // Pull bounded slices from the lazy merge: the decode pool works one
+        // while the next loads, so a spilled xact never rematerializes whole.
+        let commit_ts = drain.commit_ts;
+        let commit_lsn = drain.commit_lsn;
+        let mut rows_total: u64 = 0;
+        // Set once a slice's seq registered as publishing (final data slice);
+        // otherwise the trailing rows=0 marker publishes.
+        let mut published = false;
+        loop {
+            let Some(batch) = drain
+                .next_batch(self.batch_rows, self.batch_bytes)
+                .instrument(drain_span.clone())
                 .await
-                .map_err(|e| SinkError::Other(format!("toast store put: {e}")))?;
-        }
-
-        let is_barrier = !drained.ordered_events.is_empty()
-            || drained
-                .heaps
-                .iter()
-                .any(|h| matches!(h.op, HeapOp::Truncate));
-        if is_barrier {
-            self.run_barrier(drained)
-                .instrument(trace_span!(
-                    !txn.is_none(),
-                    parent: &txn,
-                    "commit.barrier",
-                ))
-                .await
-        } else if drained.heaps.is_empty() {
-            // Empty commit: rows=0 seq keeps the contiguous watermark unbroken
-            let seq = self.alloc_seq();
-            self.ack.register(seq, drained.commit_lsn);
-            self.ack.placed(seq, 0);
-            Ok(())
-        } else {
-            let seq = self.alloc_seq();
-            self.ack.register(seq, drained.commit_lsn);
-            let job = DecodeJob {
-                seq,
-                commit_ts: drained.commit_ts,
-                commit_lsn: drained.commit_lsn,
-                heaps: drained.heaps,
-                chunks: Arc::new(drained.chunks),
+                .map_err(SinkError::from)?
+            else {
+                break;
             };
-            self.dispatch_job(job)
-                .instrument(trace_span!(
-                    !txn.is_none(),
-                    parent: &txn,
-                    "dispatch",
-                    seq = seq,
-                ))
-                .await
+            rows_total += batch.heaps.len() as u64;
+            // Persist this slice's sealed chunks (disk / CH) before any
+            // consumer, so a later re-emit of a pre-window referrer finds
+            // them. Earlier slices reference only earlier generations,
+            // already put. `commit_lsn` is the convergence `_lsn`; per-chunk
+            // LSN was dropped at merge.
+            if let Some(new) = &batch.new_chunks {
+                self.resolver
+                    .put_map(new, commit_lsn)
+                    .await
+                    .map_err(|e| SinkError::Other(format!("toast store put: {e}")))?;
+            }
+            let is_barrier = !batch.ordered_events.is_empty()
+                || batch.heaps.iter().any(|h| matches!(h.op, HeapOp::Truncate));
+            let is_final = batch.is_final;
+            if is_barrier {
+                self.run_barrier_batch(batch, commit_ts, commit_lsn)
+                    .instrument(trace_span!(
+                        !txn.is_none(),
+                        parent: &txn,
+                        "commit.barrier",
+                    ))
+                    .await?;
+            } else if !batch.heaps.is_empty() {
+                let seq = self.alloc_seq();
+                if is_final {
+                    self.ack.register(seq, commit_lsn);
+                    published = true;
+                } else {
+                    self.ack.register_partial(seq, commit_lsn);
+                }
+                let job = DecodeJob {
+                    seq,
+                    commit_ts,
+                    commit_lsn,
+                    heaps: batch.heaps,
+                    chunks: batch.chunks,
+                };
+                self.dispatch_job(job)
+                    .instrument(trace_span!(
+                        !txn.is_none(),
+                        parent: &txn,
+                        "dispatch",
+                        seq = seq,
+                    ))
+                    .await?;
+            }
+            if is_final {
+                break;
+            }
         }
+        // Unlink spill files now that every slice dispatched; an error above
+        // drops the drain instead, leaving files for inspection.
+        drain.finish().await.map_err(SinkError::from)?;
+        txn.record("rows", rows_total);
+        txn.record("outcome", "committed");
+        if !published {
+            // rows=0 marker: publishes commit_lsn once every earlier slice
+            // is durable. Covers empty / read-only commits and barrier
+            // slices (whose segments all register partial).
+            let seq = self.alloc_seq();
+            self.ack.register(seq, commit_lsn);
+            self.ack.placed(seq, 0);
+        }
+        Ok(())
     }
 
     /// ABORT: drop the buffer, emit a rows=0 seq through the gate (never a

--- a/src/xact_buffer.rs
+++ b/src/xact_buffer.rs
@@ -35,11 +35,11 @@
 //!
 //! Spill-to-ClickHouse (Option B) is deferred; v1 is local-disk-only.
 
-use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use thiserror::Error;
@@ -56,7 +56,7 @@ use crate::heap_decoder::{
 use crate::pipeline::decode::RelCache;
 use crate::runtime_config::{ConfigEvent, ConfigTableKind};
 use crate::shadow_catalog::{CatalogError, RelDescriptor, SchemaEvent, ShadowCatalog};
-use crate::spill::{SpillEntry, SpillError, SpillStore, SpillWriter, ToastChunk};
+use crate::spill::{SpillEntry, SpillError, SpillReader, SpillStore, SpillWriter, ToastChunk};
 use crate::toast::{ChunkMap, ToastResolver};
 use crate::wal_stream::{Record, RecordSink, SinkError};
 
@@ -386,6 +386,9 @@ pub struct XactBufferStats {
     pub bytes_in_memory: u64,
     pub xacts_total: u64,
     pub spill_xacts_active: u64,
+    /// Spilled bytes awaiting commit drain. Drops when a drain takes
+    /// ownership, though the file unlinks only post-dispatch; resident
+    /// drain bytes are the separate [`XactBuffer::drain_resident_bytes`]
     pub spill_bytes_active: u64,
     pub spill_evictions_total: u64,
     pub committed_xacts_total: u64,
@@ -714,6 +717,13 @@ pub struct XactBuffer {
     /// WAL-read rather than at buffering. Empty (and unused) when tracing
     /// is off — `absorb` then mints its own span.
     span_registry: TxnSpanRegistry,
+    /// Bytes resident inside an active commit drain (decoded merge heads +
+    /// in-mem tail + unsealed chunk map). Arc'd so a detached
+    /// [`CommittedDrain`] keeps accounting after the buffer lock releases;
+    /// distinct from `spill_bytes_active` (on-disk bytes awaiting drain).
+    drain_resident: Arc<AtomicU64>,
+    /// High-water mark of `drain_resident`, monotonic per process.
+    drain_resident_peak: Arc<AtomicU64>,
 }
 
 impl XactBuffer {
@@ -726,7 +736,21 @@ impl XactBuffer {
             bytes_in_memory: 0,
             stats: XactBufferStats::default(),
             span_registry: TxnSpanRegistry::new(),
+            drain_resident: Arc::new(AtomicU64::new(0)),
+            drain_resident_peak: Arc::new(AtomicU64::new(0)),
         })
+    }
+
+    /// Current bytes resident in an active drain; `0` when no drain runs.
+    pub fn drain_resident_bytes(&self) -> u64 {
+        self.drain_resident.load(Ordering::Relaxed)
+    }
+
+    /// Monotonic high-water mark of [`Self::drain_resident_bytes`]. For a
+    /// spilled xact this stays near merge-heads + chunk bytes, far below the
+    /// xact's decoded size — the drain-streaming bound.
+    pub fn drain_resident_peak(&self) -> u64 {
+        self.drain_resident_peak.load(Ordering::Relaxed)
     }
 
     /// Clone of the [`TxnSpanRegistry`] the pump pushes `txn` spans into.
@@ -938,6 +962,47 @@ impl XactBuffer {
         Ok(())
     }
 
+    /// Convert removed states into a lazy k-way merge, releasing their
+    /// spill accounting (`spill_bytes_active` counts bytes awaiting drain;
+    /// the drain owns them from here). Files stay on disk until
+    /// [`MergedDrain::finish`] unlinks post-dispatch.
+    async fn open_drain(
+        &mut self,
+        states: Vec<XactState>,
+    ) -> std::result::Result<MergedDrain, XactBufferError> {
+        let mut gauge = ResidentGauge {
+            cur: self.drain_resident.clone(),
+            peak: self.drain_resident_peak.clone(),
+            held: 0,
+        };
+        let mut sources = Vec::with_capacity(states.len());
+        let mut events = Vec::with_capacity(states.len());
+        for mut st in states {
+            let reader = match st.spill.take() {
+                Some(writer) => {
+                    let bc = writer.byte_count();
+                    self.stats.spill_bytes_active =
+                        self.stats.spill_bytes_active.saturating_sub(bc);
+                    self.stats.spill_xacts_active = self.stats.spill_xacts_active.saturating_sub(1);
+                    Some(writer.finish().await?)
+                }
+                None => None,
+            };
+            let in_mem = std::mem::take(&mut st.in_mem);
+            sources.push(MergeSource::open(reader, in_mem, &mut gauge).await?);
+            // Arrival order == WAL order: decoder sink pushes on observe,
+            // so the Vec is already source_lsn ASC
+            events.push(std::mem::take(&mut st.events).into());
+        }
+        Ok(MergedDrain {
+            sources,
+            events,
+            chunks: ChunkMap::new(),
+            chunk_bytes: 0,
+            gauge,
+        })
+    }
+
     /// Drain xact `xid` to `observer` in WAL order, substituting each
     /// `ExternalToast` with its reassembled `Bytea` / `Text` via
     /// [`ShadowCatalog::relation_at`]. No-op for unknown `xid`
@@ -1037,107 +1102,16 @@ impl XactBuffer {
             spilled = states.iter().any(|s| s.spill.is_some()),
         );
 
-        // Drain spill files first (older in WAL order) per xid, then
-        // tack on in-mem entries. Result: one `VecDeque<SpillEntry>` per
-        // xid already sorted by `source_lsn` ASC. Catalog events ride a
-        // sibling `VecDeque<(u64, SchemaEvent)>` per xid for the k-way
-        // merge below — they don't spill.
-        let mut per_xid: Vec<VecDeque<SpillEntry>> = Vec::with_capacity(states.len());
-        let mut per_xid_events: Vec<VecDeque<(u64, DrainEntry)>> = Vec::with_capacity(states.len());
-        for mut st in states.drain(..) {
-            let in_mem = std::mem::take(&mut st.in_mem);
-            let mut entries: VecDeque<SpillEntry> = VecDeque::with_capacity(in_mem.len());
-            if let Some(writer) = st.spill.take() {
-                let bc = writer.byte_count();
-                self.stats.spill_bytes_active = self.stats.spill_bytes_active.saturating_sub(bc);
-                self.stats.spill_xacts_active = self.stats.spill_xacts_active.saturating_sub(1);
-                let mut reader = writer.finish().await?;
-                while let Some(entry) = reader.next().await? {
-                    entries.push_back(entry);
-                }
-                reader.unlink().await?;
-            }
-            entries.extend(in_mem);
-            per_xid.push(entries);
-            // Arrival order == WAL order: decoder sink pushes on observe,
-            // so the Vec is already source_lsn ASC
-            let evs: VecDeque<(u64, DrainEntry)> = std::mem::take(&mut st.events).into();
-            per_xid_events.push(evs);
-        }
-
-        // k-way merge of per_xid heads by `source_lsn` ASC. k = 1 +
-        // nsubxacts, typically <= 4, so linear head-pick beats a heap
-        let mut heaps: Vec<DecodedHeap> = Vec::new();
-        let mut chunks: HashMap<(u32, u32), BTreeMap<u32, Vec<u8>>> = HashMap::new();
-        let mut ordered_events: Vec<(usize, DrainEntry)> = Vec::new();
-        // `merge` brackets the (fully synchronous) k-way merge — confirms
-        // it's cheap rather than an O(n²) surprise on subxact-heavy xacts.
-        // Entered only across sync work; dropped before the dispatch awaits
-        // below (an entered guard held across `.await` would be unsound).
-        let merge_guard = trace_span!(
-            !drain_span.is_none(),
-            parent: &drain_span,
-            "merge",
-            xacts = per_xid.len(),
-            entries = per_xid.iter().map(VecDeque::len).sum::<usize>(),
-        )
-        .entered();
-        loop {
-            #[derive(Clone, Copy)]
-            enum Pick {
-                Spill(usize, u64),
-                Event(usize, u64),
-            }
-            let mut best: Option<Pick> = None;
-            let best_lsn = |p: Pick| match p {
-                Pick::Spill(_, l) | Pick::Event(_, l) => l,
-            };
-            // Control events (`DrainEntry`) win ties against heaps: PG writes
-            // a DDL's catalog mutation before the dependent heap, and the lazy
-            // refetch stamps the schema event with the triggering heap's
-            // source_lsn, so they share an LSN. Event-first lands the `ALTER`
-            // on CH before the dependent INSERT encodes against the post-DDL
-            // shape. The events loop runs before the heaps loop and uses `<=`
-            // (heaps use `<`), so any `DrainEntry` — Catalog now, Config/Signal
-            // per runtime-config §3/§6 — inherits the same tie-break
-            for (i, q) in per_xid_events.iter().enumerate() {
-                let Some(&(lsn, _)) = q.front() else {
-                    continue;
-                };
-                if best.is_none_or(|b| lsn <= best_lsn(b)) {
-                    best = Some(Pick::Event(i, lsn));
-                }
-            }
-            for (i, q) in per_xid.iter().enumerate() {
-                let Some(head) = q.front() else { continue };
-                let lsn = entry_lsn(head);
-                if best.is_none_or(|b| lsn < best_lsn(b)) {
-                    best = Some(Pick::Spill(i, lsn));
-                }
-            }
-            let Some(pick) = best else {
-                break;
-            };
-            match pick {
-                Pick::Spill(i, _) => {
-                    let entry = per_xid[i].pop_front().expect("just peeked head");
-                    accumulate(entry, &mut heaps, &mut chunks);
-                }
-                Pick::Event(i, _) => {
-                    let (_lsn, ev) = per_xid_events[i].pop_front().expect("just peeked head");
-                    // Event sorts before heaps[heaps.len()]
-                    ordered_events.push((heaps.len(), ev));
-                }
-            }
-        }
-        drop(merge_guard);
-        drain_span.record("rows", heaps.len());
-
-        let mut event_cursor = 0usize;
-        for (heap_idx, mut heap) in heaps.into_iter().enumerate() {
-            while event_cursor < ordered_events.len() && ordered_events[event_cursor].0 <= heap_idx
-            {
-                match &ordered_events[event_cursor].1 {
+        // Lazy k-way merge: one decoded head per source, in-mem tails
+        // chained behind spill readers (eviction discipline holds "spilled
+        // older than in-mem"). Dispatch happens per pick, so peak residency
+        // is merge heads + the chunk map — not the whole decoded xact that
+        // spilled precisely because it exceeded the buffer budget.
+        let mut drain = self.open_drain(states).await?;
+        let mut rows: u64 = 0;
+        while let Some(item) = drain.next().await? {
+            match item {
+                MergeItem::Event(ev) => match &ev {
                     DrainEntry::Catalog(ev) => observer
                         .on_schema_event(ev)
                         .instrument(drain_span.clone())
@@ -1148,40 +1122,32 @@ impl XactBuffer {
                         .instrument(drain_span.clone())
                         .await
                         .map_err(|e| XactBufferError::Observer(e.to_string()))?,
+                },
+                MergeItem::Heap(mut heap) => {
+                    detoast_heap(&mut heap, &[drain.chunks()], catalog, false, resolver).await?;
+                    let committed = CommittedTuple {
+                        decoded: *heap,
+                        commit_ts,
+                        commit_lsn,
+                    };
+                    // Under `drain_span` so the emitter's `emit.insert` (the
+                    // blocking ClickHouse round-trip, sealed on a budget trip
+                    // or at xact end) attaches as a child of this
+                    // transaction's drain.
+                    observer
+                        .on_tuple(&committed)
+                        .instrument(drain_span.clone())
+                        .await
+                        .map_err(|e| XactBufferError::Observer(e.to_string()))?;
+                    rows += 1;
                 }
-                event_cursor += 1;
             }
-            detoast_heap(&mut heap, &chunks, catalog, false, resolver).await?;
-            let committed = CommittedTuple {
-                decoded: heap,
-                commit_ts,
-                commit_lsn,
-            };
-            // Under `drain_span` so the emitter's `emit.insert` (the
-            // blocking ClickHouse round-trip, sealed on a budget trip or at
-            // xact end) attaches as a child of this transaction's drain.
-            observer
-                .on_tuple(&committed)
-                .instrument(drain_span.clone())
-                .await
-                .map_err(|e| XactBufferError::Observer(e.to_string()))?;
         }
-        // Trailing events with no heap after them
-        while event_cursor < ordered_events.len() {
-            match &ordered_events[event_cursor].1 {
-                DrainEntry::Catalog(ev) => observer
-                    .on_schema_event(ev)
-                    .instrument(drain_span.clone())
-                    .await
-                    .map_err(|e| XactBufferError::Observer(e.to_string()))?,
-                DrainEntry::Config(ev) => observer
-                    .on_config_event(ev)
-                    .instrument(drain_span.clone())
-                    .await
-                    .map_err(|e| XactBufferError::Observer(e.to_string()))?,
-            }
-            event_cursor += 1;
-        }
+        drain_span.record("rows", rows);
+        // Unlink spill files only now, after dispatch: an observer error
+        // above abandons the partially consumed reader on disk (startup
+        // wipe + redecode-from-ack cover replay).
+        drain.finish().await?;
         // drain_lsn ticks before the ack so an observer failure leaves
         // drain_lsn ahead of emitter_ack_lsn, the gap the cursor surfaces.
         // With CH flush_timeout > 0, on_xact_end returns last durable
@@ -1221,18 +1187,18 @@ impl XactBuffer {
         Ok(())
     }
 
-    /// Parallel-pipeline drain: k-way merge by `source_lsn`, return
-    /// still-toasted heaps + chunk map + interleaved events *without*
-    /// detoast or dispatch (those move to the decode pool / barrier
-    /// coordinator). Unlike [`Self::commit`], leaves `emitter_ack_lsn`
-    /// to the pipeline ack collector.
+    /// Parallel-pipeline drain: hand back a [`CommittedDrain`] that streams
+    /// bounded [`DrainedBatch`] slices from the same lazy k-way merge as
+    /// [`Self::commit`], *without* detoast or dispatch (those move to the
+    /// decode pool / barrier coordinator). Unlike `commit`, leaves
+    /// `emitter_ack_lsn` to the pipeline ack collector.
     pub async fn drain_committed(
         &mut self,
         top_xid: u32,
         commit_ts: i64,
         commit_lsn: u64,
         subxids: &[u32],
-    ) -> std::result::Result<DrainedXact, XactBufferError> {
+    ) -> std::result::Result<CommittedDrain, XactBufferError> {
         let mut xids: Vec<u32> = Vec::with_capacity(1 + subxids.len());
         xids.push(top_xid);
         xids.extend_from_slice(subxids);
@@ -1247,13 +1213,12 @@ impl XactBuffer {
             // Read-only / filter-dropped: reorder coordinator still
             // registers a seq so the contiguous watermark passes commit_lsn
             self.stats.commits_unknown_xid += 1;
-            return Ok(DrainedXact {
+            return Ok(CommittedDrain {
                 commit_ts,
                 commit_lsn,
-                heaps: Vec::new(),
-                chunks: HashMap::new(),
-                ordered_events: Vec::new(),
                 had_states: false,
+                merged: None,
+                generations: Vec::new(),
             });
         }
         for st in &states {
@@ -1261,83 +1226,14 @@ impl XactBuffer {
             self.bytes_in_memory = self.bytes_in_memory.saturating_sub(st.in_mem_bytes);
         }
         self.stats.bytes_in_memory = self.bytes_in_memory as u64;
-
-        // Spill (older) then in-mem per xid, source_lsn-ASC; see [`Self::commit`]
-        let mut per_xid: Vec<VecDeque<SpillEntry>> = Vec::with_capacity(states.len());
-        let mut per_xid_events: Vec<VecDeque<(u64, DrainEntry)>> = Vec::with_capacity(states.len());
-        for mut st in states.drain(..) {
-            let in_mem = std::mem::take(&mut st.in_mem);
-            let mut entries: VecDeque<SpillEntry> = VecDeque::with_capacity(in_mem.len());
-            if let Some(writer) = st.spill.take() {
-                let bc = writer.byte_count();
-                self.stats.spill_bytes_active = self.stats.spill_bytes_active.saturating_sub(bc);
-                self.stats.spill_xacts_active = self.stats.spill_xacts_active.saturating_sub(1);
-                let mut reader = writer.finish().await?;
-                while let Some(entry) = reader.next().await? {
-                    entries.push_back(entry);
-                }
-                reader.unlink().await?;
-            }
-            entries.extend(in_mem);
-            per_xid.push(entries);
-            let evs: VecDeque<(u64, DrainEntry)> = std::mem::take(&mut st.events).into();
-            per_xid_events.push(evs);
-        }
-
-        let mut heaps: Vec<DecodedHeap> = Vec::new();
-        let mut chunks: HashMap<(u32, u32), BTreeMap<u32, Vec<u8>>> = HashMap::new();
-        let mut ordered_events: Vec<(usize, DrainEntry)> = Vec::new();
-        loop {
-            #[derive(Clone, Copy)]
-            enum Pick {
-                Spill(usize, u64),
-                Event(usize, u64),
-            }
-            let mut best: Option<Pick> = None;
-            let best_lsn = |p: Pick| match p {
-                Pick::Spill(_, l) | Pick::Event(_, l) => l,
-            };
-            // Control events (`DrainEntry`) tie-break before heaps at equal
-            // LSN: PG writes a DDL's catalog mutation before the dependent
-            // heap, and they can share an LSN. Config/Signal (runtime-config
-            // §3/§6) extend the same queue and inherit this ordering.
-            for (i, q) in per_xid_events.iter().enumerate() {
-                let Some(&(lsn, _)) = q.front() else {
-                    continue;
-                };
-                if best.is_none_or(|b| lsn <= best_lsn(b)) {
-                    best = Some(Pick::Event(i, lsn));
-                }
-            }
-            for (i, q) in per_xid.iter().enumerate() {
-                let Some(head) = q.front() else { continue };
-                let lsn = entry_lsn(head);
-                if best.is_none_or(|b| lsn < best_lsn(b)) {
-                    best = Some(Pick::Spill(i, lsn));
-                }
-            }
-            let Some(pick) = best else {
-                break;
-            };
-            match pick {
-                Pick::Spill(i, _) => {
-                    let entry = per_xid[i].pop_front().expect("just peeked head");
-                    accumulate(entry, &mut heaps, &mut chunks);
-                }
-                Pick::Event(i, _) => {
-                    let (_lsn, ev) = per_xid_events[i].pop_front().expect("just peeked head");
-                    ordered_events.push((heaps.len(), ev));
-                }
-            }
-        }
+        let merged = self.open_drain(states).await?;
         self.stats.committed_xacts_total += 1;
-        Ok(DrainedXact {
+        Ok(CommittedDrain {
             commit_ts,
             commit_lsn,
-            heaps,
-            chunks,
-            ordered_events,
             had_states: true,
+            merged: Some(merged),
+            generations: Vec::new(),
         })
     }
 
@@ -1421,41 +1317,313 @@ impl XactBuffer {
     }
 }
 
-/// Committed xact for the parallel pipeline. Heaps still TOAST-toasted;
-/// decode pool handles detoast + routing. Non-empty `ordered_events` (or
-/// a `HeapOp::Truncate` heap) makes this a barrier the reorder
-/// coordinator serializes against ClickHouse.
-pub struct DrainedXact {
-    pub commit_ts: i64,
-    pub commit_lsn: u64,
-    pub heaps: Vec<DecodedHeap>,
-    pub chunks: HashMap<(u32, u32), BTreeMap<u32, Vec<u8>>>,
-    /// Each entry sorts before `heaps[heap_index]`; `DrainEntry::Catalog` is
-    /// the only variant today, Config/Signal extend it per runtime-config plan
-    pub ordered_events: Vec<(usize, DrainEntry)>,
-    /// False for read-only / filter-dropped / unknown xid
-    pub had_states: bool,
+/// Tracks bytes resident inside an active drain (decoded merge heads +
+/// in-mem tail + unsealed chunk map). Contribution subtracts on drop so an
+/// abandoned drain (observer error) can't wedge the gauge.
+struct ResidentGauge {
+    cur: Arc<AtomicU64>,
+    peak: Arc<AtomicU64>,
+    held: u64,
 }
 
-fn accumulate(
-    entry: SpillEntry,
-    heaps: &mut Vec<DecodedHeap>,
-    chunks: &mut HashMap<(u32, u32), BTreeMap<u32, Vec<u8>>>,
-) {
-    match entry {
-        SpillEntry::Heap(h) => heaps.push(*h),
-        SpillEntry::Chunk(c) => {
-            chunks
-                .entry((c.toast_relid, c.value_id))
-                .or_default()
-                .insert(c.chunk_seq, c.chunk_data);
+impl ResidentGauge {
+    fn add(&mut self, n: usize) {
+        self.held += n as u64;
+        let now = self.cur.fetch_add(n as u64, Ordering::Relaxed) + n as u64;
+        self.peak.fetch_max(now, Ordering::Relaxed);
+    }
+
+    fn sub(&mut self, n: usize) {
+        let n = (n as u64).min(self.held);
+        self.held -= n;
+        self.cur.fetch_sub(n, Ordering::Relaxed);
+    }
+}
+
+impl Drop for ResidentGauge {
+    fn drop(&mut self) {
+        self.cur.fetch_sub(self.held, Ordering::Relaxed);
+    }
+}
+
+/// Lazy merge source for one xid: spill-reader head (older in WAL order)
+/// chained with the in-mem tail, one decoded entry resident. `pop` refills
+/// from the reader until EOF, then drains `in_mem`. The EOF reader parks in
+/// `spent` so the file unlinks only at [`MergedDrain::finish`],
+/// post-dispatch.
+struct MergeSource {
+    head: Option<SpillEntry>,
+    reader: Option<SpillReader>,
+    spent: Option<SpillReader>,
+    in_mem: VecDeque<SpillEntry>,
+}
+
+impl MergeSource {
+    async fn open(
+        reader: Option<SpillReader>,
+        in_mem: Vec<SpillEntry>,
+        gauge: &mut ResidentGauge,
+    ) -> std::result::Result<Self, SpillError> {
+        // Tail entries are resident from the start (they left the buffer's
+        // `bytes_in_memory` at commit); spill entries join at decode.
+        for e in &in_mem {
+            gauge.add(approximate_size(e));
         }
+        let mut src = Self {
+            head: None,
+            reader,
+            spent: None,
+            in_mem: in_mem.into(),
+        };
+        src.refill(gauge).await?;
+        Ok(src)
+    }
+
+    async fn refill(&mut self, gauge: &mut ResidentGauge) -> std::result::Result<(), SpillError> {
+        debug_assert!(self.head.is_none());
+        if let Some(r) = self.reader.as_mut() {
+            if let Some(entry) = r.next().await? {
+                gauge.add(approximate_size(&entry));
+                self.head = Some(entry);
+                return Ok(());
+            }
+            self.spent = self.reader.take();
+        }
+        // Already counted at `open`; moving to head keeps it resident
+        self.head = self.in_mem.pop_front();
+        Ok(())
+    }
+
+    fn head_lsn(&self) -> Option<u64> {
+        self.head.as_ref().map(entry_lsn)
+    }
+
+    async fn pop(
+        &mut self,
+        gauge: &mut ResidentGauge,
+    ) -> std::result::Result<Option<SpillEntry>, SpillError> {
+        let Some(entry) = self.head.take() else {
+            return Ok(None);
+        };
+        gauge.sub(approximate_size(&entry));
+        self.refill(gauge).await?;
+        Ok(Some(entry))
+    }
+}
+
+enum MergeItem {
+    Heap(Box<DecodedHeap>),
+    Event(DrainEntry),
+}
+
+/// Lazy k-way merge over per-xid sources + event queues, `source_lsn` ASC.
+/// k = 1 + nsubxacts, typically <= 4, so linear head-pick beats a heap.
+///
+/// Control events (`DrainEntry`) win ties against ANY same-LSN data entry:
+/// PG writes a DDL's catalog mutation before the dependent heap, and the
+/// lazy refetch stamps the schema event with the triggering heap's
+/// source_lsn, so they share an LSN. Event-first lands the `ALTER` on CH
+/// before the dependent INSERT encodes against the post-DDL shape. The
+/// events loop runs before the data loop and uses `<=` (data uses `<`), so
+/// any `DrainEntry` — Catalog now, Config/Signal per runtime-config §3/§6 —
+/// inherits the tie-break.
+///
+/// Toast chunks fold into `chunks` and never surface as items: a chunk's
+/// WAL position precedes its referrer, so the map is complete for every
+/// heap yielded after it. Drop-after-first-use would be wrong — one value
+/// can be referenced by several row versions in one xact (unchanged-toast
+/// UPDATE chain) — so entries live until [`Self::take_chunks`] / drop.
+struct MergedDrain {
+    sources: Vec<MergeSource>,
+    events: Vec<VecDeque<(u64, DrainEntry)>>,
+    chunks: ChunkMap,
+    chunk_bytes: usize,
+    gauge: ResidentGauge,
+}
+
+impl MergedDrain {
+    async fn next(&mut self) -> std::result::Result<Option<MergeItem>, XactBufferError> {
+        loop {
+            enum Pick {
+                Data(usize),
+                Event(usize),
+            }
+            let mut best: Option<(Pick, u64)> = None;
+            for (i, q) in self.events.iter().enumerate() {
+                let Some(&(lsn, _)) = q.front() else {
+                    continue;
+                };
+                if best.as_ref().is_none_or(|&(_, b)| lsn <= b) {
+                    best = Some((Pick::Event(i), lsn));
+                }
+            }
+            for (i, s) in self.sources.iter().enumerate() {
+                let Some(lsn) = s.head_lsn() else { continue };
+                if best.as_ref().is_none_or(|&(_, b)| lsn < b) {
+                    best = Some((Pick::Data(i), lsn));
+                }
+            }
+            let Some((pick, _)) = best else {
+                return Ok(None);
+            };
+            match pick {
+                Pick::Event(i) => {
+                    let (_lsn, ev) = self.events[i].pop_front().expect("just peeked head");
+                    return Ok(Some(MergeItem::Event(ev)));
+                }
+                Pick::Data(i) => {
+                    let entry = self.sources[i]
+                        .pop(&mut self.gauge)
+                        .await?
+                        .expect("just peeked head");
+                    match entry {
+                        SpillEntry::Heap(h) => return Ok(Some(MergeItem::Heap(h))),
+                        SpillEntry::Chunk(c) => {
+                            self.chunk_bytes += c.chunk_data.len();
+                            self.gauge.add(c.chunk_data.len());
+                            self.chunks
+                                .entry((c.toast_relid, c.value_id))
+                                .or_default()
+                                .insert(c.chunk_seq, c.chunk_data);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn chunks(&self) -> &ChunkMap {
+        &self.chunks
+    }
+
+    /// Chunks accumulated since the last take, sealed into a generation.
+    fn take_chunks(&mut self) -> ChunkMap {
+        self.gauge.sub(self.chunk_bytes);
+        self.chunk_bytes = 0;
+        std::mem::take(&mut self.chunks)
+    }
+
+    /// Every head empty and every event queue drained.
+    fn is_exhausted(&self) -> bool {
+        self.sources.iter().all(|s| s.head.is_none()) && self.events.iter().all(VecDeque::is_empty)
+    }
+
+    /// Unlink spill files; call only after dispatch completes. An error
+    /// path drops `self` instead, leaving files for inspection (startup
+    /// wipe + redecode-from-ack cover replay).
+    async fn finish(self) -> std::result::Result<(), XactBufferError> {
+        for s in self.sources {
+            if let Some(r) = s.spent {
+                r.unlink().await?;
+            }
+            if let Some(r) = s.reader {
+                r.unlink().await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// One bounded slice of a committed xact for the parallel pipeline. Heaps
+/// still TOAST-toasted; the decode pool handles detoast + routing.
+/// Non-empty `ordered_events` (or a `HeapOp::Truncate` heap) makes the
+/// slice a barrier the reorder coordinator serializes against ClickHouse.
+pub struct DrainedBatch {
+    /// `source_lsn` ASC within the slice; later slices strictly follow.
+    pub heaps: Vec<DecodedHeap>,
+    /// Each entry sorts before `heaps[i]`, `i` slice-local.
+    /// `DrainEntry::Catalog` + `Config` today, Signal per runtime-config plan
+    pub ordered_events: Vec<(usize, DrainEntry)>,
+    /// Chunk generations sealed so far, oldest first. A chunk's WAL position
+    /// precedes its referrer, so every heap's value lives in exactly one
+    /// generation sealed no later than this slice; slices share payloads via
+    /// `Arc` instead of copying per batch, and each generation is immutable
+    /// once sealed (decode pool reads while later slices load).
+    pub chunks: Vec<Arc<ChunkMap>>,
+    /// Generation sealed with this slice (last element of `chunks`) — the
+    /// only chunks not yet handed out, the toast-store put target.
+    pub new_chunks: Option<Arc<ChunkMap>>,
+    /// Last slice of the commit. Only its seq may publish `commit_lsn` in
+    /// the ack (`register` vs `register_partial`): an earlier slice
+    /// publishing would claim durability for rows still in flight.
+    pub is_final: bool,
+}
+
+/// Streaming handle for one committed xact: pull [`DrainedBatch`] slices,
+/// then [`Self::finish`] to unlink spill files once dispatch completes.
+pub struct CommittedDrain {
+    pub commit_ts: i64,
+    pub commit_lsn: u64,
+    /// False for read-only / filter-dropped / unknown xid.
+    pub had_states: bool,
+    merged: Option<MergedDrain>,
+    generations: Vec<Arc<ChunkMap>>,
+}
+
+impl CommittedDrain {
+    /// Next slice, `None` once exhausted. The slice closes at the first
+    /// heap reaching `max_rows` / `max_bytes` (budget is a trigger, not a
+    /// hard cap: one oversized row still ships alone). Slices only cut at
+    /// heap boundaries, so a value's contiguous chunk run never splits
+    /// across generations.
+    pub async fn next_batch(
+        &mut self,
+        max_rows: usize,
+        max_bytes: usize,
+    ) -> std::result::Result<Option<DrainedBatch>, XactBufferError> {
+        let Some(m) = self.merged.as_mut() else {
+            return Ok(None);
+        };
+        let mut heaps: Vec<DecodedHeap> = Vec::new();
+        let mut ordered_events: Vec<(usize, DrainEntry)> = Vec::new();
+        let mut bytes = 0usize;
+        while heaps.len() < max_rows.max(1) && bytes < max_bytes.max(1) {
+            match m.next().await? {
+                None => break,
+                Some(MergeItem::Event(ev)) => ordered_events.push((heaps.len(), ev)),
+                Some(MergeItem::Heap(h)) => {
+                    bytes += h.approx_bytes();
+                    heaps.push(*h);
+                }
+            }
+        }
+        let is_final = m.is_exhausted();
+        let new_chunks = {
+            let sealed = m.take_chunks();
+            (!sealed.is_empty()).then(|| Arc::new(sealed))
+        };
+        if let Some(g) = &new_chunks {
+            self.generations.push(g.clone());
+        }
+        if heaps.is_empty() && ordered_events.is_empty() && new_chunks.is_none() {
+            return Ok(None);
+        }
+        Ok(Some(DrainedBatch {
+            heaps,
+            ordered_events,
+            chunks: self.generations.clone(),
+            new_chunks,
+            is_final,
+        }))
+    }
+
+    /// Unlink spill files; call after the final slice dispatches. On an
+    /// error path drop instead: files stay for inspection, startup wipe +
+    /// redecode-from-ack cover replay.
+    pub async fn finish(mut self) -> std::result::Result<(), XactBufferError> {
+        if let Some(m) = self.merged.take() {
+            m.finish().await?;
+        }
+        Ok(())
     }
 }
 
 pub(crate) async fn detoast_heap(
     heap: &mut DecodedHeap,
-    chunks: &ChunkMap,
+    // Chunk-map generations, oldest first; a value lives in exactly one
+    // (single map on the serial path, sealed drain-batch generations on the
+    // parallel path)
+    chunk_maps: &[&ChunkMap],
     catalog: &Arc<Mutex<ShadowCatalog>>,
     // Async decode pool can lag past a DDL and re-resolve an older heap,
     // so it reuses the inline cached descriptor without mutating cache or
@@ -1485,7 +1653,11 @@ pub(crate) async fn detoast_heap(
         collect_toast_keys(heap.new.as_ref(), &mut keys);
         collect_toast_keys(heap.old.as_ref(), &mut keys);
         for (relid, value_id) in keys {
-            if chunks.contains_key(&(relid, value_id)) || extra.contains_key(&(relid, value_id)) {
+            if chunk_maps
+                .iter()
+                .any(|m| m.contains_key(&(relid, value_id)))
+                || extra.contains_key(&(relid, value_id))
+            {
                 continue;
             }
             resolver
@@ -1494,7 +1666,8 @@ pub(crate) async fn detoast_heap(
                 .map_err(|e| XactBufferError::Detoast(format!("toast store fetch: {e}")))?;
         }
     }
-    let maps: [&ChunkMap; 2] = [chunks, &extra];
+    let mut maps: Vec<&ChunkMap> = chunk_maps.to_vec();
+    maps.push(&extra);
     if let Some(t) = heap.new.as_mut() {
         detoast_tuple(t, &rel, &maps, resolver)?;
     }
@@ -2793,5 +2966,209 @@ mod tests {
         assert!(b.active_xids().is_empty());
         // One bump per terminator record, not per subxid
         assert_eq!(b.stats().aborted_xacts_total, 1);
+    }
+
+    // ── drain streaming ───────────────────────────────────────────────
+
+    fn chunk(value_id: u32, seq: u32, lsn: u64, body: &[u8]) -> ToastChunk {
+        ToastChunk {
+            toast_relid: 16400,
+            value_id,
+            chunk_seq: seq,
+            source_lsn: lsn,
+            chunk_data: body.to_vec(),
+        }
+    }
+
+    fn dropped_event(oid: u32) -> SchemaEvent {
+        use crate::shadow_catalog::RelName;
+        SchemaEvent::Dropped {
+            oid,
+            rel_name: RelName::new("public", &format!("t{oid}")),
+        }
+    }
+
+    /// Interleave a batch's events at their local indices with its heaps:
+    /// `e<oid>` / `h<lsn>` labels for order assertions.
+    fn flatten_batch(batch: &DrainedBatch) -> Vec<String> {
+        let label = |e: &DrainEntry| match e {
+            DrainEntry::Catalog(SchemaEvent::Dropped { oid, .. }) => format!("e{oid}"),
+            other => panic!("unexpected event {other:?}"),
+        };
+        let mut out = Vec::new();
+        let mut ev = 0usize;
+        for (i, h) in batch.heaps.iter().enumerate() {
+            while ev < batch.ordered_events.len() && batch.ordered_events[ev].0 <= i {
+                out.push(label(&batch.ordered_events[ev].1));
+                ev += 1;
+            }
+            out.push(format!("h{}", h.source_lsn));
+        }
+        while ev < batch.ordered_events.len() {
+            out.push(label(&batch.ordered_events[ev].1));
+            ev += 1;
+        }
+        out
+    }
+
+    /// Batched drain must reproduce the serial merge order: spilled + in-mem
+    /// across top/subxact by `source_lsn` ASC, events winning ties, trailing
+    /// event after the last heap. `is_final` only on the last slice.
+    #[tokio::test(flavor = "current_thread")]
+    async fn drain_batches_merge_lsn_order_events_first() {
+        let tmp = tempdir().unwrap();
+        // 1 KiB budget: xid 1's 512-byte payloads spill, xid 2 stays in memory
+        let mut b = XactBuffer::new(cfg(tmp.path().to_path_buf())).unwrap();
+        for lsn in [100u64, 120, 140] {
+            b.on_heap(heap_with_value(1, lsn, 512)).await.unwrap();
+        }
+        b.on_heap(heap_with_value(2, 110, 16)).await.unwrap();
+        b.on_heap(heap_with_value(2, 130, 16)).await.unwrap();
+        // Ties heap@120; event-first tie-break puts it before the heap
+        b.on_schema_event(1, 120, dropped_event(7));
+        // Trailing, no heap after it
+        b.on_schema_event(2, 150, dropped_event(8));
+        assert!(b.stats().spill_xacts_active >= 1, "xid 1 must spill");
+
+        let mut drain = b.drain_committed(1, 42, 0x2000, &[2]).await.unwrap();
+        assert!(drain.had_states);
+        let mut order: Vec<String> = Vec::new();
+        let mut finals = Vec::new();
+        while let Some(batch) = drain.next_batch(2, usize::MAX).await.unwrap() {
+            order.extend(flatten_batch(&batch));
+            finals.push(batch.is_final);
+            if batch.is_final {
+                break;
+            }
+        }
+        assert_eq!(
+            order,
+            ["h100", "h110", "e7", "h120", "h130", "h140", "e8"]
+                .map(str::to_string)
+                .to_vec(),
+        );
+        assert!(finals.pop().unwrap(), "last slice flags final");
+        assert!(finals.iter().all(|f| !f), "earlier slices non-final");
+        assert!(drain.next_batch(2, usize::MAX).await.unwrap().is_none());
+        drain.finish().await.unwrap();
+        assert_eq!(b.stats().committed_xacts_total, 1);
+        assert!(b.active_xids().is_empty());
+    }
+
+    /// A chunk generation sealed with an earlier slice must stay visible to
+    /// later slices carrying the referrer (unchanged-toast UPDATE chain).
+    #[tokio::test(flavor = "current_thread")]
+    async fn drain_batch_chunk_generations_cover_cross_batch_referrer() {
+        let tmp = tempdir().unwrap();
+        let mut b = XactBuffer::new(cfg(tmp.path().to_path_buf())).unwrap();
+        b.on_toast_chunk(chunk(55, 0, 100, b"ab"), 9).await.unwrap();
+        b.on_toast_chunk(chunk(55, 1, 105, b"cd"), 9).await.unwrap();
+        b.on_heap(heap_with_value(9, 110, 16)).await.unwrap();
+        b.on_heap(heap_with_value(9, 300, 16)).await.unwrap();
+
+        let mut drain = b.drain_committed(9, 0, 0x1000, &[]).await.unwrap();
+        let b1 = drain.next_batch(1, usize::MAX).await.unwrap().unwrap();
+        assert_eq!(b1.heaps.len(), 1);
+        let g1 = b1.new_chunks.as_ref().expect("chunks seal with slice 1");
+        assert!(g1.contains_key(&(16400, 55)));
+        let b2 = drain.next_batch(1, usize::MAX).await.unwrap().unwrap();
+        assert!(b2.is_final);
+        assert!(b2.new_chunks.is_none(), "no fresh chunks in slice 2");
+        let maps: Vec<&ChunkMap> = b2.chunks.iter().map(Arc::as_ref).collect();
+        let p = ToastPointer {
+            va_rawsize: 8,
+            va_extinfo: 0,
+            va_valueid: 55,
+            va_toastrelid: 16400,
+        };
+        let raw = try_reassemble(&p, &maps).unwrap().expect("value visible");
+        assert_eq!(raw, b"abcd");
+        drain.finish().await.unwrap();
+    }
+
+    fn spill_files(dir: &std::path::Path) -> Vec<String> {
+        std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with("xid-"))
+            .collect()
+    }
+
+    /// Spill files survive the whole batch pull (redecode-from-disk on an
+    /// abandoned drain) and unlink only at `finish`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn drain_spill_unlinks_only_at_finish() {
+        let tmp = tempdir().unwrap();
+        let mut b = XactBuffer::new(cfg(tmp.path().to_path_buf())).unwrap();
+        for i in 0..8u64 {
+            b.on_heap(heap_with_value(3, 100 + i, 512)).await.unwrap();
+        }
+        assert_eq!(spill_files(tmp.path()).len(), 1);
+        let mut drain = b.drain_committed(3, 0, 0x5000, &[]).await.unwrap();
+        assert_eq!(
+            b.stats().spill_bytes_active,
+            0,
+            "drain owns the bytes once opened"
+        );
+        while let Some(batch) = drain.next_batch(2, usize::MAX).await.unwrap() {
+            if batch.is_final {
+                break;
+            }
+        }
+        assert_eq!(
+            spill_files(tmp.path()).len(),
+            1,
+            "file persists until finish"
+        );
+        drain.finish().await.unwrap();
+        assert!(spill_files(tmp.path()).is_empty());
+    }
+
+    /// The drain-resident gauge bounds what the merge holds: for a fully
+    /// spilled xact, peak stays near merge-heads, far below the xact size.
+    #[tokio::test(flavor = "current_thread")]
+    async fn drain_resident_gauge_stays_bounded() {
+        let tmp = tempdir().unwrap();
+        let mut b = XactBuffer::new(cfg(tmp.path().to_path_buf())).unwrap();
+        let n = 64u64;
+        for i in 0..n {
+            b.on_heap(heap_with_value(4, 100 + i, 512)).await.unwrap();
+        }
+        let total = n * 512;
+        let mut drain = b.drain_committed(4, 0, 0x9000, &[]).await.unwrap();
+        let mut rows = 0usize;
+        while let Some(batch) = drain.next_batch(4, usize::MAX).await.unwrap() {
+            rows += batch.heaps.len();
+            assert!(
+                b.drain_resident_bytes() < total / 4,
+                "resident {} vs xact {total}",
+                b.drain_resident_bytes(),
+            );
+            if batch.is_final {
+                break;
+            }
+        }
+        assert_eq!(rows as u64, n);
+        assert!(b.drain_resident_peak() > 0, "gauge saw the merge heads");
+        assert!(
+            b.drain_resident_peak() < total / 4,
+            "peak {} vs xact {total}",
+            b.drain_resident_peak(),
+        );
+        drain.finish().await.unwrap();
+        assert_eq!(b.drain_resident_bytes(), 0, "gauge drains with the drain");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn drain_committed_unknown_xid_yields_no_batches() {
+        let tmp = tempdir().unwrap();
+        let mut b = XactBuffer::new(cfg(tmp.path().to_path_buf())).unwrap();
+        let mut drain = b.drain_committed(999, 0, 0x100, &[]).await.unwrap();
+        assert!(!drain.had_states);
+        assert!(drain.next_batch(10, 1000).await.unwrap().is_none());
+        drain.finish().await.unwrap();
+        assert_eq!(b.stats().commits_unknown_xid, 1);
+        assert_eq!(b.stats().drain_lsn, 0x100);
     }
 }

--- a/tests/pipeline_parallel_e2e.rs
+++ b/tests/pipeline_parallel_e2e.rs
@@ -30,6 +30,12 @@ const CH_TCP_PORT: u16 = 17503;
 const CH_HTTP_PORT: u16 = 17504;
 const WALSENDER_PORT: u16 = 17552;
 
+const SLICE_SOURCE_PORT: u16 = 17505;
+const SLICE_SHADOW_PORT: u16 = 17506;
+const SLICE_CH_TCP_PORT: u16 = 17507;
+const SLICE_CH_HTTP_PORT: u16 = 17508;
+const SLICE_WALSENDER_PORT: u16 = 17553;
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn parallel_pipeline_replicates_dml() {
     if !fx::pg_available() {
@@ -246,5 +252,198 @@ async fn parallel_pipeline_replicates_dml() {
     assert!(
         stats.unsupported_relations.load(Ordering::Relaxed) > 0,
         "emitter_unsupported_relations_total live on pipeline",
+    );
+}
+
+/// 8192 bytes, comfortably past the ~2KB toast threshold (see toast_e2e).
+const TOAST_BODY_SQL: &str = "repeat('walshadow-toast-', 512)";
+const TOAST_BODY_LEN: &str = "8192";
+/// Fat replacement `meta` forcing the UPDATE's new version onto another
+/// page, so the full tuple (incl. the unchanged toast pointer) is logged
+/// rather than prefix/suffix-elided (`log_heap_update`); see toast_e2e.
+const META2_SQL: &str = "repeat('v2-update-', 60)";
+
+/// Commits sliced into many `DrainedBatch`es (`drain_batch_rows = 1`):
+/// every row of a multi-row xact dispatches as its own seq, all but the
+/// last registered partial. Proves slice plumbing end-to-end — rows land
+/// once each, and the durable watermark still advances (final-slice-only
+/// publication; a broken marker would pin the ack at 0).
+///
+/// The toasted xact drives cross-slice detoast through the decode pool:
+/// toasted INSERT, page-packing fillers, then an unchanged-toast UPDATE,
+/// all in ONE xact — the update's slice carries no chunks of its own, so
+/// its `ExternalToast` pointer must resolve against the chunk generation
+/// sealed with the insert's slice (`DecodeJob.chunks` → `detoast_heap`),
+/// with no toast store to fall back on (disabled mode). A broken
+/// generation lookup NULL-fills the value and the length assertion (on
+/// the max-`_lsn` row, not NULL-skipping argMax) catches it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parallel_pipeline_slices_multi_batch_commit() {
+    if !fx::pg_available() {
+        eprintln!("skip: no initdb on PATH");
+        return;
+    }
+    if !fx::pg_basebackup_available() {
+        eprintln!("skip: no pg_basebackup on PATH");
+        return;
+    }
+    if !fx::clickhouse_available() {
+        eprintln!("skip: no clickhouse binary on PATH");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let (
+        fx::BootstrappedClusters {
+            source,
+            shadow,
+            shadow_filter_dir,
+        },
+        shadow_stream_state,
+    ) = fx::bootstrap_clusters(
+        &tmp,
+        "CREATE TABLE public.slices (id int PRIMARY KEY, val text, meta text);\n\
+         ALTER TABLE public.slices ALTER COLUMN val SET STORAGE EXTERNAL;\n",
+        SLICE_SOURCE_PORT,
+        SLICE_SHADOW_PORT,
+        SLICE_WALSENDER_PORT,
+    )
+    .await;
+    let _src_stop = fx::StopOnDrop { sh: &source };
+    let _shd_stop = fx::StopOnDrop { sh: &shadow };
+
+    let ch_tmp = tempfile::tempdir().unwrap();
+    let ch = fx::ChServer::spawn(ch_tmp, SLICE_CH_TCP_PORT, SLICE_CH_HTTP_PORT).expect("spawn ch");
+    ch.query("CREATE DATABASE IF NOT EXISTS walshadow_test")
+        .expect("create db");
+    ch.query(
+        "CREATE OR REPLACE TABLE walshadow_test.slices (\
+            id Int32,\
+            val Nullable(String),\
+            meta Nullable(String),\
+            _lsn UInt64,\
+            _xid UInt32,\
+            _commit_ts DateTime64(6, 'UTC'), _is_deleted Bool\
+         ) ENGINE = ReplacingMergeTree(_lsn, _is_deleted) ORDER BY id",
+    )
+    .expect("create dest table");
+
+    let mappings = vec![fx::TableMappingSpec {
+        source_table: RelName::new("public", "slices"),
+        target_table: TableTarget::new("walshadow_test", "slices"),
+        columns: vec![
+            ColumnMapping {
+                src_attnum: 1,
+                target_name: "id".into(),
+                target_type: "Int32".into(),
+            },
+            ColumnMapping {
+                src_attnum: 2,
+                target_name: "val".into(),
+                target_type: "Nullable(String)".into(),
+            },
+            ColumnMapping {
+                src_attnum: 3,
+                target_name: "meta".into(),
+                target_type: "Nullable(String)".into(),
+            },
+        ],
+    }];
+
+    let mut pipeline = fx::build_pipeline_with(
+        fx::BuildPipelineArgs {
+            tmp: &tmp,
+            source: &source,
+            shadow: &shadow,
+            shadow_filter_dir: &shadow_filter_dir,
+            shadow_stream_state,
+            ch_database: "walshadow_test",
+            ch_tcp_port: SLICE_CH_TCP_PORT,
+            mappings,
+            app_name: "walshadow-pipeline-slices",
+            ddl: None,
+        },
+        |cfg| cfg.drain_batch_rows = 1,
+    )
+    .await;
+
+    // First xact: nine rows → nine slices; only the last slice's seq
+    // publishes the commit LSN. Second xact (one multi-statement `-c` =
+    // one implicit transaction): toasted INSERT, page-packing fillers,
+    // unchanged-toast UPDATE — the fat replacement `meta` forces the new
+    // version cross-page so the full tuple (with the toast pointer) is
+    // logged, and with rows=1 slicing the update's slice holds no chunks.
+    let driver = fx::spawn_workload(
+        &source,
+        vec![
+            "INSERT INTO public.slices (id, val) \
+             SELECT g, 'v' || g FROM generate_series(1, 9) g"
+                .into(),
+            format!(
+                "INSERT INTO public.slices VALUES (100, {TOAST_BODY_SQL}, 'v1'); \
+                 INSERT INTO public.slices (id, meta) \
+                 SELECT g, repeat('f', 500) FROM generate_series(101, 116) g; \
+                 UPDATE public.slices SET meta = {META2_SQL} WHERE id = 100"
+            ),
+            "SELECT pg_switch_wal()".into(),
+        ],
+    );
+
+    let shipped = fx::pump_until(
+        &mut pipeline.feed,
+        &mut pipeline.stream,
+        &mut pipeline.sinks,
+        &mut pipeline.segment_sink,
+        &mut pipeline.chunk_buf,
+        1,
+        Duration::from_secs(45),
+    )
+    .await;
+    let _ = driver.join();
+    assert!(shipped >= 1, "no segments shipped in 45s");
+
+    let target = pipeline.stream.dispatched_lsn();
+    let observed = shadow
+        .wait_for_replay(target, Duration::from_secs(30))
+        .expect("shadow replay catches up");
+    assert!(observed >= target);
+
+    let ack = pipeline.ack.clone();
+    pipeline.shutdown().await.expect("pipeline drains clean");
+
+    let ch_count = ch
+        .query("SELECT count() FROM walshadow_test.slices FINAL")
+        .expect("ch count");
+    assert_eq!(ch_count, "26", "all slices of both sliced commits landed");
+    let ch_vals = ch
+        .query("SELECT val FROM walshadow_test.slices FINAL ORDER BY id LIMIT 1")
+        .expect("ch first val");
+    assert_eq!(ch_vals, "v1");
+    // Winning (max _lsn) version of id=100 is the UPDATE's. ORDER BY, not
+    // argMax: Nullable aggregates skip NULL rows, so argMax(val, _lsn)
+    // would silently fall back to the INSERT version on a NULL-filled
+    // update (see toast_e2e).
+    let winning_meta = ch
+        .query(&format!(
+            "SELECT meta = {META2_SQL} FROM walshadow_test.slices \
+             WHERE id = 100 ORDER BY _lsn DESC LIMIT 1"
+        ))
+        .expect("ch id=100 meta");
+    assert_eq!(winning_meta, "1", "update version won, full tuple logged");
+    // Its slice carried no chunks: a full-length value proves the decode
+    // pool resolved the pointer against the insert slice's generation.
+    let winning_len = ch
+        .query(
+            "SELECT length(val) FROM walshadow_test.slices \
+             WHERE id = 100 ORDER BY _lsn DESC LIMIT 1",
+        )
+        .expect("ch id=100 val length");
+    assert_eq!(
+        winning_len, TOAST_BODY_LEN,
+        "cross-slice detoast rehydrated the unchanged-toast UPDATE",
+    );
+    assert!(
+        ack.load(std::sync::atomic::Ordering::Acquire) > 0,
+        "final-slice publication advanced the durable watermark",
     );
 }

--- a/tests/xact_buffer.rs
+++ b/tests/xact_buffer.rs
@@ -387,6 +387,24 @@ async fn detoast_concatenates_uncompressed_chunks_into_text() {
         va_valueid: 55,
         va_toastrelid: toast_oid,
     }));
+    // Chunks buffered before the referring heap, as in WAL:
+    // `toast_save_datum` writes chunk INSERTs before the referring tuple,
+    // and the streaming drain detoasts each heap at yield against the
+    // chunks merged so far.
+    for (seq, body) in [(0u32, &b"Hell"[..]), (1, b"o, "), (2, b"wor")] {
+        b.on_toast_chunk(
+            ToastChunk {
+                toast_relid: toast_oid,
+                value_id: 55,
+                chunk_seq: seq,
+                source_lsn: 0,
+                chunk_data: body.to_vec(),
+            },
+            33,
+        )
+        .await
+        .unwrap();
+    }
     // source_lsn=0 bypasses the shadow-replay gate in
     // `ShadowCatalog::relation_at` — shadow PG isn't in recovery in
     // this test (no `standby.signal`), so `pg_last_wal_replay_lsn()`
@@ -395,20 +413,6 @@ async fn detoast_concatenates_uncompressed_chunks_into_text() {
     b.on_heap(heap(rfn, 33, 0, HeapOp::Insert, vec![id_col, body_ptr]))
         .await
         .unwrap();
-    for (seq, body) in [(0u32, &b"Hell"[..]), (1, b"o, "), (2, b"wor")] {
-        b.on_toast_chunk(
-            ToastChunk {
-                toast_relid: toast_oid,
-                value_id: 55,
-                chunk_seq: seq,
-                source_lsn: 102 + seq as u64,
-                chunk_data: body.to_vec(),
-            },
-            33,
-        )
-        .await
-        .unwrap();
-    }
     b.commit(
         33,
         12345,
@@ -446,19 +450,15 @@ async fn detoast_missing_chunk_seq_errors_clearly() {
         va_valueid: 1,
         va_toastrelid: toast_oid,
     }));
-    // source_lsn=0 to bypass the shadow-replay gate; see sibling test
-    // for the rationale.
-    b.on_heap(heap(rfn, 42, 0, HeapOp::Insert, vec![id_col, body_ptr]))
-        .await
-        .unwrap();
-    // Only chunks 0 + 2 — seq 1 missing.
+    // Only chunks 0 + 2 — seq 1 missing. Buffered before the referring
+    // heap per WAL order (see sibling test).
     for (seq, body) in [(0u32, &b"AAA"[..]), (2, b"CCC")] {
         b.on_toast_chunk(
             ToastChunk {
                 toast_relid: toast_oid,
                 value_id: 1,
                 chunk_seq: seq,
-                source_lsn: 101 + seq as u64,
+                source_lsn: 0,
                 chunk_data: body.to_vec(),
             },
             42,
@@ -466,6 +466,11 @@ async fn detoast_missing_chunk_seq_errors_clearly() {
         .await
         .unwrap();
     }
+    // source_lsn=0 to bypass the shadow-replay gate; see sibling test
+    // for the rationale.
+    b.on_heap(heap(rfn, 42, 0, HeapOp::Insert, vec![id_col, body_ptr]))
+        .await
+        .unwrap();
     // Gap only errors with an active store (disabled mode NULL-fills);
     // disk mode with an empty store keeps the in-xact chunks authoritative
     let emitter_cfg = EmitterConfig {


### PR DESCRIPTION
Drain re-read whole spill file at commit, putting entire decoded xact in memory.

TOAST chunks still accumulate per-xact since one value serves several row versions

Acks split into commit groups: slices gate contiguity but only a commit's last seq publishes commit_lsn

New walshadow_drain_resident_bytes gauge tracks bound