### PR TITLE
Manage shadow catalog more directly

### DIFF
--- a/docker/DEMO.md
+++ b/docker/DEMO.md
@@ -10,7 +10,7 @@ Five services from the base stack plus a demo tier:
 | service | role |
 |---|---|
 | `source` | postgres:18, `wal_level=logical`, seeds `demo.users` + pgbench TPC-B schema (`REPLICA IDENTITY FULL`) |
-| `walshadow` | the daemon: in-container shadow PG (auto-spawned) + WAL→CH stream, `/metrics` on :9484 |
+| `walshadow` | daemon: in-container daemon-owned shadow PG + WAL→CH stream, `/metrics` on :9484 |
 | `clickhouse` | destination, `demo.*` tables pre-created |
 | `pgbench` | hammers `source` with the TPC-B workload |
 | `postgres-exporter` | source PG stats (TPS, tuple rates) → Prometheus |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,8 +4,7 @@
 #   2. postgres:N-alpine     -> walshadow PG extension, compiled against the
 #      exact runtime PG (same image) so PG_MODULE_MAGIC matches. The stream
 #      binary itself links no PG, so it builds separately.
-#   3. postgres:N-alpine runtime carries both, so shadow PG (auto-spawned in
-#      this same container by --bootstrap-autospawn-shadow) can
+#   3. postgres:N-alpine runtime carries both, so daemon-owned shadow PG can
 #      `CREATE EXTENSION walshadow` against its own $libdir.
 
 ARG PG_MAJOR=18

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,8 +5,8 @@
 #                table pre-created
 #   walshadow  — custom image carrying walshadow-stream + the
 #                walshadow PG extension. Boots an in-container shadow
-#                PG via --bootstrap-mode=direct + --bootstrap-autospawn
-#                then streams source's WAL into clickhouse
+#                PG via --bootstrap-mode=direct on empty volume, resumes it
+#                on later starts, then streams source WAL into clickhouse
 #
 # Quick start (from repo root):
 #   git submodule update --init --recursive

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# walshadow demo entrypoint. Wipes any stale shadow data dir so
-# --bootstrap-mode=direct sees an empty target, then execs the daemon
-# pointed at the docker-compose source / clickhouse hostnames.
+# walshadow demo entrypoint. Creates state directories, then execs daemon
+# against docker-compose source and ClickHouse services
 
 set -euo pipefail
 
@@ -10,14 +9,7 @@ OUT_DIR="${WALSHADOW_OUT_DIR:-/var/lib/walshadow/out}"
 SPILL_DIR="${WALSHADOW_SPILL_DIR:-/var/lib/walshadow/spill}"
 SOCKET_DIR="${WALSHADOW_SHADOW_SOCKET_DIR:-/var/run/postgresql}"
 
-# Direct bootstrap refuses to land into a non-empty data dir, mirror
-# initdb's contract. Drop the volume contents on every (re)start so
-# `docker compose up --force-recreate` rebootstraps cleanly.
-if [ -d "$SHADOW_DATA" ]; then
-    find "$SHADOW_DATA" -mindepth 1 -delete
-else
-    mkdir -p "$SHADOW_DATA"
-fi
+mkdir -p "$SHADOW_DATA"
 # Shadow PG refuses to start on anything other than 0700/0750. Named
 # volume mount drops Dockerfile-time perms, so reassert on each boot.
 chmod 700 "$SHADOW_DATA"
@@ -54,7 +46,6 @@ exec walshadow-stream \
     --shadow-dbname postgres \
     --bootstrap-mode direct \
     --bootstrap-shadow-data-dir "$SHADOW_DATA" \
-    --bootstrap-autospawn-shadow \
     --walsender-bind 127.0.0.1:5433 \
     --ch-config "${WALSHADOW_CH_CONFIG:-/etc/walshadow/ch-config.toml}" \
     --metrics-bind 0.0.0.0:9484 \

--- a/plans/bootstrap.md
+++ b/plans/bootstrap.md
@@ -55,10 +55,12 @@ for rendered diagram. Five clusters top→bottom:
    before handoff. Metrics-only runs (no `--ch-config`) instead drain
    through `drain_backfill` into a counting `TupleObserver`
 4. **Shadow handoff** — `BootstrapOutcome { start, end }` returned;
-   daemon writes `standby.signal`, appends `restore_command` +
-   `primary_conninfo` to shadow's `postgresql.auto.conf`,
-   `--bootstrap-autospawn-shadow` optionally drives `Shadow::start` +
-   `wait_for_replay(end_lsn, timeout)` under `block_in_place`
+   daemon writes `standby.signal` and calls `materialize_conf` to
+   replace shadow's config files. Config includes walshadow settings,
+   minimum GUC values from `pg_control`, `restore_command`, and
+   `primary_conninfo`. Daemon empties `postgresql.auto.conf`, starts
+   shadow with `start_with_floor_retry`, waits for `end_lsn` with
+   `wait_for_replay`, then supervises it (see [shadow.md](shadow.md))
 5. **Cursor + WAL pump start** — `cursor::write` lands
    `emitter_ack_lsn = end_lsn` atomically, `SourceFeed` opens
    `START_REPLICATION PHYSICAL <slot> <end_lsn>`, steady-state emitter
@@ -426,33 +428,38 @@ opt into Nullable for post-attach columns. Differential oracle does
 not patch this, it is structural shape difference between
 bootstrap-time & WAL-time decode
 
-## Operator-facing autospawn shape
+## Daemon-owned shadow
 
-`--bootstrap-autospawn-shadow` (default off): daemon drives shadow
-lifecycle itself via `Shadow::start` + `Shadow::wait_for_replay(end_lsn,
-timeout)`. Off-by-default because production deploys typically run
-shadow under systemd / k8s; on-by-default would conflict with
-operator-owned supervision
+Setting `--bootstrap-shadow-data-dir` makes daemon own shadow
+lifecycle. At startup it bootstraps an empty data dir or resumes an
+initialized cluster. `--bootstrap-mode` selects only bootstrap source.
+Bootstrap writes `walshadow_bootstrap.incomplete` before extraction
+and removes it after backup and required WAL land. If marker survives,
+daemon fails without changing data dir. Automatic rebootstrap is not
+part of standby lifecycle; operator-initiated workflow may add it later.
+Omit data-dir flag to run shadow as an external process, such as k8s
+sidecar
 
-When on, `autospawn_shadow_and_wait` calls
-`write_shadow_listener_overrides` to append last-wins `port` /
-`unix_socket_directories` / `listen_addresses = ''` keys to cloned data
-dir's `postgresql.auto.conf` (BASE_BACKUP shipped source's
-`postgresql.conf` verbatim, so without these overrides shadow would
-inherit source's port & socket dir & collide with still-running source).
-`listen_addresses = ''` disables TCP entirely; shadow is local-only
-over socket dir daemon connects to. Operators wanting TCP shadow
-override via `ALTER SYSTEM` after first boot
+Object-store mode currently fetches backup-required WAL during initial
+bootstrap. Future object-store recovery belongs in WAL acquisition loop,
+parallel to live primary path; it must not transition existing standby
+back into `BASE_BACKUP`
 
-Sync `pg_ctl` + `psql` shells run inside `tokio::task::block_in_place`
-so multi-threaded runtime keeps making forward progress on other tasks
-while `wait_for_replay` polls. Single-threaded runtime would deadlock
-here — hard constraint
+Daemon does not rely on config files from backup. Debian stores
+`postgresql.conf` under `/etc/postgresql/<v>/<cluster>`, so
+BASE_BACKUP from Debian does not include it. A backed-up
+`postgresql.auto.conf` can also contain `ALTER SYSTEM` settings that
+override appended values. `materialize_conf` replaces all four config
+files instead ([shadow.md](shadow.md)). `listen_addresses = ''`
+disables TCP, daemon connects through local socket
 
-`--bootstrap-shadow-replay-timeout` (default 300 s) bounds wait.
-Operator-supplied `--shadow-socket-dir` / `--shadow-port` flags double
-as autospawn listener config — same socket daemon connects to for
-`ShadowCatalog` further down pipeline
+Synchronous `pg_ctl` and `psql` commands run inside
+`tokio::task::spawn_blocking`, keeping runtime responsive while
+`wait_for_replay` polls
+
+`--bootstrap-shadow-replay-timeout` (default 300 s) limits post-bootstrap
+wait. `--shadow-socket-dir` and `--shadow-port` configure shadow
+listener used later by `ShadowCatalog`
 
 ## Cross-links
 

--- a/plans/future/coverage100.md
+++ b/plans/future/coverage100.md
@@ -127,7 +127,7 @@ configured denominator
    near the floor; `stream` is the whole decision. Choose coverage or exclusion
    explicitly. `stream` coverage means bootstrap off/direct/object-store paths,
    CH emitter + DDL setup, metrics-only observer, oracle wrapper on/off,
-   retention loop, object-store WAL fetch, autospawn success/failure, and
+   retention loop, object-store WAL fetch, shadow startup success/failure, and
    shutdown hooks. Prefer moving pure helpers into library modules before
    testing
 2. **Decoder/value matrix, `heap_decoder.rs`.** Varlena short / 4-byte /
@@ -144,7 +144,7 @@ configured denominator
 4. **Live control plane.** Validation hard-error, `seed_from_source`
    empty/known/new relation/not-found/error paths, TCP walsender listener,
    COPYDATA enqueue error, TCP/TLS source transports, direct/object-store
-   bootstrap, tablespace symlink, object-store WAL fetch, and shadow autospawn.
+   bootstrap, tablespace symlink, object-store WAL fetch, and shadow lifecycle.
    Extend existing e2e tests where state is real; add injectable clients or
    failing readers/writers where deterministic faults are needed
 5. **Defensive OS/transport/fault lines.** Add explicit fault injection for

--- a/plans/ops.md
+++ b/plans/ops.md
@@ -198,12 +198,16 @@ containing `cutoff_lsn` is preserved (shadow may still be reading it).
 files left alone — trimmer is conservative on purpose so sibling
 system writing into same dir doesn't lose unrelated files
 
-Sweeper task in `bin/stream.rs` ticks every
-`DEFAULT_TRIM_INTERVAL = 30s`, polls
-`SELECT pg_last_wal_replay_lsn()::text` from shadow, computes
-`cutoff_lsn = replay_lsn.saturating_sub(retention_bytes)`. Single
-`Arc<AtomicU64>` shared with status loop so metrics gauge + sweeper
-see the same value with one round-trip
+Sweeper task in `bin/stream.rs` runs every
+`DEFAULT_TRIM_INTERVAL = 30s`. It reads replay LSN from
+`pg_last_wal_replay_lsn()` and last restartpoint REDO LSN from
+`pg_control_checkpoint()`, then computes
+`cutoff_lsn = min(replay_lsn - retention_bytes, redo)`. Restarted
+shadow recovers from restartpoint, not current replay position, so
+`restore_command` must still find those segments. A failed query
+closes client and reconnects on next cycle because daemon may restart
+shadow. Status loop and sweeper share one `Arc<AtomicU64>`, so one
+query updates both metrics gauge and sweeper
 
 `--retention-bytes` default `DEFAULT_RETENTION_BYTES = 256 MiB` (~16 ×
 16 MiB segments). `--retention-bytes 0` disables sweeper outright.
@@ -319,9 +323,19 @@ Boot order ([`bin/stream.rs`](../src/bin/stream.rs)):
 Start-LSN precedence:
 
 1. `--start-lsn <hex>` — explicit operator override
-2. `cursor.emitter_ack_lsn` (segment-aligned down) when cursor present
+2. fresh bootstrap `end_lsn`, because shadow catalog already includes
+   earlier WAL
+3. `cursor.emitter_ack_lsn` (segment-aligned down) when cursor present
    and `--ignore-cursor` unset
-3. Source's current write head — greenfield
+4. Source's current write LSN when no saved state exists
+
+Resolved LSN aligns down to segment boundary. When no bootstrap ran and no
+`--start-lsn` was given, it cannot exceed end of last sealed segment
+in `out/` (`retention::max_segment_end`). Shadow alternates between
+`primary_conninfo` and `restore_command`, so archive must stay
+continuous until live streaming begins. Starting after archive end
+would leave a missing segment and prevent shadow from resuming. CH
+removes re-read duplicates by `_lsn`
 
 Per-field restart role is on cursor.bin layout table in diagram above.
 `emitter_ack_lsn` is load-bearing resume LSN (daemon restarts here);
@@ -389,7 +403,7 @@ Pipeline: `initdb` source PG `wal_level=logical` → `pgbench -i -s 1`
 `pgbench_history` requires FULL or an index; the PK tables would also
 pass under DEFAULT) → spawn CH + dest tables ReplacingMergeTree(_lsn) → spawn
 `walshadow-stream --bootstrap-mode=direct
---bootstrap-autospawn-shadow` → wait for metrics endpoint
+--bootstrap-shadow-data-dir <path>` → wait for metrics endpoint
 (bootstrap-finished gate, ~100k rows land via the shared insert tail) → `pgbench -T 6 -c 4 -j 2` background (CI uses 6
 s, plan called for 30 s) → +2 s `ALTER TABLE pgbench_accounts ADD
 COLUMN c int DEFAULT 7` (exercises read-time defaults via

--- a/plans/overview.md
+++ b/plans/overview.md
@@ -79,8 +79,8 @@ Component docs live alongside this overview:
   `SourceFeed`, walsender server feeding shadow at record cadence,
   `WalStream` page walker, `streaming_walker`, `QueueingRecordSink`
   decoupling pump from decoder, `decoder_sink`
-- [shadow.md](shadow.md) — shadow PG lifecycle (`initdb`,
-  `recovery.signal`, supervision), `ShadowCatalog` libpq cache with
+- [shadow.md](shadow.md) — shadow PG lifecycle (`materialize_conf`,
+  `standby.signal`, supervision), `ShadowCatalog` libpq cache with
   generation counter + `relation_at` replay-LSN gate, per-relation
   `SchemaEvent` channel feeding CH DDL applicator
 - [decoder.md](decoder.md) — `heap_decoder` Tier 1/2 type matrix,

--- a/plans/shadow.md
+++ b/plans/shadow.md
@@ -10,9 +10,10 @@ accepts writes from anywhere but source WAL feed
 
 Two surfaces:
 
-- **lifecycle** — process management (`initdb`, conf, `pg_ctl`),
-  bootstrap restore, recovery-mode startup. Owned by `Shadow` in
-  `src/shadow.rs`. Production daemon defers supervision to systemd
+- **lifecycle** — process management (config, `pg_ctl`), bootstrap
+  restore, recovery startup, supervision. `Shadow` in
+  `src/catalog/shadow.rs` provides operations. Daemon owns full
+  lifecycle whenever `--bootstrap-shadow-data-dir` is set
 - **catalog API** — async libpq client + LRU + replay-LSN gate +
   schema-event channel. Owned by `ShadowCatalog` in
   `src/shadow_catalog.rs`. Consumed by heap decoder & CH DDL applicator
@@ -23,39 +24,76 @@ otherwise compose at daemon level
 
 ## Lifecycle
 
-`Shadow` ([src/shadow.rs](../src/shadow.rs)) wraps `initdb`, `pg_ctl`,
-`psql` plus on-disk plumbing (`postgresql.conf`, `standby.signal`,
-`restore_command`, `primary_conninfo`) behind one struct. Bootstrap
-order:
+`Shadow` ([src/catalog/shadow.rs](../src/catalog/shadow.rs)) wraps
+`initdb`, `pg_ctl`, `psql`, and config files (`postgresql.conf`,
+`pg_hba.conf`, `standby.signal`, `restore_command`,
+`primary_conninfo`) in one struct. Daemon boot order with
+`--bootstrap-shadow-data-dir`:
 
-1. `initdb` — fresh empty cluster (~50 MiB, ~400 `pg_class` rows)
-2. `write_base_conf` — append walshadow knobs (port, unix socket,
-   `autovacuum = off`, `fsync = off`, `hot_standby = on`,
-   `wal_level = replica`, `max_wal_senders = 0`,
-   `listen_addresses = ''`)
-3. schema-only restore — see [bootstrap.md](bootstrap.md). Two paths:
-   `apply_schema_dump(sql)` pipes `pg_dump --schema-only` through
-   `psql -f -`; `BASE_BACKUP` greenfield copies source's catalog files
-   directly. `apply_schema_dump` takes `&str` payload, not source
-   connection — outbound source connection management lives in daemon
-4. `enable_standby_recovery(primary_conninfo)` — writes empty
-   `standby.signal`,
-   appends `primary_conninfo = '<walsender>'` + `restore_command =
-   'cp <filter_dir>/%f %p'` + `recovery_target_timeline = 'latest'`.
-   Standby (not recovery) signal: continuous-feed topology requires
-   staying in recovery indefinitely
-5. `start` — `pg_ctl -w start`, blocks until postmaster accepts
-   connections (~600 ms on PG 18, standby mode)
-6. `wait_for_replay(target, timeout)` — polls
-   `pg_last_wal_replay_lsn() ≥ target`. `target = 0` waits for any
-   non-NULL observation (post-startup catch-up)
-7. `health` — recovery state + replay LSN + `pg_class` count +
-   `pg_proc` lookup. Single-probe corruption canary
+1. Choose bootstrap or resume. Bootstrap only an empty data dir
+   according to `--bootstrap-mode` (see [bootstrap.md](bootstrap.md)).
+   Resume initialized cluster regardless of mode. If
+   `walshadow_bootstrap.incomplete` exists, fail without changing data
+   dir. Never turn standby recovery failure into automatic rebootstrap
+2. Run `write_standby_signal`. Standby signal keeps shadow in recovery
+   while it receives continuous WAL stream
+3. Run `control_guc_floor` and
+   `materialize_conf(floor, primary_conninfo)`. They read five minimum
+   GUC values from shadow's `pg_control` with `pg_controldata`.
+   `LC_ALL=C` keeps output labels stable. PostgreSQL
+   checks these values against `pg_control`, so reading them locally
+   matches WAL being replayed and avoids querying source. Current
+   source settings can differ from values required by older WAL. For
+   example, shadow with `max_connections = 100` cannot start when
+   `pg_control` requires 500. Replace `postgresql.conf` with
+   walshadow settings (port, unix socket,
+   `autovacuum = off`, `fsync = on`, `hot_standby = on`,
+   `wal_level = replica`, `listen_addresses = ''`),
+   `restore_command = 'cp <filter_dir>/%f %p'`,
+   `recovery_target_timeline = 'latest'`, and `primary_conninfo =
+   '<walsender>'`. Empty `postgresql.auto.conf` to remove source
+   `ALTER SYSTEM` settings included by BASE_BACKUP. Write
+   socket-only `pg_hba.conf` using trust authentication and empty
+   `pg_ident.conf`. Do not use config files from backup because Debian
+   stores them outside data dir under
+   `/etc/postgresql/<v>/<cluster>`
+4. Run `clear_stale_pid`, then `start_with_floor_retry`.
+   `pg_ctl -w start` waits for postmaster to accept connections
+   (~600 ms on PG 18 in standby mode). WAL can raise required GUC
+   values during startup. PostgreSQL first updates `pg_control`, then
+   aborts startup. On failure, read new values and retry. Return error
+   if values did not change. Include end of `startup.log` because
+   `pg_ctl` only reports "could not start server" while log includes
+   required value. After a fresh bootstrap, run
+   `wait_for_replay(end_lsn, timeout)` against WAL included in backup
+5. Call `is_running` every 2 s. If postmaster stops, restart it with
+   backoff and read minimum GUC values again. Hot standby can pause
+   replay when WAL requires higher value. Detect a pause with
+   `pg_get_wal_replay_pause_state()`, then confirm the cause: a floor
+   raise writes the higher value to `pg_control` before pausing, so a
+   `control_guc_floor` above the running `current_setting` values marks
+   it. Only then call `pg_wal_replay_resume()`; resume shuts server down,
+   allowing restart with updated values. A pause with floor equal to
+   running settings (operator `pg_wal_replay_pause`, recovery target)
+   holds untouched. On daemon exit, run `pg_ctl stop -m fast` so data
+   dir is ready for next startup
+6. Run `health` to check recovery state, replay LSN, `pg_class` count,
+   and `pg_proc` lookup in one corruption probe
+
+After bootstrap marker clears, every later start is standby recovery.
+WAL unavailability leaves recovery waiting or restarting against configured
+WAL sources; it never invokes bootstrap or replaces data dir
+
+Tests use `initdb` to create empty cluster (~50 MiB, ~400 `pg_class`
+rows), call `write_base_conf`, restore schema with
+`apply_schema_dump(sql)`, then call
+`enable_standby_recovery(primary_conninfo)`. `apply_schema_dump` sends
+`pg_dump --schema-only` output to `psql -f -` and accepts `&str`, not
+source connection
 
 Probes route through `psql -tAXq -c` via `psql_one` helper. Real libpq
 client lives in `ShadowCatalog`; mixing the two at this layer would
-duplicate connection state for no measurable win. Production deploys
-run shadow under systemd — walshadow does not babysit postmaster
+duplicate connection state for no measurable win
 
 ## Three channels to shadow
 
@@ -71,10 +109,11 @@ for rendered diagram:
    walreceiver (`primary_conninfo` in shadow's conf). Record-cadence
    WAL push, ms-scale. See [source.md](source.md) for source-side
    walsender walshadow itself consumes
-3. **restore_command archive fallback** — `cp out/%f %p` pulls completed
-   16 MiB segments from filter output dir. Segment-cadence, used by
-   shadow's walreceiver when wire disconnects or shadow restarts past
-   walshadow's segment-retention window
+3. **restore_command archive fallback** — `cp out/%f %p` copies
+   completed 16 MiB segments from filter output dir. Startup recovery
+   uses it after wire disconnects and while catching up after restart.
+   Retention keeps segments back to shadow's last restartpoint, see
+   [ops.md](ops.md)
 
 Channels (2) & (3) coexist by PG design: walreceiver tries
 `primary_conninfo` first, falls back to `restore_command` on connect
@@ -148,7 +187,7 @@ aborts disarm without sweeping
 
 `ShadowCatalog` stashes `conninfo` at construct time; diagram's
 reconnect path triggers transparently on client close (shadow bounce,
-OOM kill, systemd restart):
+OOM kill, supervisor restart):
 
 - `reconnect()` & `ensure_open()` are **private** async fns on
   `ShadowCatalog`. Earlier notes presented them as `pub` for
@@ -284,11 +323,13 @@ backfill, net-new knobs) is
   `XLH_UPDATE_CONTAINS_OLD_KEY` decode; `wal_level = replica`
   insufficient. Shadow itself runs at `wal_level = replica` because it
   never emits logical decoding
-- **process supervision out of scope.** Production deploys run shadow
-  under systemd, which owns crash recovery & restart policy.
-  `Shadow::start` / `stop` are bootstrap & test helpers; daemon does
-  not babysit postmaster. `ShadowCatalog`'s reconnect path absorbs
-  supervisor-driven bounces transparently
+- **daemon supervises process.** With
+  `--bootstrap-shadow-data-dir` set the daemon starts, probes, and
+  restarts postmaster with capped backoff, then stops it on exit.
+  Initialized standby always resumes; daemon never replaces it with a
+  new base backup. `ShadowCatalog` reconnects after each restart.
+  Without flag, shadow runs as external process such as k8s sidecar,
+  and another supervisor owns it
 - **PG version skew on cross-WAL replay.** Shadow's PG version must
   match (or exceed in compatible ways) source's. See PG 17 repro docker
   memory note for PG-17-specific repro layout

--- a/plans/source.md
+++ b/plans/source.md
@@ -390,10 +390,13 @@ reconnect. See [shadow.md](shadow.md)
 
 [`src/bin/stream.rs`](../src/bin/stream.rs). `walshadow-stream` daemon
 entry point. Boots in order: args + pre-flight validators
-([`preflight.rs`](../src/preflight.rs)); optional bootstrap (direct
-`BASE_BACKUP` from source, or wal-g-compatible from object store);
-`SourceFeed` connect + `IDENTIFY_SYSTEM` + derive `start_lsn` from
-cursor / `--start-lsn` / source's `xlogpos` aligned down;
+([`preflight.rs`](../src/preflight.rs)); bootstrap empty shadow or resume
+initialized shadow when `--bootstrap-shadow-data-dir` is set; bootstrap
+from direct `BASE_BACKUP` or wal-g-compatible object store backup
+([shadow.md](shadow.md)); connect `SourceFeed`; run `IDENTIFY_SYSTEM`;
+derive `start_lsn` from bootstrap `end_lsn`, cursor, `--start-lsn`, or
+source `xlogpos`; align it down and limit it to sealed archive end
+([ops.md](ops.md));
 `ShadowCatalog` + `XactBuffer` + `schema_events` subscription; bind
 walsender listener before shadow's walreceiver attaches; construct
 [`DaemonSinks`](../src/bin/stream.rs) (`MetricsRecordSink` +

--- a/src/backfill/backfill_staging.rs
+++ b/src/backfill/backfill_staging.rs
@@ -260,7 +260,7 @@ impl StagingSession {
     /// stream delivered during the pass carry `_lsn > S`; anything at or
     /// below `S` is prior-life state the swap just purged and must not come
     /// back. Column list is the intersection (destination order) so DDL
-    /// applied to the destination after the swap can't wedge the copy-back.
+    /// applied to the destination after the swap can't block the copy-back.
     pub async fn copy_back(&mut self, rel: &StagingRel) -> Result<()> {
         let real_cols = self
             .query_strings(&format!(

--- a/src/bin/stream.rs
+++ b/src/bin/stream.rs
@@ -34,10 +34,10 @@ use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use std::fs;
 use std::future::Future;
-use std::io::Write as _;
 use std::pin::Pin;
 use tokio::sync::{Mutex, watch};
 use tokio_postgres::types::PgLsn;
+use tokio_util::sync::CancellationToken;
 use walrus::pg::backup::{BACKUP_NAME_PREFIX, format_pg_lsn};
 use walrus::pg::replication::base_backup::BaseBackupOpts;
 use walrus::pg::replication::conn::PgConfig;
@@ -60,11 +60,13 @@ use walshadow::queueing_record_sink::{
     DEFAULT_QUEUEING_BATCH_SIZE, DEFAULT_QUEUEING_RECORD_SINK_CAPACITY, QueueingRecordSink,
 };
 use walshadow::record::{MetricsRecordSink, Record, RecordSink, SinkError, WAL_SEG_SIZE};
-use walshadow::retention::{DEFAULT_RETENTION_BYTES, DEFAULT_TRIM_INTERVAL, trim_below_lsn};
+use walshadow::retention::{
+    DEFAULT_RETENTION_BYTES, DEFAULT_TRIM_INTERVAL, max_segment_end, trim_below_lsn,
+};
 use walshadow::runtime_config::InitialLoadMode;
 use walshadow::schema::{RelName, SchemaEvent};
 use walshadow::segment_sink::{DirSegmentSink, SegFsync};
-use walshadow::shadow::{Shadow, ShadowConfig};
+use walshadow::shadow::{ResumeOutcome, Shadow, ShadowConfig};
 use walshadow::shadow_catalog::{ShadowCatalog, ShadowCatalogConfig, with_transient_retry};
 use walshadow::source_feed::{SourceFeed, StandbyStatus};
 use walshadow::toast::ToastResolver;
@@ -73,11 +75,13 @@ use walshadow::xact_buffer::{
     BufferingDecoderSink, SubxactTracker, XactBuffer, XactBufferConfig, XactRecordSink,
 };
 
-/// Bootstrap source pick: lands catalog files + standby.signal so a
-/// fresh shadow PG can be brought up against this run's `out_dir`.
+/// Choose bootstrap source for empty shadow data dir
+/// Initialized data dir resumes regardless of mode
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
 enum BootstrapMode {
-    /// Caller supplied shadow data dir externally (e.g. `pg_basebackup`)
+    /// Never bootstrap. Without `--bootstrap-shadow-data-dir`, manage shadow
+    /// externally. With data dir, manage initialized cluster but reject
+    /// empty dir
     #[default]
     Off,
     /// Source-PG-driven BASE_BACKUP over the replication protocol,
@@ -232,8 +236,12 @@ struct Args {
     #[arg(long, default_value_t = 30)]
     shadow_connect_timeout: u64,
     /// Walsender bind address. `127.0.0.1:0` lets the kernel pick a free
-    /// port; set explicitly when shadow's `primary_conninfo` references
-    /// a fixed port.
+    /// port, valid only for externally managed shadow (no
+    /// `--bootstrap-shadow-data-dir`): operator reads
+    /// `--walsender-port-file` and configures `primary_conninfo` by hand.
+    /// Daemon-owned shadow bakes this address into shadow's generated
+    /// `primary_conninfo` before shadow starts, so it rejects port 0 —
+    /// pass an explicit port there.
     #[arg(long, default_value = "127.0.0.1:0")]
     walsender_bind: SocketAddr,
     /// File the daemon writes the bound walsender address into (one line
@@ -341,18 +349,17 @@ struct Args {
     /// progresses.
     #[arg(long, default_value_t = false)]
     ignore_cursor: bool,
-    /// Bootstrap source pick. `off` keeps shadow externally bootstrapped.
-    /// `direct` issues BASE_BACKUP over the same replication connection;
-    /// `object_store` pulls a wal-g-format backup from `DynStorage`
-    /// (`WALG_*` env vars). Both modes land catalog files + standby.signal +
-    /// restore_command to `--bootstrap-shadow-data-dir`, then resume the
-    /// WAL pump at the backup's `end_lsn` (overriding cursor / `--start-lsn`).
+    /// Bootstrap source for empty shadow data dir. `off` never bootstraps;
+    /// `direct` runs BASE_BACKUP over current replication connection;
+    /// `object_store` reads wal-g-format backup from `DynStorage`
+    /// (`WALG_*` env vars). Initialized data dir resumes without bootstrap
+    /// regardless of mode
     #[arg(long, value_enum, default_value_t = BootstrapMode::Off)]
     bootstrap_mode: BootstrapMode,
-    /// Shadow PG data dir the bootstrap lands catalogs into; PG recovery's
-    /// `restore_command` then consumes `out_dir/<seg>.partial` to replay
-    /// WAL beyond `end_lsn`. Required when `--bootstrap-mode != off`. Must
-    /// be empty (or non-existent) at boot.
+    /// Shadow PG data dir. When set, daemon bootstraps or resumes shadow,
+    /// writes config, starts and supervises postmaster, then stops it on
+    /// exit. When unset, manage shadow externally. Required when
+    /// `--bootstrap-mode != off`
     #[arg(long)]
     bootstrap_shadow_data_dir: Option<PathBuf>,
     /// Object-store backup name. `LATEST` resolves to newest sentinel;
@@ -368,15 +375,8 @@ struct Args {
     /// cost matters more than bootstrap latency.
     #[arg(long, default_value_t = true)]
     bootstrap_fast_checkpoint: bool,
-    /// Auto-spawn shadow PG against `--bootstrap-shadow-data-dir` after
-    /// the bootstrap pump returns (drives `pg_ctl start`, waits for
-    /// `pg_last_wal_replay_lsn` to clear `end_lsn`). Off so external
-    /// supervisors (systemd, k8s) own shadow lifecycle without
-    /// double-management.
-    #[arg(long, default_value_t = false)]
-    bootstrap_autospawn_shadow: bool,
-    /// Seconds budget for `--bootstrap-autospawn-shadow`'s wait on shadow's
-    /// replay LSN. Exceeded → daemon aborts.
+    /// Maximum seconds to wait for shadow replay after bootstrap
+    /// Abort daemon when timeout expires
     #[arg(long, default_value_t = 300)]
     bootstrap_shadow_replay_timeout: u64,
 }
@@ -493,6 +493,15 @@ async fn run(args: Args) -> Result<()> {
                 "SIGHUP install failed; reload disabled",
             );
         })?;
+    // Match systemd SIGTERM with ctrl_c shutdown path
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .inspect_err(|e| {
+            tracing::warn!(
+                target: "walshadow",
+                error = %e,
+                "SIGTERM install failed",
+            );
+        })?;
     let sslmode = SslMode::parse(&args.sslmode).context("--sslmode")?;
     let cfg = PgConfig {
         host: args.host.clone(),
@@ -538,24 +547,37 @@ async fn run(args: Args) -> Result<()> {
     // Effective physical replication slot (`[source] slot` + --slot override);
     // None = slotless.
     let source_slot: Option<String> = ch_config.as_ref().and_then(|c| c.source_slot.clone());
-    let bootstrap_end_lsn: Option<u64> = if matches!(args.bootstrap_mode, BootstrapMode::Off) {
-        None
-    } else {
+    let shadow_start = resolve_shadow_start(&args)?;
+    let bootstrap_end_lsn: Option<u64> = if matches!(shadow_start, ShadowStart::Bootstrap(_)) {
         Some(
             run_bootstrap(&cfg, &mut feed, &args, ch_config.clone())
                 .await
                 .context("bootstrap")?,
         )
+    } else {
+        None
     };
-    if let Some(end_lsn) = bootstrap_end_lsn
-        && args.bootstrap_autospawn_shadow
-    {
-        let shadow_data_dir = args
-            .bootstrap_shadow_data_dir
-            .clone()
-            .context("--bootstrap-shadow-data-dir required with --bootstrap-autospawn-shadow")?;
-        autospawn_shadow_and_wait(&args, shadow_data_dir, end_lsn).await?;
-    }
+    // Regenerate config because walsender address and port may change
+    // Read minimum GUC values from shadow pg_control
+    // Keep shadow alive until pipeline teardown finishes
+    let shadow_lifecycle: Option<ShadowLifecycle> = match &shadow_start {
+        ShadowStart::External => None,
+        ShadowStart::Bootstrap(dir) | ShadowStart::Resume(dir) => {
+            let shadow = Arc::new(build_owned_shadow(&args, dir.clone()));
+            let conninfo = walsender_primary_conninfo(args.walsender_bind);
+            shadow
+                .write_standby_signal()
+                .context("write standby.signal")?;
+            start_owned_shadow(
+                &shadow,
+                conninfo.clone(),
+                bootstrap_end_lsn,
+                Duration::from_secs(args.bootstrap_shadow_replay_timeout),
+            )
+            .await?;
+            Some(ShadowLifecycle::spawn(shadow, conninfo))
+        }
+    };
 
     // Resume precedence: `--start-lsn` > cursor.bin emitter-ack > greenfield
     // (source write head). `--ignore-cursor` forces greenfield (recovery drills).
@@ -589,7 +611,26 @@ async fn run(args: Args) -> Result<()> {
         cursor_at_boot.as_ref().map(|c| c.emitter_ack_lsn),
         ident.xlogpos,
     );
-    let aligned = WalStream::align_down(raw_start, WAL_SEG_SIZE);
+    let mut aligned = WalStream::align_down(raw_start, WAL_SEG_SIZE);
+    // Keep archive continuous until live streaming begins
+    // Starting after last sealed segment leaves shadow missing WAL
+    // Re-read from earlier LSN, CH removes duplicates using `_lsn`
+    // Preserve fresh bootstrap position and explicit `--start-lsn`
+    if bootstrap_end_lsn.is_none()
+        && start_lsn_override.is_none()
+        && let Some(archive_end) = max_segment_end(&args.out_dir)
+            .await
+            .context("scan out-dir for sealed archive end")?
+        && archive_end < aligned
+    {
+        tracing::info!(
+            target: "walshadow",
+            archive_end = format_pg_lsn(archive_end).to_string(),
+            unclamped = format_pg_lsn(aligned).to_string(),
+            "resume clamped to sealed archive end",
+        );
+        aligned = archive_end;
+    }
     tracing::info!(
         target: "walshadow",
         raw = format_pg_lsn(raw_start).to_string(),
@@ -1303,6 +1344,7 @@ async fn run(args: Args) -> Result<()> {
                 sig.context("install ctrl_c handler")?;
                 break "signal";
             }
+            _ = sigterm.recv() => break "signal",
             // Idle tick so metrics/cursor keep tracking the draining pipeline
             // when no new WAL arrives.
             _ = tokio::time::sleep(metrics_tick) => None,
@@ -1534,6 +1576,9 @@ async fn run(args: Args) -> Result<()> {
             .join()
             .await
             .map_err(|m| anyhow::anyhow!("decode+insert pipeline drain failed: {m}"))?;
+    }
+    if let Some(lifecycle) = shadow_lifecycle {
+        lifecycle.shutdown().await;
     }
     Ok(())
 }
@@ -1851,9 +1896,11 @@ fn spawn_segment_fsync(
     })
 }
 
-/// Retention sweeper: every [`DEFAULT_TRIM_INTERVAL`], query shadow's
-/// `pg_last_wal_replay_lsn()` and trim segments older than
-/// `replay_lsn - retention_bytes`.
+/// Every [`DEFAULT_TRIM_INTERVAL`], read shadow replay LSN and last
+/// restartpoint REDO LSN, then trim below
+/// `min(replay_lsn - retention_bytes, redo)`
+/// Keep WAL from restartpoint because shadow resumes recovery there
+/// Reconnect after failed query because daemon may restart shadow
 fn spawn_retention(
     out_dir: PathBuf,
     retention_bytes: u64,
@@ -1861,29 +1908,37 @@ fn spawn_retention(
     shadow_replay_lsn: Arc<AtomicU64>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        let client = match open_retention_client(&shadow_conninfo).await {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!(
-                    target: "walshadow::retention",
-                    error = %e,
-                    "shadow connect failed; retention disabled",
-                );
-                return;
-            }
-        };
+        let mut client: Option<tokio_postgres::Client> = None;
         loop {
             tokio::time::sleep(DEFAULT_TRIM_INTERVAL).await;
-            let lsn = match query_replay_lsn(&client).await {
-                Ok(Some(l)) => l,
-                Ok(None) => continue, // shadow hasn't replayed anything yet
+            if client.is_none() {
+                match open_retention_client(&shadow_conninfo).await {
+                    Ok(c) => client = Some(c),
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "walshadow::retention",
+                            error = %e,
+                            "shadow connect failed; retrying next cycle",
+                        );
+                        continue;
+                    }
+                }
+            }
+            let (replay, redo) = match query_replay_state(client.as_ref().expect("just set")).await
+            {
+                Ok(v) => v,
                 Err(e) => {
                     tracing::warn!(target: "walshadow::retention", error = %e, "lsn query");
+                    client = None;
                     continue;
                 }
             };
+            // Wait until shadow replays first record
+            let Some(lsn) = replay else { continue };
             shadow_replay_lsn.fetch_max(lsn, Ordering::Release);
-            let cutoff = lsn.saturating_sub(retention_bytes);
+            let cutoff = lsn
+                .saturating_sub(retention_bytes)
+                .min(redo.unwrap_or(u64::MAX));
             match trim_below_lsn(&out_dir, cutoff).await {
                 Ok(r) if r.segments_removed > 0 => {
                     tracing::info!(
@@ -1911,12 +1966,16 @@ async fn open_retention_client(conninfo: &str) -> Result<tokio_postgres::Client>
     Ok(client)
 }
 
-async fn query_replay_lsn(client: &tokio_postgres::Client) -> Result<Option<u64>> {
+async fn query_replay_state(client: &tokio_postgres::Client) -> Result<(Option<u64>, Option<u64>)> {
     let row = client
-        .query_one("SELECT pg_last_wal_replay_lsn()", &[])
+        .query_one(
+            "SELECT pg_last_wal_replay_lsn(), redo_lsn FROM pg_control_checkpoint()",
+            &[],
+        )
         .await?;
-    let lsn: Option<PgLsn> = row.get(0);
-    Ok(lsn.map(u64::from))
+    let replay: Option<PgLsn> = row.get(0);
+    let redo: Option<PgLsn> = row.get(1);
+    Ok((replay.map(u64::from), redo.map(u64::from)))
 }
 
 /// Shadow-side numbers for the metrics publish step, from
@@ -2171,18 +2230,11 @@ async fn reconnect_or_fatal(
         .map_err(recycled)
 }
 
-/// Orchestrate BASE_BACKUP into a fresh shadow data dir; returns the
-/// backup's `end_lsn` so the caller rebinds the WAL pump past it.
-///
-/// Operator contract after this returns:
-///
-/// 1. Bring up shadow PG with `standby.signal` + `restore_command`
-///    pointing at `--out-dir` (both written here).
-/// 2. Shadow consumes filtered WAL segments the daemon produces against
-///    `--out-dir` and replays them.
-/// 3. No automatic shadow-process management; a service manager (systemd,
-///    k8s) owning shadow should start it once `bootstrap_shadow_data_dir`
-///    exists and is non-empty (true once this returns).
+/// Run BASE_BACKUP into new shadow data dir and return backup `end_lsn`
+/// Caller starts WAL pump from returned LSN, then starts and supervises
+/// shadow in [`run`]
+/// [`BOOTSTRAP_INCOMPLETE_MARKER`] remains after any failed bootstrap;
+/// automatic rebootstrap is intentionally unsupported
 ///
 /// `ch_config` `Some`: bootstrap rows route through the shared insert tail
 /// (synthetic INSERT `_lsn = start_lsn`, `_commit_ts = 0`, `_is_deleted = 0`).
@@ -2199,6 +2251,9 @@ async fn run_bootstrap(
         .bootstrap_shadow_data_dir
         .clone()
         .context("--bootstrap-shadow-data-dir required when --bootstrap-mode != off")?;
+    prepare_bootstrap_dir(&shadow_data_dir)
+        .await
+        .context("prepare shadow data dir for bootstrap")?;
 
     // Seed catalog map inside a REPEATABLE READ snapshot. DDL between the
     // seed COMMIT and BASE_BACKUP's checkpoint window is operator-quiesced
@@ -2234,11 +2289,10 @@ async fn run_bootstrap(
                     fast_checkpoint: args.bootstrap_fast_checkpoint,
                     no_verify_checksums: false,
                     max_rate_kib: None,
-                    // Ship pg_wal [start_lsn, end_lsn] inside base.tar so the
-                    // auto-spawned shadow hits `minRecoveryPoint` from local WAL
-                    // alone. Else `pg_ctl -w start` polls `restore_command`
-                    // against an `out/` dir the streamer hasn't filled yet
-                    // (queued behind autospawn) and times out.
+                    // Ship pg_wal [start_lsn, end_lsn] inside base.tar so
+                    // daemon-owned shadow reaches `minRecoveryPoint` locally.
+                    // Otherwise `pg_ctl -w start` polls `restore_command`
+                    // against empty `out/` before WAL pump starts and times out.
                     wal: true,
                 };
                 (Box::new(DirectSource::new(src_cfg.clone(), opts)), None)
@@ -2379,8 +2433,8 @@ async fn run_bootstrap(
 
     // Object-store mode: hydrate shadow's pg_wal/ before pg_ctl. wal-g
     // backups keep WAL in wal_005/ separately (direct mode shipped it in
-    // base.tar). Skipping deadlocks autospawn_shadow_and_wait: empty out/
-    // dir for restore_command, walsender not yet bound.
+    // base.tar). Skipping blocks shadow startup: restore_command sees empty
+    // out/ and walsender has not bound yet.
     if let Some((settings, storage)) = object_store_handles {
         fetch_wal_into_pg_wal(
             &settings,
@@ -2394,12 +2448,6 @@ async fn run_bootstrap(
         .context("bootstrap: hydrate shadow pg_wal from object store")?;
     }
 
-    // primary_conninfo points at the daemon's walsender; restore_command
-    // is the archive fallback. PG's walreceiver tries the wire first, falls
-    // back on disconnect or end-of-WAL.
-    write_standby_config(&shadow_data_dir, &args.out_dir, args.walsender_bind)
-        .context("bootstrap: write standby.signal + primary_conninfo + restore_command")?;
-
     // PG refuses to start on a data dir whose mode isn't 0700 or 0750.
     // BASE_BACKUP tar carries no entry for the root, so extraction leaves
     // it at the process umask (typically 0755); reassert 0700 before pg_ctl.
@@ -2412,132 +2460,334 @@ async fn run_bootstrap(
             .with_context(|| format!("bootstrap: chmod 0700 {}", shadow_data_dir.display()))?;
     }
 
+    tokio::fs::remove_file(shadow_data_dir.join(BOOTSTRAP_INCOMPLETE_MARKER))
+        .await
+        .context("clear completed bootstrap marker")?;
+
     Ok(outcome.end.end_lsn)
 }
 
-/// Boot shadow PG against the bootstrapped data dir and wait until its
-/// replay LSN clears `end_lsn`. Sync `pg_ctl` / `psql` shells run via
-/// `block_in_place` so the runtime keeps progressing other tasks.
-/// Reuses `--shadow-socket-dir` / `--shadow-port` (same socket
-/// `ShadowCatalog` connects to later).
-async fn autospawn_shadow_and_wait(
-    args: &Args,
-    shadow_data_dir: PathBuf,
-    end_lsn: u64,
-) -> Result<()> {
-    // BASE_BACKUP ships source's postgresql.conf verbatim; without override
-    // shadow inherits source's port / listen_addresses / socket dir and
-    // collides with the still-running source. Write last-wins overrides into
-    // postgresql.auto.conf so the clone comes up on the `--shadow-*` values.
-    write_shadow_listener_overrides(&shadow_data_dir, args.shadow_port, &args.shadow_socket_dir)
-        .context("bootstrap: write shadow listener overrides")?;
+/// Mark bootstrap before extraction, clear only after backup and required
+/// object-store WAL land successfully. Refuse automatic rebootstrap when
+/// marker survives a failed run
+const BOOTSTRAP_INCOMPLETE_MARKER: &str = "walshadow_bootstrap.incomplete";
 
-    let mut cfg = ShadowConfig::new(shadow_data_dir.clone(), args.out_dir.clone());
+/// Choose external management, one-time bootstrap, or resume from
+/// `--bootstrap-shadow-data-dir` and data dir state
+/// Mode only chooses bootstrap source
+enum ShadowStart {
+    /// Connect to externally managed shadow when no data dir is given
+    External,
+    Bootstrap(PathBuf),
+    Resume(PathBuf),
+}
+
+fn resolve_shadow_start(args: &Args) -> Result<ShadowStart> {
+    let Some(dir) = &args.bootstrap_shadow_data_dir else {
+        anyhow::ensure!(
+            matches!(args.bootstrap_mode, BootstrapMode::Off),
+            "--bootstrap-mode {:?} requires --bootstrap-shadow-data-dir",
+            args.bootstrap_mode,
+        );
+        return Ok(ShadowStart::External);
+    };
+    anyhow::ensure!(
+        args.walsender_bind.port() != 0,
+        "--walsender-bind {} has port 0; daemon-owned shadow bakes this \
+         address into shadow's primary_conninfo before shadow starts, so the \
+         port must be known upfront, pass an explicit --walsender-bind port",
+        args.walsender_bind,
+    );
+    for (flag, other) in [
+        ("--out-dir", &args.out_dir),
+        ("--spill-dir", &args.spill_dir),
+        ("--shadow-socket-dir", &args.shadow_socket_dir),
+    ] {
+        anyhow::ensure!(
+            !paths_overlap(dir, other),
+            "--bootstrap-shadow-data-dir {} overlaps {flag} {}",
+            dir.display(),
+            other.display(),
+        );
+    }
+    anyhow::ensure!(
+        !dir.join(BOOTSTRAP_INCOMPLETE_MARKER).exists(),
+        "shadow data dir {} contains {BOOTSTRAP_INCOMPLETE_MARKER}; bootstrap incomplete, automatic rebootstrap unsupported, choose a new empty data dir or use operator recovery",
+        dir.display(),
+    );
+    if dir.join("PG_VERSION").exists() {
+        if !matches!(args.bootstrap_mode, BootstrapMode::Off) {
+            tracing::info!(
+                target: "walshadow::bootstrap",
+                data_dir = %dir.display(),
+                "shadow data dir already initialized, resuming without bootstrap",
+            );
+        }
+        return Ok(ShadowStart::Resume(dir.clone()));
+    }
+    anyhow::ensure!(
+        !matches!(args.bootstrap_mode, BootstrapMode::Off),
+        "shadow data dir {} does not contain an initialized cluster; --bootstrap-mode off cannot bootstrap it, pass direct or object_store",
+        dir.display(),
+    );
+    Ok(ShadowStart::Bootstrap(dir.clone()))
+}
+
+/// True if `a` and `b` are the same path, or one is an ancestor of the other
+fn paths_overlap(a: &Path, b: &Path) -> bool {
+    match (std::path::absolute(a), std::path::absolute(b)) {
+        (Ok(a), Ok(b)) => a == b || a.starts_with(&b) || b.starts_with(&a),
+        _ => true,
+    }
+}
+
+/// Require empty data dir and mark bootstrap in progress
+/// Never clear partial or initialized standby state automatically
+async fn prepare_bootstrap_dir(dir: &Path) -> Result<()> {
+    tokio::fs::create_dir_all(dir)
+        .await
+        .with_context(|| format!("create {}", dir.display()))?;
+    let mut rd = tokio::fs::read_dir(dir).await?;
+    anyhow::ensure!(
+        rd.next_entry().await?.is_none(),
+        "shadow data dir {} is non-empty; automatic rebootstrap unsupported, choose a new empty data dir or use operator recovery",
+        dir.display(),
+    );
+    tokio::fs::write(dir.join(BOOTSTRAP_INCOMPLETE_MARKER), b"").await?;
+    Ok(())
+}
+
+fn build_owned_shadow(args: &Args, data_dir: PathBuf) -> Shadow {
+    let mut cfg = ShadowConfig::new(data_dir, args.out_dir.clone());
     cfg.port = args.shadow_port;
     cfg.socket_dir = args.shadow_socket_dir.clone();
     cfg.ctl_timeout = Duration::from_secs(args.shadow_connect_timeout);
-    let shadow = Shadow::new(cfg);
-    let timeout = Duration::from_secs(args.bootstrap_shadow_replay_timeout);
-
-    tracing::info!(
-        target: "walshadow::bootstrap",
-        data_dir = %shadow_data_dir.display(),
-        end_lsn = format_pg_lsn(end_lsn).to_string(),
-        replay_timeout_secs = args.bootstrap_shadow_replay_timeout,
-        "auto-spawning shadow PG",
-    );
-    let replay_lsn = tokio::task::block_in_place(move || -> Result<u64> {
-        shadow.start().context("auto-spawn: shadow start")?;
-        shadow
-            .wait_for_replay(end_lsn, timeout)
-            .context("auto-spawn: wait_for_replay")
-    })?;
-    tracing::info!(
-        target: "walshadow::bootstrap",
-        replay_lsn = format_pg_lsn(replay_lsn).to_string(),
-        "shadow caught up to bootstrap end_lsn",
-    );
-    Ok(())
+    cfg.user = args.shadow_user.clone();
+    cfg.dbname = args.shadow_dbname.clone();
+    Shadow::new(cfg)
 }
 
-/// Write `standby.signal` (zero-byte marker) + append `restore_command`
-/// so shadow starts in standby mode and feeds from the daemon's
-/// filtered-segment dir. Idempotent (appended once).
-fn write_standby_config(
-    shadow_data_dir: &Path,
-    filter_out_dir: &Path,
-    walsender_bind: SocketAddr,
-) -> Result<()> {
-    fs::create_dir_all(shadow_data_dir)?;
-    fs::write(shadow_data_dir.join("standby.signal"), b"")?;
-    let conf = shadow_data_dir.join("postgresql.auto.conf");
-    let marker = "# walshadow bootstrap";
-    if conf.exists() {
-        let existing = fs::read_to_string(&conf).unwrap_or_default();
-        if existing.contains(marker) {
-            return Ok(());
-        }
-    }
-    let mut f = fs::OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(&conf)?;
-    writeln!(f, "\n{marker}")?;
-    // Skip primary_conninfo when port=0: kernel-picked addresses are
-    // unstable across daemon restarts, fall back to archive-only.
-    if walsender_bind.port() != 0 {
-        writeln!(
-            f,
-            "primary_conninfo = 'host={} port={} user=walshadow application_name=shadow sslmode=disable'",
-            walsender_bind.ip(),
-            walsender_bind.port(),
-        )?;
-    }
-    writeln!(
-        f,
-        "restore_command = 'cp {}/%f %p'",
-        filter_out_dir.display()
-    )?;
-    Ok(())
+/// Return `None` for kernel-assigned port because it may change after
+/// restart. Shadow then reads only archive through `restore_command`
+fn walsender_primary_conninfo(bind: SocketAddr) -> Option<String> {
+    (bind.port() != 0).then(|| {
+        format!(
+            "host={} port={} user=walshadow application_name=shadow sslmode=disable",
+            bind.ip(),
+            bind.port(),
+        )
+    })
 }
 
-/// Append shadow-side `port` / `unix_socket_directories` /
-/// `listen_addresses` to the cloned data dir's `postgresql.auto.conf`.
-/// PG honours last-wins-per-key across the conf chain, so these override
-/// what source's conf carried into the BASE_BACKUP. Idempotent via a marker.
-///
-/// `listen_addresses = ''` disables TCP: shadow is local-only over the
-/// socket dir. Operators wanting TCP override via `ALTER SYSTEM SET
-/// listen_addresses = ...` after first boot.
-fn write_shadow_listener_overrides(
-    shadow_data_dir: &Path,
-    port: u16,
-    socket_dir: &Path,
+/// Start daemon-owned shadow with current walsender address and minimum
+/// GUC values from its `pg_control`
+/// After fresh bootstrap, wait for backup `end_lsn`; direct mode includes
+/// required WAL in `base.tar`
+/// Restart a postmaster left alive by an unclean prior exit so it binds
+/// this daemon's port, socket, and walsender address
+async fn start_owned_shadow(
+    shadow: &Arc<Shadow>,
+    conninfo: Option<String>,
+    replay_target: Option<u64>,
+    replay_timeout: Duration,
 ) -> Result<()> {
-    let conf = shadow_data_dir.join("postgresql.auto.conf");
-    let marker = "# walshadow shadow-listener overrides";
-    if conf.exists() {
-        let existing = fs::read_to_string(&conf).unwrap_or_default();
-        if existing.contains(marker) {
-            return Ok(());
+    let s = shadow.clone();
+    tokio::task::spawn_blocking(move || -> Result<()> {
+        if s.is_running().context("shadow status probe")? {
+            // Adopt only fires after unclean prior exit left the postmaster
+            // alive holding stale port/socket/primary_conninfo. Stop so the
+            // restart below binds params this daemon connects and streams with;
+            // start_with_floor_retry regenerates conf.
+            tracing::warn!(
+                target: "walshadow::shadow",
+                "shadow alive from unclean exit; restarting under fresh config",
+            );
+            s.stop().context("stop stale shadow before restart")?;
+        }
+        s.clear_stale_pid().context("clear stale postmaster.pid")?;
+        s.start_with_floor_retry(conninfo.as_deref())
+            .context("shadow start")?;
+        if let Some(target) = replay_target {
+            let lsn = s
+                .wait_for_replay(target, replay_timeout)
+                .context("wait for shadow replay of bootstrap end_lsn")?;
+            tracing::info!(
+                target: "walshadow::shadow",
+                replay_lsn = format_pg_lsn(lsn).to_string(),
+                "shadow caught up to bootstrap end_lsn",
+            );
+        }
+        Ok(())
+    })
+    .await
+    .context("shadow start task")?
+}
+
+const SHADOW_PROBE_INTERVAL: Duration = Duration::from_secs(2);
+const SHADOW_RESTART_BACKOFF_MAX: Duration = Duration::from_secs(60);
+
+/// Supervise daemon-owned shadow, restarting stopped postmaster with
+/// backoff. `ShadowCatalog` reconnects after restart
+/// Read minimum GUC values from `pg_control` before each restart because
+/// replayed `XLOG_PARAMETER_CHANGE` may raise them
+/// Call `shutdown` on clean exit; Drop is just a fallback, its abort
+/// can race a restart already in flight on the blocking pool
+struct ShadowLifecycle {
+    shadow: Arc<Shadow>,
+    supervisor: Option<tokio::task::JoinHandle<()>>,
+    cancel: CancellationToken,
+}
+
+impl ShadowLifecycle {
+    fn spawn(shadow: Arc<Shadow>, conninfo: Option<String>) -> Self {
+        let cancel = CancellationToken::new();
+        let supervisor = tokio::spawn(Self::supervise(shadow.clone(), conninfo, cancel.clone()));
+        Self {
+            shadow,
+            supervisor: Some(supervisor),
+            cancel,
         }
     }
-    let mut f = fs::OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(&conf)?;
-    writeln!(f, "\n{marker}")?;
-    writeln!(f, "port = {port}")?;
-    writeln!(f, "unix_socket_directories = '{}'", socket_dir.display())?;
-    writeln!(f, "listen_addresses = ''")?;
-    Ok(())
+
+    async fn supervise(shadow: Arc<Shadow>, conninfo: Option<String>, cancel: CancellationToken) {
+        let mut backoff = Duration::from_secs(1);
+        // Edge-trigger the foreign-pause log so a held operator pause does
+        // not spam once per tick
+        let mut foreign_logged = false;
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => return,
+                () = tokio::time::sleep(SHADOW_PROBE_INTERVAL) => {}
+            }
+            match probe_blocking(&shadow, |s| s.is_running()).await {
+                Some(true) => {
+                    backoff = Duration::from_secs(1);
+                    // Higher GUC requirement pauses active hot standby
+                    // Resume forces shutdown, then restart uses new values
+                    // Ignore probe errors while psql waits for consistency
+                    let s = shadow.clone();
+                    let outcome =
+                        tokio::task::spawn_blocking(move || s.try_pg_wal_replay_resume()).await;
+                    match outcome {
+                        Ok(Ok(ResumeOutcome::ResumedForFloor)) => {
+                            foreign_logged = false;
+                            tracing::warn!(
+                                target: "walshadow::shadow",
+                                "shadow replay paused because GUC value is below primary; \
+                                 resumed replay to restart with required value",
+                            );
+                        }
+                        Ok(Ok(ResumeOutcome::PausedForeign)) => {
+                            if !foreign_logged {
+                                foreign_logged = true;
+                                tracing::info!(
+                                    target: "walshadow::shadow",
+                                    "shadow replay paused for a reason other than GUC floor \
+                                     (eg operator pg_wal_replay_pause); leaving paused",
+                                );
+                            }
+                        }
+                        Ok(Ok(ResumeOutcome::NotPaused)) => foreign_logged = false,
+                        _ => {}
+                    }
+                }
+                Some(false) => {
+                    tracing::warn!(
+                        target: "walshadow::shadow",
+                        "shadow postmaster stopped, restarting",
+                    );
+                    let ci = conninfo.clone();
+                    let restarted = probe_blocking(&shadow, move |s| {
+                        s.clear_stale_pid()?;
+                        s.start_with_floor_retry(ci.as_deref())
+                    })
+                    .await;
+                    if restarted.is_some() {
+                        tracing::info!(target: "walshadow::shadow", "shadow restarted");
+                        backoff = Duration::from_secs(1);
+                    } else {
+                        tokio::select! {
+                            () = cancel.cancelled() => return,
+                            () = tokio::time::sleep(backoff) => {}
+                        }
+                        backoff = (backoff * 2).min(SHADOW_RESTART_BACKOFF_MAX);
+                    }
+                }
+                None => {}
+            }
+        }
+    }
+
+    /// Signal supervisor and join it — this waits out any probe/restart
+    /// already in flight rather than racing past it — then stop shadow
+    /// with the now-settled state. Call on every clean exit path; Drop
+    /// covers whatever this misses.
+    async fn shutdown(mut self) {
+        self.cancel.cancel();
+        if let Some(h) = self.supervisor.take()
+            && let Err(e) = h.await
+        {
+            tracing::warn!(target: "walshadow::shadow", error = %e, "shadow supervisor join failed");
+        }
+        if let Some(true) = probe_blocking(&self.shadow, |s| s.is_running()).await
+            && probe_blocking(&self.shadow, |s| s.stop()).await.is_none()
+        {
+            tracing::warn!(target: "walshadow::shadow", "shadow stop on shutdown failed");
+        }
+    }
+}
+
+/// Run blocking `pg_ctl` operation outside async runtime
+/// Return `None` after logging failure
+async fn probe_blocking<T: Send + 'static>(
+    shadow: &Arc<Shadow>,
+    op: impl FnOnce(&Shadow) -> walshadow::shadow::Result<T> + Send + 'static,
+) -> Option<T> {
+    let s = shadow.clone();
+    match tokio::task::spawn_blocking(move || op(&s)).await {
+        Ok(Ok(v)) => Some(v),
+        Ok(Err(e)) => {
+            tracing::warn!(target: "walshadow::shadow", error = %e, "shadow op failed");
+            None
+        }
+        Err(e) => {
+            tracing::warn!(target: "walshadow::shadow", error = %e, "shadow op join failed");
+            None
+        }
+    }
+}
+
+impl Drop for ShadowLifecycle {
+    fn drop(&mut self) {
+        if let Some(h) = &self.supervisor {
+            h.abort();
+        }
+        // Daemon is exiting, blocking pg_ctl cannot delay other work
+        match self.shadow.is_running() {
+            Ok(true) => {
+                if let Err(e) = self.shadow.stop() {
+                    tracing::warn!(
+                        target: "walshadow::shadow",
+                        error = %e,
+                        "shadow stop on daemon exit failed",
+                    );
+                }
+            }
+            Ok(false) => {}
+            Err(e) => tracing::warn!(
+                target: "walshadow::shadow",
+                error = %e,
+                "shadow status probe on daemon exit failed",
+            ),
+        }
+    }
 }
 
 /// Pull WAL `[start_lsn, end_lsn]` on `timeline` from wal-rus storage into
-/// `<shadow_data_dir>/pg_wal/` so auto-spawned shadow recovery hits
+/// `<shadow_data_dir>/pg_wal/` so daemon-owned shadow recovery reaches
 /// `minRecoveryPoint` from local WAL, depending on neither `restore_command`
-/// (filtered out-dir empty until the post-autospawn WAL pump) nor
-/// `primary_conninfo` (walsender binds later in `run`).
+/// (filtered out-dir stays empty until WAL pump starts) nor `primary_conninfo`
+/// (walsender binds later in `run`).
 ///
 /// `walrus::pg::backup::push::handle` sets `wal: false`, so object-store
 /// tars don't carry WAL; it lives in `wal_005/` (wal-push / archive_command).
@@ -2603,52 +2853,119 @@ async fn fetch_wal_into_pg_wal(
 mod tests {
     use super::*;
 
-    #[test]
-    fn write_standby_config_writes_signal_and_conninfo_idempotently() {
-        let tmp = tempfile::tempdir().unwrap();
-        let data = tmp.path().join("data");
-        let filt = tmp.path().join("filt");
-        let bind = "127.0.0.1:5999".parse().unwrap();
-        write_standby_config(&data, &filt, bind).unwrap();
-        assert!(data.join("standby.signal").exists());
-        let conf = fs::read_to_string(data.join("postgresql.auto.conf")).unwrap();
-        assert!(conf.contains("primary_conninfo"), "{conf}");
-        assert!(conf.contains("port=5999"), "{conf}");
-        assert!(conf.contains("restore_command"), "{conf}");
-
-        write_standby_config(&data, &filt, bind).unwrap();
-        let again = fs::read_to_string(data.join("postgresql.auto.conf")).unwrap();
-        assert_eq!(again.matches("# walshadow bootstrap").count(), 1);
+    fn args_from(argv: &[&str]) -> Args {
+        let base = [
+            "walshadow-stream",
+            "--out-dir",
+            "/tmp/out",
+            "--spill-dir",
+            "/tmp/spill",
+            "--shadow-socket-dir",
+            "/tmp/sock",
+        ];
+        Args::parse_from(base.iter().copied().chain(argv.iter().copied()))
     }
 
     #[test]
-    fn write_standby_config_skips_conninfo_when_port_zero() {
-        let tmp = tempfile::tempdir().unwrap();
-        let data = tmp.path().join("data");
-        write_standby_config(&data, tmp.path(), "127.0.0.1:0".parse().unwrap()).unwrap();
-        let conf = fs::read_to_string(data.join("postgresql.auto.conf")).unwrap();
-        assert!(!conf.contains("primary_conninfo"), "{conf}");
-        assert!(conf.contains("restore_command"), "{conf}");
+    fn shadow_start_external_without_data_dir() {
+        assert!(matches!(
+            resolve_shadow_start(&args_from(&[])).unwrap(),
+            ShadowStart::External
+        ));
+        assert!(resolve_shadow_start(&args_from(&["--bootstrap-mode", "direct"])).is_err());
     }
 
     #[test]
-    fn write_shadow_listener_overrides_sets_port_socket_and_disables_tcp() {
+    fn shadow_start_bootstrap_vs_resume_keys_on_dir_state() {
         let tmp = tempfile::tempdir().unwrap();
-        let data = tmp.path().join("data");
-        fs::create_dir_all(&data).unwrap();
-        write_shadow_listener_overrides(&data, 6543, tmp.path()).unwrap();
-        let conf = fs::read_to_string(data.join("postgresql.auto.conf")).unwrap();
-        assert!(conf.contains("port = 6543"), "{conf}");
-        assert!(conf.contains("unix_socket_directories"), "{conf}");
-        assert!(conf.contains("listen_addresses = ''"), "{conf}");
+        let dir = tmp.path().join("data");
+        std::fs::create_dir_all(&dir).unwrap();
+        let dir_str = dir.to_str().unwrap();
+        let direct = |d: &str| {
+            args_from(&[
+                "--bootstrap-mode",
+                "direct",
+                "--bootstrap-shadow-data-dir",
+                d,
+                "--walsender-bind",
+                "127.0.0.1:5555",
+            ])
+        };
+        let off = |d: &str| {
+            args_from(&[
+                "--bootstrap-shadow-data-dir",
+                d,
+                "--walsender-bind",
+                "127.0.0.1:5555",
+            ])
+        };
 
-        write_shadow_listener_overrides(&data, 6543, tmp.path()).unwrap();
-        let again = fs::read_to_string(data.join("postgresql.auto.conf")).unwrap();
-        assert_eq!(
-            again
-                .matches("# walshadow shadow-listener overrides")
-                .count(),
-            1
+        // Direct bootstraps empty dir, off rejects it
+        assert!(matches!(
+            resolve_shadow_start(&direct(dir_str)).unwrap(),
+            ShadowStart::Bootstrap(_)
+        ));
+        assert!(resolve_shadow_start(&off(dir_str)).is_err());
+
+        // Resume initialized dir regardless of mode
+        std::fs::write(dir.join("PG_VERSION"), b"17\n").unwrap();
+        assert!(matches!(
+            resolve_shadow_start(&direct(dir_str)).unwrap(),
+            ShadowStart::Resume(_)
+        ));
+        assert!(matches!(
+            resolve_shadow_start(&off(dir_str)).unwrap(),
+            ShadowStart::Resume(_)
+        ));
+
+        // Incomplete bootstrap never triggers automatic rebootstrap
+        std::fs::write(dir.join(BOOTSTRAP_INCOMPLETE_MARKER), b"").unwrap();
+        assert!(resolve_shadow_start(&direct(dir_str)).is_err());
+        assert!(resolve_shadow_start(&off(dir_str)).is_err());
+        assert!(dir.join("PG_VERSION").exists());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn prepare_bootstrap_dir_marks_empty_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("data");
+        prepare_bootstrap_dir(&dir).await.unwrap();
+        assert!(dir.join(BOOTSTRAP_INCOMPLETE_MARKER).exists());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn prepare_bootstrap_dir_refuses_nonempty_dir_without_deleting_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("data");
+        std::fs::create_dir_all(dir.join("sibling-archive")).unwrap();
+        assert!(prepare_bootstrap_dir(&dir).await.is_err());
+        assert!(dir.join("sibling-archive").exists());
+    }
+
+    #[test]
+    fn shadow_start_rejects_kernel_picked_port_for_owned_shadow() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("data");
+        std::fs::create_dir_all(&dir).unwrap();
+        let dir_str = dir.to_str().unwrap();
+        // Default --walsender-bind is 127.0.0.1:0 (kernel-picked); daemon
+        // can't bake an unknown port into shadow's primary_conninfo.
+        assert!(
+            resolve_shadow_start(&args_from(&[
+                "--bootstrap-mode",
+                "direct",
+                "--bootstrap-shadow-data-dir",
+                dir_str,
+            ]))
+            .is_err()
         );
+    }
+
+    #[test]
+    fn walsender_conninfo_skipped_on_kernel_picked_port() {
+        assert!(walsender_primary_conninfo("127.0.0.1:0".parse().unwrap()).is_none());
+        let ci = walsender_primary_conninfo("127.0.0.1:5441".parse().unwrap()).unwrap();
+        assert!(ci.contains("host=127.0.0.1"), "{ci}");
+        assert!(ci.contains("port=5441"), "{ci}");
     }
 }

--- a/src/catalog/shadow.rs
+++ b/src/catalog/shadow.rs
@@ -1,20 +1,24 @@
-//! Shadow Postgres lifecycle: the co-located instance walshadow uses
-//! as catalog mirror & decode oracle. Wraps PG binaries (`initdb`,
-//! `pg_ctl`, `psql`) + on-disk plumbing (`postgresql.conf`,
-//! `standby.signal`, `restore_command`).
+//! Manage co-located Postgres used as catalog mirror and decode oracle
+//! Run PG binaries (`initdb`, `pg_ctl`, `psql`) and write config files
+//! (`postgresql.conf`, `standby.signal`, `restore_command`)
 //!
-//! Bootstrap: [`initdb`](Shadow::initdb),
+//! Daemon path: [`control_guc_floor`](Shadow::control_guc_floor),
+//! [`materialize_conf`](Shadow::materialize_conf),
+//! [`write_standby_signal`](Shadow::write_standby_signal),
+//! [`clear_stale_pid`](Shadow::clear_stale_pid),
+//! [`start_with_floor_retry`](Shadow::start_with_floor_retry),
+//! [`wait_for_replay`](Shadow::wait_for_replay),
+//! [`is_running`](Shadow::is_running),
+//! [`try_pg_wal_replay_resume`](Shadow::try_pg_wal_replay_resume),
+//! [`health`](Shadow::health),
+//! [`stop`](Shadow::stop). Test harness: [`initdb`](Shadow::initdb),
 //! [`write_base_conf`](Shadow::write_base_conf),
-//! [`start`](Shadow::start), [`apply_schema_dump`](Shadow::apply_schema_dump),
-//! [`stop`](Shadow::stop),
-//! [`enable_standby_recovery`](Shadow::enable_standby_recovery),
-//! [`start`](Shadow::start), [`wait_for_replay`](Shadow::wait_for_replay),
-//! [`health`](Shadow::health).
+//! [`apply_schema_dump`](Shadow::apply_schema_dump),
+//! [`enable_standby_recovery`](Shadow::enable_standby_recovery).
 //!
-//! `standby.signal` not `recovery.signal`: shadow is a *standby*.
-//! `recovery.signal` exits recovery when archive WAL runs out; wrong
-//! primitive. `standby.signal` stays in continuous recovery, retrying
-//! `restore_command` on each new filter-landed segment.
+//! Use `standby.signal`, not `recovery.signal`. Recovery signal ends
+//! recovery when archive runs out. Standby signal keeps recovery active
+//! and retries `primary_conninfo`, then `restore_command`
 
 use std::fs;
 use std::io::Write;
@@ -37,6 +41,8 @@ pub enum ShadowError {
     },
     #[error("psql parse: {0}")]
     PsqlParse(String),
+    #[error("pg_controldata parse: {0}")]
+    ControlDataParse(String),
     #[error("timeout waiting for {what} after {elapsed:?}")]
     Timeout { what: String, elapsed: Duration },
     #[error("shadow not in recovery (probe returned f)")]
@@ -62,6 +68,12 @@ pub struct ShadowConfig {
     /// `pg_ctl -t`, both start and stop.
     pub ctl_timeout: Duration,
     pub wait_poll: Duration,
+    /// `-U` for `initdb` and all probe connections. Must match a role
+    /// that exists post-seed, ie source's superuser role name on
+    /// managed Postgres where it isn't literally `postgres`.
+    pub user: String,
+    /// `-d` for all probe connections.
+    pub dbname: String,
 }
 
 impl ShadowConfig {
@@ -78,6 +90,8 @@ impl ShadowConfig {
             pg_bin_dir: None,
             ctl_timeout: Duration::from_secs(60),
             wait_poll: Duration::from_millis(200),
+            user: "postgres".to_string(),
+            dbname: "postgres".to_string(),
         }
     }
 
@@ -95,6 +109,56 @@ impl ShadowConfig {
     fn socket_str(&self) -> &str {
         self.socket_dir.to_str().expect("non-utf8 socket_dir")
     }
+}
+
+/// Minimum standby GUC values
+/// PG `CheckRequiredParameterValues` refuses hot standby startup when
+/// any value is below primary value stored in `pg_control`
+/// Read values from shadow using [`control_guc_floor`](Shadow::control_guc_floor)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceGucFloor {
+    pub max_connections: u32,
+    pub max_worker_processes: u32,
+    pub max_wal_senders: u32,
+    pub max_prepared_transactions: u32,
+    pub max_locks_per_transaction: u32,
+}
+
+impl Default for SourceGucFloor {
+    /// PG defaults for initdb cluster without source requirements
+    fn default() -> Self {
+        Self {
+            max_connections: 100,
+            max_worker_processes: 8,
+            max_wal_senders: 10,
+            max_prepared_transactions: 0,
+            max_locks_per_transaction: 64,
+        }
+    }
+}
+
+impl SourceGucFloor {
+    /// True when any field requires more than `running` provides, ie the
+    /// state that pauses hot standby after `XLOG_PARAMETER_CHANGE`
+    fn exceeds(&self, running: &SourceGucFloor) -> bool {
+        self.max_connections > running.max_connections
+            || self.max_worker_processes > running.max_worker_processes
+            || self.max_wal_senders > running.max_wal_senders
+            || self.max_prepared_transactions > running.max_prepared_transactions
+            || self.max_locks_per_transaction > running.max_locks_per_transaction
+    }
+}
+
+/// Outcome of [`try_pg_wal_replay_resume`](Shadow::try_pg_wal_replay_resume)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResumeOutcome {
+    /// Replay running normally
+    NotPaused,
+    /// Paused by raised GUC floor; resumed to force shutdown then restart
+    ResumedForFloor,
+    /// Paused for another reason (operator `pg_wal_replay_pause`, recovery
+    /// target); left untouched so the pause holds
+    PausedForeign,
 }
 
 /// One-shot recovery & catalog state snapshot.
@@ -137,7 +201,7 @@ impl Shadow {
                 "-D",
                 self.config.data_str(),
                 "-U",
-                "postgres",
+                self.config.user.as_str(),
                 "--auth=trust",
                 "--encoding=UTF8",
                 "--locale=C",
@@ -157,7 +221,7 @@ impl Shadow {
              wal_level = replica\n\
              max_wal_senders = 0\n\
              autovacuum = off\n\
-             fsync = off\n\
+             fsync = on\n\
              full_page_writes = on\n\
              listen_addresses = ''\n\
              unix_socket_directories = '{sock}'\n\
@@ -169,6 +233,93 @@ impl Shadow {
         let mut f = fs::OpenOptions::new().append(true).open(&conf_path)?;
         f.write_all(body.as_bytes())?;
         Ok(())
+    }
+
+    /// Replace data dir config with walshadow settings
+    /// Write base, recovery, and minimum GUC settings to `postgresql.conf`
+    /// Empty `postgresql.auto.conf` so source `ALTER SYSTEM` settings from
+    /// BASE_BACKUP cannot override them. Allow trusted socket connections
+    /// in `pg_hba.conf` and empty `pg_ident.conf`
+    /// Do not depend on backup config because Debian stores it outside data
+    /// dir under `/etc/postgresql/<v>/<cluster>`
+    pub fn materialize_conf(
+        &self,
+        floor: &SourceGucFloor,
+        primary_conninfo: Option<&str>,
+    ) -> Result<()> {
+        let filter_dir = self
+            .config
+            .filter_out_dir
+            .to_str()
+            .expect("non-utf8 filter_out_dir");
+        let mut conf = format!(
+            "# walshadow-owned conf, regenerated each boot\n\
+             hot_standby = on\n\
+             wal_level = replica\n\
+             autovacuum = off\n\
+             fsync = on\n\
+             full_page_writes = on\n\
+             listen_addresses = ''\n\
+             unix_socket_directories = '{sock}'\n\
+             port = {port}\n\
+             shared_buffers = 32MB\n\
+             max_connections = {max_connections}\n\
+             max_worker_processes = {max_worker_processes}\n\
+             max_wal_senders = {max_wal_senders}\n\
+             max_prepared_transactions = {max_prepared_transactions}\n\
+             max_locks_per_transaction = {max_locks_per_transaction}\n\
+             restore_command = 'cp {filter_dir}/%f %p'\n\
+             recovery_target_timeline = 'latest'\n",
+            sock = self.config.socket_str(),
+            port = self.config.port,
+            max_connections = floor.max_connections,
+            max_worker_processes = floor.max_worker_processes,
+            max_wal_senders = floor.max_wal_senders,
+            max_prepared_transactions = floor.max_prepared_transactions,
+            max_locks_per_transaction = floor.max_locks_per_transaction,
+        );
+        if let Some(conninfo) = primary_conninfo {
+            // Escape single quotes in PostgreSQL config string
+            let escaped = conninfo.replace('\'', "''");
+            conf.push_str(&format!("primary_conninfo = '{escaped}'\n"));
+        }
+        let d = &self.config.data_dir;
+        fs::write(d.join("postgresql.conf"), conf)?;
+        fs::write(
+            d.join("postgresql.auto.conf"),
+            "# walshadow: emptied, all config lives in postgresql.conf\n",
+        )?;
+        fs::write(
+            d.join("pg_hba.conf"),
+            "# walshadow-owned hba: socket-only, no TCP (listen_addresses = '')\n\
+             local all all trust\n\
+             local replication all trust\n",
+        )?;
+        fs::write(d.join("pg_ident.conf"), "# walshadow: unused\n")?;
+        Ok(())
+    }
+
+    /// Create empty `standby.signal`
+    pub fn write_standby_signal(&self) -> Result<()> {
+        fs::write(self.config.data_dir.join("standby.signal"), b"")?;
+        Ok(())
+    }
+
+    /// Return whether data dir contains initialized cluster
+    pub fn data_dir_initialized(&self) -> bool {
+        self.config.data_dir.join("PG_VERSION").exists()
+    }
+
+    /// Remove `postmaster.pid` left by stopped postmaster
+    /// Call only after [`is_running`](Self::is_running) returns false
+    /// Return whether file was removed
+    pub fn clear_stale_pid(&self) -> Result<bool> {
+        let pid = self.config.data_dir.join("postmaster.pid");
+        match fs::remove_file(&pid) {
+            Ok(()) => Ok(true),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(e.into()),
+        }
     }
 
     /// Drop `standby.signal` + append `primary_conninfo` and
@@ -199,7 +350,7 @@ impl Shadow {
 
     pub fn start(&self) -> Result<()> {
         let log = self.config.data_dir.join("startup.log");
-        self.run(
+        let res = self.run(
             "pg_ctl",
             [
                 "-D",
@@ -211,8 +362,62 @@ impl Shadow {
                 &self.config.ctl_timeout.as_secs().to_string(),
                 "start",
             ],
-        )?;
-        Ok(())
+        );
+        match res {
+            Ok(_) => Ok(()),
+            // pg_ctl only reports "could not start server"
+            // Include log where Postgres reports required GUC value
+            Err(ShadowError::Process {
+                cmd,
+                status,
+                stderr,
+            }) => Err(ShadowError::Process {
+                cmd,
+                status,
+                stderr: format!("{stderr}\nstartup.log tail:\n{}", log_tail(&log)),
+            }),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Read minimum standby GUC values from local `pg_control`
+    /// Seed copies source file. Replayed `XLOG_PARAMETER_CHANGE` updates it
+    /// before startup stops, so next attempt reads new values
+    pub fn control_guc_floor(&self) -> Result<SourceGucFloor> {
+        let out = Command::new(self.config.bin("pg_controldata"))
+            .args(["-D", self.config.data_str()])
+            // Keep labels stable for parser
+            .env("LC_ALL", "C")
+            .output()
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    ShadowError::MissingBinary("pg_controldata".into())
+                } else {
+                    ShadowError::Io(e)
+                }
+            })?;
+        let out = self.check("pg_controldata", out)?;
+        parse_controldata_floor(&String::from_utf8_lossy(&out.stdout))
+    }
+
+    /// Write config with values from `pg_control` and start shadow
+    /// If failed start updates required values, rewrite config and retry
+    /// Return original error when values did not change
+    pub fn start_with_floor_retry(&self, primary_conninfo: Option<&str>) -> Result<()> {
+        let mut floor = self.control_guc_floor()?;
+        loop {
+            self.materialize_conf(&floor, primary_conninfo)?;
+            let err = match self.start() {
+                Ok(()) => return Ok(()),
+                Err(e) => e,
+            };
+            let raised = self.control_guc_floor()?;
+            if raised == floor {
+                return Err(err);
+            }
+            self.clear_stale_pid()?;
+            floor = raised;
+        }
     }
 
     pub fn stop(&self) -> Result<()> {
@@ -265,9 +470,9 @@ impl Shadow {
                 "-p",
                 &self.config.port.to_string(),
                 "-U",
-                "postgres",
+                self.config.user.as_str(),
                 "-d",
-                "postgres",
+                self.config.dbname.as_str(),
                 "-v",
                 "ON_ERROR_STOP=1",
                 "-f",
@@ -298,9 +503,9 @@ impl Shadow {
                 "-p",
                 &self.config.port.to_string(),
                 "-U",
-                "postgres",
+                self.config.user.as_str(),
                 "-d",
-                "postgres",
+                self.config.dbname.as_str(),
                 "-tAXq",
                 "-c",
                 sql,
@@ -355,6 +560,57 @@ impl Shadow {
         }
     }
 
+    /// Resume only a GUC-floor pause; leave other pauses intact
+    /// Low hot standby GUC pauses replay after `XLOG_PARAMETER_CHANGE`,
+    /// which writes the raised values to `pg_control` before pausing, so
+    /// `control_guc_floor` exceeding the running settings identifies that
+    /// cause. Resume shuts server down, then next
+    /// [`start_with_floor_retry`](Self::start_with_floor_retry) reads new
+    /// value from `pg_control`. An operator `pg_wal_replay_pause` (or a
+    /// recovery-target pause) leaves floor equal to running, so it holds
+    pub fn try_pg_wal_replay_resume(&self) -> Result<ResumeOutcome> {
+        if self.psql_one("SELECT pg_get_wal_replay_pause_state()")? == "not paused" {
+            return Ok(ResumeOutcome::NotPaused);
+        }
+        if !self
+            .control_guc_floor()?
+            .exceeds(&self.running_guc_floor()?)
+        {
+            return Ok(ResumeOutcome::PausedForeign);
+        }
+        self.psql_one("SELECT pg_wal_replay_resume()")?;
+        Ok(ResumeOutcome::ResumedForFloor)
+    }
+
+    /// Read running GUC values with `current_setting`. Compare to
+    /// [`control_guc_floor`](Self::control_guc_floor) to tell a floor-raise
+    /// pause apart from other replay pauses
+    fn running_guc_floor(&self) -> Result<SourceGucFloor> {
+        let row = self.psql_one(
+            "SELECT current_setting('max_connections'), \
+             current_setting('max_worker_processes'), \
+             current_setting('max_wal_senders'), \
+             current_setting('max_prepared_transactions'), \
+             current_setting('max_locks_per_transaction')",
+        )?;
+        let mut cols = row.split('|');
+        let mut next = |name: &str| -> Result<u32> {
+            cols.next()
+                .ok_or_else(|| ShadowError::PsqlParse(format!("missing {name}")))
+                .and_then(|v| {
+                    v.parse()
+                        .map_err(|_| ShadowError::PsqlParse(format!("{name} {v:?}")))
+                })
+        };
+        Ok(SourceGucFloor {
+            max_connections: next("max_connections")?,
+            max_worker_processes: next("max_worker_processes")?,
+            max_wal_senders: next("max_wal_senders")?,
+            max_prepared_transactions: next("max_prepared_transactions")?,
+            max_locks_per_transaction: next("max_locks_per_transaction")?,
+        })
+    }
+
     pub fn health(&self) -> Result<HealthReport> {
         let in_recovery = self.is_in_recovery()?;
         let replay_lsn = self.last_replay_lsn()?;
@@ -402,6 +658,42 @@ impl Shadow {
     }
 }
 
+/// Parse required GUC values from `pg_controldata`
+/// `LC_ALL=C` keeps labels stable; two labels use abbreviated `xact`
+fn parse_controldata_floor(text: &str) -> Result<SourceGucFloor> {
+    let find = |key: &str| -> Result<u32> {
+        text.lines()
+            .find_map(|line| line.strip_prefix(key))
+            .ok_or_else(|| ShadowError::ControlDataParse(format!("missing {key:?}")))
+            .and_then(|rest| {
+                let v = rest.trim();
+                v.parse()
+                    .map_err(|_| ShadowError::ControlDataParse(format!("{key} {v:?}")))
+            })
+    };
+    Ok(SourceGucFloor {
+        max_connections: find("max_connections setting:")?,
+        max_worker_processes: find("max_worker_processes setting:")?,
+        max_wal_senders: find("max_wal_senders setting:")?,
+        max_prepared_transactions: find("max_prepared_xacts setting:")?,
+        max_locks_per_transaction: find("max_locks_per_xact setting:")?,
+    })
+}
+
+/// Read end of log, where appended `pg_ctl -l` writes latest attempt
+fn log_tail(path: &Path) -> String {
+    use std::io::{Read, Seek, SeekFrom};
+    const TAIL: u64 = 4096;
+    let Ok(mut f) = fs::File::open(path) else {
+        return "<unreadable>".into();
+    };
+    let len = f.metadata().map(|m| m.len()).unwrap_or(0);
+    let _ = f.seek(SeekFrom::Start(len.saturating_sub(TAIL)));
+    let mut buf = Vec::new();
+    let _ = f.read_to_end(&mut buf);
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -427,6 +719,72 @@ mod tests {
     }
 
     #[test]
+    fn parse_controldata_floor_reads_all_five() {
+        let text = "pg_control version number:            1300\n\
+                    max_connections setting:              500\n\
+                    max_worker_processes setting:         16\n\
+                    max_wal_senders setting:              12\n\
+                    max_prepared_xacts setting:           2\n\
+                    max_locks_per_xact setting:           128\n\
+                    WAL block size:                       8192\n";
+        let floor = parse_controldata_floor(text).unwrap();
+        assert_eq!(
+            floor,
+            SourceGucFloor {
+                max_connections: 500,
+                max_worker_processes: 16,
+                max_wal_senders: 12,
+                max_prepared_transactions: 2,
+                max_locks_per_transaction: 128,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_controldata_floor_rejects_missing_key() {
+        let err = parse_controldata_floor("max_connections setting: 100\n").unwrap_err();
+        assert!(matches!(err, ShadowError::ControlDataParse(_)), "{err}");
+    }
+
+    #[test]
+    fn floor_exceeds_running_only_when_some_field_higher() {
+        let running = SourceGucFloor::default();
+        // Equal floor is an operator/other pause, not a raised requirement
+        assert!(!running.exceeds(&running));
+        // Any single raised field flags the parameter-change pause
+        for raised in [
+            SourceGucFloor {
+                max_connections: running.max_connections + 1,
+                ..running
+            },
+            SourceGucFloor {
+                max_worker_processes: running.max_worker_processes + 1,
+                ..running
+            },
+            SourceGucFloor {
+                max_wal_senders: running.max_wal_senders + 1,
+                ..running
+            },
+            SourceGucFloor {
+                max_prepared_transactions: running.max_prepared_transactions + 1,
+                ..running
+            },
+            SourceGucFloor {
+                max_locks_per_transaction: running.max_locks_per_transaction + 1,
+                ..running
+            },
+        ] {
+            assert!(raised.exceeds(&running), "{raised:?}");
+        }
+        // Lower control floor than running never counts as exceeding
+        let lower = SourceGucFloor {
+            max_connections: running.max_connections - 1,
+            ..running
+        };
+        assert!(!lower.exceeds(&running));
+    }
+
+    #[test]
     fn config_socket_dir_default_sits_next_to_data_dir() {
         let cfg = ShadowConfig::new(
             PathBuf::from("/tmp/walshadow-test/data"),
@@ -436,6 +794,89 @@ mod tests {
             cfg.socket_dir,
             PathBuf::from("/tmp/walshadow-test/shadow_sock")
         );
+    }
+
+    #[test]
+    fn materialize_conf_owns_every_conf_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        fs::create_dir_all(&data_dir).unwrap();
+        // Replace source config copied by BASE_BACKUP
+        fs::write(data_dir.join("postgresql.conf"), b"port = 5432\n").unwrap();
+        fs::write(
+            data_dir.join("postgresql.auto.conf"),
+            b"listen_addresses = '*'\n",
+        )
+        .unwrap();
+        let mut cfg = ShadowConfig::new(data_dir.clone(), tmp.path().join("filtered"));
+        cfg.port = 5440;
+        let shadow = Shadow::new(cfg);
+        let floor = SourceGucFloor {
+            max_connections: 500,
+            ..SourceGucFloor::default()
+        };
+        shadow
+            .materialize_conf(&floor, Some("host=127.0.0.1 port=5441 user=walshadow"))
+            .unwrap();
+
+        let conf = fs::read_to_string(data_dir.join("postgresql.conf")).unwrap();
+        assert!(conf.contains("port = 5440"), "{conf}");
+        assert!(
+            !conf.contains("port = 5432"),
+            "source config must be replaced: {conf}"
+        );
+        assert!(conf.contains("fsync = on"), "{conf}");
+        assert!(conf.contains("max_connections = 500"), "{conf}");
+        assert!(conf.contains("max_locks_per_transaction = 64"), "{conf}");
+        assert!(conf.contains("restore_command"), "{conf}");
+        assert!(conf.contains("recovery_target_timeline"), "{conf}");
+        assert!(
+            conf.contains("primary_conninfo = 'host=127.0.0.1"),
+            "{conf}"
+        );
+
+        let auto = fs::read_to_string(data_dir.join("postgresql.auto.conf")).unwrap();
+        assert!(
+            !auto.contains("listen_addresses"),
+            "auto.conf must be empty: {auto}"
+        );
+        let hba = fs::read_to_string(data_dir.join("pg_hba.conf")).unwrap();
+        assert!(hba.contains("local replication all trust"), "{hba}");
+        assert!(!hba.contains("host "), "socket-only: {hba}");
+        assert!(data_dir.join("pg_ident.conf").exists());
+    }
+
+    #[test]
+    fn materialize_conf_skips_conninfo_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        fs::create_dir_all(&data_dir).unwrap();
+        let cfg = ShadowConfig::new(data_dir.clone(), tmp.path().join("filtered"));
+        let shadow = Shadow::new(cfg);
+        shadow
+            .materialize_conf(&SourceGucFloor::default(), None)
+            .unwrap();
+        let conf = fs::read_to_string(data_dir.join("postgresql.conf")).unwrap();
+        assert!(!conf.contains("primary_conninfo"), "{conf}");
+        assert!(conf.contains("restore_command"), "{conf}");
+    }
+
+    #[test]
+    fn clear_stale_pid_reports_removal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        fs::create_dir_all(&data_dir).unwrap();
+        let shadow = Shadow::new(ShadowConfig::new(
+            data_dir.clone(),
+            tmp.path().join("filtered"),
+        ));
+        assert!(!shadow.data_dir_initialized());
+        assert!(!shadow.clear_stale_pid().unwrap());
+        fs::write(data_dir.join("postmaster.pid"), b"1234\n").unwrap();
+        assert!(shadow.clear_stale_pid().unwrap());
+        assert!(!data_dir.join("postmaster.pid").exists());
+        fs::write(data_dir.join("PG_VERSION"), b"17\n").unwrap();
+        assert!(shadow.data_dir_initialized());
     }
 
     #[test]

--- a/src/emit/ch_emitter.rs
+++ b/src/emit/ch_emitter.rs
@@ -116,10 +116,10 @@ pub struct EmitterConfig {
     /// via `[namespace.<ns>] drop_table_strategy = ...`
     pub drop_table_strategy: String,
     pub retry: RetryConfig,
-    /// Wall-clock cap on a single INSERT attempt. A connection that
-    /// wedges mid-INSERT surfaces as retryable [`EmitterError::Timeout`]
-    /// so the inserter reconnects + resends rather than pinning the
-    /// durable watermark forever. Sized far above a healthy round-trip.
+    /// Wall-clock limit for one INSERT attempt. If connection stalls
+    /// mid-INSERT, return retryable [`EmitterError::Timeout`] so inserter
+    /// reconnects and resends without blocking durable watermark
+    /// Set well above healthy round-trip time
     pub insert_timeout: Duration,
     /// A CH connection idle longer than this may be half-open (NAT/LB/CH
     /// idle-reap); reconnect before the next op instead of blocking the

--- a/src/ops/retention.rs
+++ b/src/ops/retention.rs
@@ -87,6 +87,33 @@ pub async fn trim_below_lsn(dir: &Path, cutoff_lsn: u64) -> Result<TrimReport, R
     Ok(report)
 }
 
+/// Return highest end LSN among sealed segments in `dir`
+/// Return `None` when no sealed segment exists
+/// Ignore `.partial` files because `restore_command` serves only sealed
+/// segments
+pub async fn max_segment_end(dir: &Path) -> Result<Option<u64>, RetentionError> {
+    let mut max_end = None;
+    if !dir.exists() {
+        return Ok(max_end);
+    }
+    let mut rd = tokio::fs::read_dir(dir).await?;
+    while let Some(entry) = rd.next_entry().await? {
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let (seg_str, kind) = classify(&name);
+        if !matches!(kind, FileKind::Segment) {
+            continue;
+        }
+        let Some(seg) = seg_str.and_then(|s| SegmentName::parse(s).ok()) else {
+            continue;
+        };
+        let end = seg.start_lsn(WAL_SEG_SIZE).saturating_add(WAL_SEG_SIZE);
+        max_end = Some(max_end.map_or(end, |m: u64| m.max(end)));
+    }
+    Ok(max_end)
+}
+
 #[derive(Debug, Clone, Copy)]
 enum FileKind {
     Segment,
@@ -223,6 +250,33 @@ mod tests {
         let report = trim_below_lsn(dir, u64::MAX).await.unwrap();
         assert_eq!(report.segments_removed, 0);
         assert!(dir.join(raw).exists());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn max_segment_end_keys_on_sealed_segments_only() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        assert_eq!(max_segment_end(dir).await.unwrap(), None);
+        touch(dir, &seg_name(1, 0, 2), b"seg");
+        touch(dir, &seg_name(1, 0, 4), b"seg");
+        // Ignore partial segment, manifest, and unrelated file
+        touch(dir, &format!("{}.partial", seg_name(1, 0, 7)), b"p");
+        touch(dir, &format!("{}.manifest.json", seg_name(1, 0, 7)), b"{}");
+        touch(dir, "README", b"hi");
+        let want = SegmentName {
+            timeline: 1,
+            log_id: 0,
+            seg_no: 4,
+        }
+        .start_lsn(WAL_SEG_SIZE)
+            + WAL_SEG_SIZE;
+        assert_eq!(max_segment_end(dir).await.unwrap(), Some(want));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn max_segment_end_missing_dir_is_none() {
+        let missing = std::path::Path::new("/this/path/does/not/exist/walshadow-retention-test");
+        assert_eq!(max_segment_end(missing).await.unwrap(), None);
     }
 
     #[test]

--- a/src/xact/xact_buffer.rs
+++ b/src/xact/xact_buffer.rs
@@ -1454,7 +1454,7 @@ impl XactBuffer {
 /// Tracks bytes resident inside an active drain. One instance per
 /// category (merge heads / sealed chunk generations / mirror rows), all
 /// feeding one total. Contribution subtracts on drop so an abandoned
-/// drain (observer error) can't wedge the gauge.
+/// drain (observer error) can't leave the gauge stuck.
 struct ResidentGauge {
     cur: Arc<AtomicU64>,
     peak: Arc<AtomicU64>,

--- a/tests/bootstrap_direct_ch.rs
+++ b/tests/bootstrap_direct_ch.rs
@@ -5,7 +5,7 @@
 //! direct bootstrap pipeline against a `RecordingObserver` (no live
 //! CH). This drill runs the real daemon binary
 //! (`target/debug/walshadow-stream`) with
-//! `--bootstrap-mode=direct --bootstrap-autospawn-shadow --ch-config`
+//! `--bootstrap-mode=direct --bootstrap-shadow-data-dir --ch-config`
 //! against a self-hosted source PG + spawned `clickhouse server`,
 //! then verifies the bootstrap rows land in CH end-to-end.
 //!
@@ -18,7 +18,7 @@
 //!         → run_bootstrap (DirectSource BASE_BACKUP → MultiplexSink)
 //!         → pipeline::bootstrap::drain → shared tail (batcher + inserter
 //!           pool + ack) → CH default.t
-//!         → autospawn shadow PG against bootstrap_shadow_data_dir
+//!         → start shadow PG against bootstrap_shadow_data_dir
 //!         → ShadowCatalog connect + preflight + WAL pump
 //!   → assert_ch_matches_source(ch, source, "s14.t", "default.t")
 //! ```
@@ -115,11 +115,8 @@ async fn direct_bootstrap_ch_end_to_end() {
     )
     .expect("write ch-config");
 
-    // 5. Shadow data dir + socket layout for the daemon's autospawn.
-    //    `--bootstrap-autospawn-shadow` writes the shadow-side
-    //    `port` / `unix_socket_directories` / `listen_addresses`
-    //    overrides into the cloned data dir's postgresql.auto.conf and
-    //    asserts mode 0700 before pg_ctl start.
+    // 5. Shadow data dir and socket layout. Daemon writes listener
+    //    config and sets data dir mode to 0700 before pg_ctl start
     let bootstrap_shadow_data_dir = tmp.path().join("shadow-data");
     let shadow_sock = tmp.path().join("shadow-sock");
     fs::create_dir_all(&shadow_sock).unwrap();
@@ -178,7 +175,6 @@ async fn direct_bootstrap_ch_end_to_end() {
             "direct",
             "--bootstrap-shadow-data-dir",
             bootstrap_shadow_data_dir.to_str().unwrap(),
-            "--bootstrap-autospawn-shadow",
             "--bootstrap-shadow-replay-timeout",
             "120",
         ])
@@ -189,14 +185,10 @@ async fn direct_bootstrap_ch_end_to_end() {
         .spawn()
         .expect("spawn walshadow-stream");
     let guard = fx::ChildGuard::new(child);
-    // Drop guard for the shadow PG the daemon's autospawn brings up —
-    // stops it after the test so leftover postmasters don't linger.
-    // SAFETY: only set up paths; we'll attach the Shadow handle after
-    // the daemon has exited so we can issue pg_ctl stop against it.
 
     let result = (|| -> Result<()> {
         // 7. Wait for the daemon's metrics endpoint. Crossing this
-        //    barrier means: bootstrap finished, autospawn'd shadow is
+        //    barrier means: bootstrap finished, daemon-owned shadow is
         //    serving, preflight passed, WAL pump is in its main loop.
         //    The bootstrap tail's `wait_through(K)` makes every backfill
         //    row durable on CH before the daemon hands off to the streaming
@@ -214,9 +206,12 @@ async fn direct_bootstrap_ch_end_to_end() {
         Ok(())
     })();
 
-    // 11. Tear down the autospawn'd shadow PG so the data dir's
-    //     postmaster is reaped before tempdir cleanup. The daemon
-    //     doesn't stop shadow on its own (autospawn is start-only).
+    // 11. Kill daemon before shadow so supervisor cannot restart it
+    //     SIGKILL skips shadow cleanup, stop any remaining postmaster
+    let _ = guard.into_inner().map(|mut c| {
+        let _ = c.kill();
+        let _ = c.wait();
+    });
     if bootstrap_shadow_data_dir.join("postmaster.pid").exists() {
         let mut shadow_cfg =
             ShadowConfig::new(bootstrap_shadow_data_dir.clone(), shadow_filter_dir.clone());
@@ -226,11 +221,6 @@ async fn direct_bootstrap_ch_end_to_end() {
         let shadow = Shadow::new(shadow_cfg);
         let _ = shadow.stop();
     }
-    // Drain guard so any leftover child also gets cleaned.
-    let _ = guard.into_inner().map(|mut c| {
-        let _ = c.kill();
-        let _ = c.wait();
-    });
 
     if let Err(e) = result {
         let stderr = fs::read_to_string(&stderr_path).unwrap_or_default();

--- a/tests/bootstrap_object_store_ch.rs
+++ b/tests/bootstrap_object_store_ch.rs
@@ -19,7 +19,7 @@
 //!         --bootstrap-backup-name=<resolved>
 //!     → ObjectStoreSource → MultiplexSink → pipeline::bootstrap::drain
 //!     → shared tail (batcher + inserter pool + ack) → default.t
-//!     → autospawn shadow PG against bootstrap_shadow_data_dir
+//!     → start shadow PG against bootstrap_shadow_data_dir
 //!     → WAL pump main loop
 //!   → assert_ch_matches_source(ch, source, "s14.t", "default.t")
 //! ```
@@ -209,9 +209,8 @@ async fn object_store_bootstrap_ch_end_to_end() {
     )
     .expect("write ch-config");
 
-    // 6. Shadow layout. `--bootstrap-autospawn-shadow` writes port +
-    //    socket overrides into the cloned data dir's auto.conf, so the
-    //    test no longer pre-seeds source-side overrides.
+    // 6. Shadow layout. Daemon writes port and socket config, so test
+    //    does not add source settings before bootstrap
     let bootstrap_shadow_data_dir = tmp.path().join("shadow-data");
     let shadow_sock = tmp.path().join("shadow-sock");
     fs::create_dir_all(&shadow_sock).unwrap();
@@ -269,7 +268,6 @@ async fn object_store_bootstrap_ch_end_to_end() {
             bootstrap_shadow_data_dir.to_str().unwrap(),
             "--bootstrap-backup-name",
             &backup_name,
-            "--bootstrap-autospawn-shadow",
             "--bootstrap-shadow-replay-timeout",
             "120",
         ])
@@ -290,8 +288,8 @@ async fn object_store_bootstrap_ch_end_to_end() {
     let guard = fx::ChildGuard::new(child);
 
     let result = (|| -> Result<()> {
-        // 8. Wait for the daemon's metrics endpoint — bootstrap done,
-        //    autospawn'd shadow live, WAL pump alive. Bootstrap-emitter
+        // 8. Wait for daemon's metrics endpoint, bootstrap done,
+        //    daemon-owned shadow live, WAL pump alive. Bootstrap-emitter
         //    INSERTs flush to CH synchronously before the streaming
         //    pump starts, so the 64-row fixture lands on CH by this
         //    point.
@@ -307,7 +305,12 @@ async fn object_store_bootstrap_ch_end_to_end() {
         Ok(())
     })();
 
-    // 12. Tear down autospawn'd shadow PG.
+    // 12. Kill daemon before shadow so supervisor cannot restart it
+    //     Stop any remaining postmaster
+    let _ = guard.into_inner().map(|mut c| {
+        let _ = c.kill();
+        let _ = c.wait();
+    });
     if bootstrap_shadow_data_dir.join("postmaster.pid").exists() {
         let mut shadow_cfg =
             ShadowConfig::new(bootstrap_shadow_data_dir.clone(), shadow_filter_dir.clone());
@@ -317,10 +320,6 @@ async fn object_store_bootstrap_ch_end_to_end() {
         let shadow = Shadow::new(shadow_cfg);
         let _ = shadow.stop();
     }
-    let _ = guard.into_inner().map(|mut c| {
-        let _ = c.kill();
-        let _ = c.wait();
-    });
 
     if let Err(e) = result {
         let stderr = fs::read_to_string(&stderr_path).unwrap_or_default();

--- a/tests/common/bootstrap_ch_fixture.rs
+++ b/tests/common/bootstrap_ch_fixture.rs
@@ -303,7 +303,7 @@ pub fn parse_metric(body: &str, name: &str) -> Option<u64> {
 
 /// Poll a TCP port until accept succeeds. Used as a coarse readiness
 /// gate for `walshadow-stream`'s metrics endpoint — by the time it's
-/// listening, bootstrap + autospawn-shadow + WAL pump init have all
+/// listening, bootstrap, shadow startup, and WAL pump setup have all
 /// finished and bootstrap rows have drained to CH.
 pub fn wait_for_listen(addr: std::net::SocketAddr, deadline: Duration) -> Result<()> {
     let start = Instant::now();

--- a/tests/pgbench_acceptance.rs
+++ b/tests/pgbench_acceptance.rs
@@ -10,7 +10,7 @@
 //!    refuses non-FULL identity on tracked rels)
 //! 3. spawn CH + pre-create dest tables ReplacingMergeTree(_lsn)
 //! 4. spawn walshadow-stream `--bootstrap-mode=direct
-//!    --bootstrap-autospawn-shadow` against the four-table CH config
+//!    --bootstrap-shadow-data-dir` against four-table CH config
 //! 5. await bootstrap (metrics endpoint up) → assert row counts match
 //! 6. `pgbench -T 30 -c 4 -j 2` in background; at +10s ADD COLUMN c
 //!    int DEFAULT 7 on pgbench_accounts (item 1 read-time defaults);
@@ -327,7 +327,7 @@ async fn run_ddl_intermix(ports: Ports, decoder_pool: usize, inserter_pool: usiz
     write_pgbench_ch_config(&ch_config_path, "127.0.0.1", ports.ch_tcp, "default")
         .expect("write ch-config");
 
-    // 6. Shadow autospawn layout — same quirk as direct-bootstrap drill.
+    // 6. Daemon-owned shadow layout, same quirk as direct-bootstrap drill.
     let bootstrap_shadow_data_dir = tmp.path().join("shadow-data");
     let shadow_sock = tmp.path().join("shadow-sock");
     fs::create_dir_all(&shadow_sock).unwrap();
@@ -390,7 +390,6 @@ async fn run_ddl_intermix(ports: Ports, decoder_pool: usize, inserter_pool: usiz
             "direct",
             "--bootstrap-shadow-data-dir",
             bootstrap_shadow_data_dir.to_str().unwrap(),
-            "--bootstrap-autospawn-shadow",
             "--bootstrap-shadow-replay-timeout",
             "180",
             // N>1 here drives concurrent AsyncClients for bootstrap +
@@ -603,8 +602,12 @@ async fn run_ddl_intermix(ports: Ports, decoder_pool: usize, inserter_pool: usiz
         Ok(())
     })();
 
-    // Tear down autospawn'd shadow PG so postmaster is reaped before
-    // tempdir cleanup. Daemon's autospawn is start-only.
+    // Kill daemon before shadow so supervisor cannot restart it
+    // Stop any remaining postmaster before tempdir cleanup
+    let _ = guard.into_inner().map(|mut c| {
+        let _ = c.kill();
+        let _ = c.wait();
+    });
     if bootstrap_shadow_data_dir.join("postmaster.pid").exists() {
         let mut shadow_cfg =
             ShadowConfig::new(bootstrap_shadow_data_dir.clone(), shadow_filter_dir.clone());
@@ -614,10 +617,6 @@ async fn run_ddl_intermix(ports: Ports, decoder_pool: usize, inserter_pool: usiz
         let shadow = Shadow::new(shadow_cfg);
         let _ = shadow.stop();
     }
-    let _ = guard.into_inner().map(|mut c| {
-        let _ = c.kill();
-        let _ = c.wait();
-    });
 
     if let Err(e) = result {
         let stderr = fs::read_to_string(&stderr_path).unwrap_or_default();


### PR DESCRIPTION
walshadow manages starting/configuring shadow catalog,
important when postgresql.conf of primary can be outside data directory
    
Improve replay continuity, potentially replaying some wal on restarts.
Avoids skipping archives in weird situation, avoids automatically rebootstrapping,
& respects redo lsn as postgres can't necessarily replay from where it was interrupted
    
Reactively adjust shadow catalog with settings necessary to process wal from primary