### PR TITLE
Updated default configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,30 @@ docs indexed at [plans/INDEX.md](plans/INDEX.md); for diagrams,
 
 ## Quick start (docker)
 
-End-to-end demo wiring source PG → walshadow → ClickHouse. Step-by-step
-in [docker/DEMO.md](docker/DEMO.md). Short form:
+One command against your source PG (image publishing soon):
+
+```
+docker run --rm \
+    -v walshadow-data:/var/lib/walshadow \
+    -v /etc/walshadow/ch.toml:/etc/walshadow/ch.toml:ro \
+    clickhouse/walshadow \
+    --host source.example --user replicator \
+    --out-dir                   /var/lib/walshadow/wal \
+    --spill-dir                 /var/lib/walshadow/spill \
+    --shadow-socket-dir         /var/run/postgresql \
+    --bootstrap-shadow-data-dir /var/lib/walshadow/shadow \
+    --walsender-bind            127.0.0.1:6510 \
+    --ch-config                 /etc/walshadow/ch.toml
+```
+
+`ch.toml` is just the CH connection block (see [CH emitter
+config](#ch-emitter-config)). walshadow bootstraps its own shadow PG, copies
+every table into ClickHouse, then streams live — no per-table config. See
+[Running standalone](#running-standalone) for the flags.
+
+## Try the demo locally
+
+Full source PG → walshadow → ClickHouse stack (builds from source):
 
 ```
 git submodule update --init --recursive
@@ -21,11 +43,18 @@ docker compose -f docker/docker-compose.yml up --build -d
 docker compose -f docker/docker-compose.yml logs -f walshadow
 ```
 
-Wait for the `shadow caught up to bootstrap end_lsn` line, then drive
-changes on source and read them back from CH (full sequence in
-[docker/DEMO.md](docker/DEMO.md))
+Wait for the `shadow caught up to bootstrap end_lsn` line, then drive a change
+and read it back:
 
-For pgbench with Grafana dashboards plus live schema-change propagation:
+```
+docker compose -f docker/docker-compose.yml exec source \
+    psql -U postgres -c "UPDATE demo.users SET email='new@addr' WHERE id=1"
+docker compose -f docker/docker-compose.yml exec clickhouse \
+    clickhouse-client --query "SELECT id, email FROM demo.users FINAL ORDER BY id"
+```
+
+Full sequence in [docker/DEMO.md](docker/DEMO.md). For pgbench load with
+Grafana dashboards and live schema-change propagation:
 
 ```
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.demo.yml up --build -d
@@ -44,9 +73,95 @@ when any of these fails:
 - every mapped relation has a row key for deletes: a PRIMARY KEY
   (`REPLICA IDENTITY DEFAULT`), `USING INDEX`, or `FULL`. `NOTHING` and
   keyless `DEFAULT` are rejected. `FULL` is accepted, not required
-- `--slot`, if set, names an existing physical replication slot
 
 Skip with `--skip-preflight` only for recovery drills
+
+## Recommended Configurations:
+
+In case of backlog buildup, we need either a physical replication slot or some way to get
+data from a cloud backup location. Otherwise walshadow would crash with "WAl not found error"
+ 
+- `slot`, if set, names an existing physical replication slot
+or
+- `backup`, if set, would pull data from backup location like standby pg
+
+## Running standalone
+
+The easiest path: point the daemon at source PG + an empty data dir and let
+it bootstrap its own shadow. First install the PG module so the shadow can
+preload it (`make -C pgext install`; see [Building](#building-from-source)),
+create the target CH database (walshadow makes tables, not databases), then:
+
+```
+walshadow-stream \
+    --host source.example --user replicator \
+    --out-dir                   /var/lib/walshadow/wal \
+    --spill-dir                 /var/lib/walshadow/spill \
+    --shadow-socket-dir         /var/run/postgresql \
+    --bootstrap-shadow-data-dir /var/lib/walshadow/shadow \
+    --walsender-bind            127.0.0.1:6510 \
+    --ch-config                 /etc/walshadow/ch.toml
+```
+
+with a `ch.toml` that is just the connection block:
+
+```toml
+[ch]
+host = "localhost"
+database = "analytics"
+```
+
+On first boot this base-backups source into the shadow dir, does a direct
+initial copy of **every** table into ClickHouse, then tails changes live. A
+restart resumes from the durable cursor — no re-copy. That's it; no per-table
+config and no separately-managed shadow PG.
+
+Notes:
+- `--walsender-bind` needs an explicit non-zero port for a daemon-owned shadow
+  (it is baked into shadow's `primary_conninfo`).
+- `--bootstrap-shadow-data-dir` must be a new/empty dir; an initialized one
+  resumes instead of re-bootstrapping.
+- Without `--ch-config` the daemon stays metrics-only (no CH emission). Pass
+  `--metrics-bind 127.0.0.1:9484` for a Prometheus scrape endpoint.
+- To manage shadow PG yourself, drop `--bootstrap-shadow-data-dir` (bootstrap
+  defaults to `off` then, streaming only). See `walshadow-stream --help` for
+  the full surface (bootstrap modes, walsender tuning, retention, etc.)
+
+### CH emitter config
+
+`[ch]` connection defaults: `port = 9000`, `user = "default"`, empty
+`password`, `compression = "lz4"`, `secure = false`. With `[stream]
+replicate_all` on (the default) a bare `[ch]` block replicates every user
+table into `[ch] database` with high-throughput batching. To narrow scope:
+
+```toml
+[ch]
+host = "localhost"
+database = "analytics"
+
+# Opt a table out (wins over replicate_all):
+[table."public.audit_log"]
+replicate = false
+
+# Or list explicitly — replicate only what you name:
+[stream]
+replicate_all = false
+[table."public.users"]
+replicate = true
+initial_load = "none"
+target = "users"
+columns = [
+    { attnum = 1, target = "id",    type = "UInt64" },
+    { attnum = 2, target = "name",  type = "String" },
+]
+```
+
+`replicate_all` skips system schemas (`pg_*`, `information_schema`, the
+`[runtime_config]` schema). `attnum` values match `pg_attribute.attnum`
+(1-based) on the source relation; `type` is the CH destination type walshadow
+advertises in the INSERT block. SIGHUP reloads mappings atomically;
+connection params stay boot-only.
+
 
 ## Building from source
 
@@ -80,54 +195,6 @@ writes preload and `walshadow.*` settings for shadows it owns, then requires
 worker socket. `--bridge-socket` defaults to
 `<shadow-socket-dir>/walshadow-bridge.sock`
 
-## Running standalone
-
-Minimum viable invocation against an existing source PG + shadow PG:
-
-```
-walshadow-stream \
-    --host source.example \
-    --user replicator \
-    --out-dir /var/lib/walshadow/wal \
-    --shadow-socket-dir /var/run/postgresql \
-    --spill-dir /var/lib/walshadow/spill \
-    --ch-config /etc/walshadow/ch.toml
-```
-
-Without `--ch-config` the daemon stays metrics-only (no CH emission).
-Pass `--metrics-bind 127.0.0.1:9484` for a Prometheus scrape endpoint.
-See `walshadow-stream --help` for the full surface (bootstrap modes,
-walsender tuning, retention, etc.)
-
-### CH emitter config
-
-TOML, see [docker/ch-config.toml](docker/ch-config.toml) for a minimal
-example. Shape:
-
-```toml
-[ch]
-host = "localhost"
-port = 9000
-database = "default"
-user = "default"
-password = ""
-compression = "lz4"
-
-[table."public.users"]
-replicate = true
-initial_load = "none"
-target = "users"
-columns = [
-    { attnum = 1, target = "id",    type = "UInt64" },
-    { attnum = 2, target = "name",  type = "String" },
-]
-```
-
-`attnum` values match `pg_attribute.attnum` (1-based) on the source
-relation; `type` is the CH destination type walshadow advertises in
-the INSERT block. SIGHUP reloads mappings atomically; connection
-params stay boot-only
-
 ## Testing
 
 ```
@@ -153,13 +220,15 @@ one machine — do not collide
 ## Repository layout
 
 ```
-src/                walshadow daemon + library
+src/                walshadow daemon + library (submodules: emit/ source/ backfill/ decode/ catalog/ …)
 src/bin/            CLI entry points (stream, filter, classify)
 clickhouse-c-rs/    CH-Native client, separate submodule
 pgext/              walshadow decode-bridge PG module (PGXS)
+sql/                runtime-config overlay install SQL
 architecture/       overview + internals diagrams
 plans/              component design docs (overview.md is the baseline)
 docker/             docker-compose demo + Dockerfile
+bench/              throughput / latency benchmark harnesses
 tests/              integration suite
 fixtures/wal/       golden WAL fixtures for offline tests
 ```

--- a/docker/DEMO.md
+++ b/docker/DEMO.md
@@ -11,7 +11,7 @@ Five services from the base stack plus a demo tier:
 |---|---|
 | `source` | postgres:18, `wal_level=logical`, seeds `demo.users` + pgbench TPC-B schema (`REPLICA IDENTITY FULL`) |
 | `walshadow` | daemon: in-container daemon-owned shadow PG + WAL→CH stream, `/metrics` on :9484 |
-| `clickhouse` | destination, `demo.*` tables pre-created |
+| `clickhouse` | destination; only the `demo` database is pre-created, walshadow auto-creates the tables |
 | `pgbench` | hammers `source` with the TPC-B workload |
 | `postgres-exporter` | source PG stats (TPS, tuple rates) → Prometheus |
 | `prometheus` | scrapes walshadow + postgres-exporter |
@@ -102,10 +102,10 @@ source TPS line with the lag shown in section 3.
 
 ## 4. Drive a row change, then evolve the schema (live)
 
-`demo.users` is tiny, pinned in the emitter config to exactly `id` /
-`name` / `email`, and untouched by pgbench — so it's the clean stage for
-showing CDC and live DDL replication while the hammer roars in the
-background.
+`demo.users` is tiny, has just `id` / `name` / `email`, and is untouched
+by pgbench — so it's the clean stage for showing CDC and live DDL
+replication while the hammer roars in the background. walshadow
+auto-created it and copied its rows at bootstrap (`replicate_all`).
 
 **Beat 1 — a row change rides the stream.** Update a row on the source
 and read it back from ClickHouse:
@@ -118,12 +118,7 @@ $dc exec clickhouse clickhouse-client --query \
     "SELECT id, email, _lsn FROM demo.users FINAL ORDER BY id"
 ```
 
-Row 1's email updates; its `_lsn` advances — CDC in flight. Pure
-demonstration now: walshadow seeds each pinned relation's column baseline
-at startup, so Beat 2's schema change replicates even if you skip this
-beat. (Pre-seed this row change was load-bearing — a pinned table needed
-one DML before an `ALTER` read as *column added* rather than *new table*,
-since operator-pinned tables are assumed CH-managed on first sight.)
+Row 1's email updates; its `_lsn` advances — CDC in flight.
 
 **Beat 2 — the schema evolves.** Add a column on the source and watch
 walshadow replicate the DDL to ClickHouse — no config edit, no restart:

--- a/docker/ch-config.demo.toml
+++ b/docker/ch-config.demo.toml
@@ -1,16 +1,6 @@
-# walshadow demo CH emitter mapping — observability variant.
-# Superset of ch-config.toml: keeps demo.users (the schema-change
-# narrative table) and adds the four pgbench TPC-B tables the hammer
-# service pounds. attnum values match pg_attribute.attnum (1-based);
-# `type` is the CH destination type walshadow advertises in its INSERT
-# block (must match the pre-created dest table from
-# init/clickhouse/02-pgbench.sh).
-#
-# demo.users is pinned to exactly id/name/email — no `signup_ts`. The
-# DEMO walks an operator adding that column live; walshadow's DDL
-# applicator runs ALTER TABLE ... ADD COLUMN on CH and auto-extends this
-# mapping at runtime, so the new column appears in ClickHouse without a
-# config edit.
+# walshadow demo CH emitter mapping — observability variant. replicate_all
+# (on by default) auto-creates demo.users; the explicit pgbench mappings pin
+# dest types to the tables pre-created by init/clickhouse/02-pgbench.sh.
 
 [ch]
 host = "clickhouse"
@@ -19,21 +9,7 @@ database = "demo"
 user = "default"
 password = ""
 compression = "lz4"
-# Hold INSERTs open across xacts and close them on a 200ms timer.
-# pgbench's TPC-B xact writes four tables; closing every INSERT per
-# xact is one CH round-trip each and caps throughput at a few xact/s.
-# Coalescing into one MergeTree part per window lets the daemon track
-# pgbench's hundreds of xact/s.
 flush_timeout_ms = 200
-
-# [table.<namespace>.<relname>]; destination defaults to
-# [ch] database + source relname, override via target_database / target_table
-[table.demo.users]
-columns = [
-    { attnum = 1, target = "id",    type = "UInt64" },
-    { attnum = 2, target = "name",  type = "String" },
-    { attnum = 3, target = "email", type = "String" },
-]
 
 [table.public.pgbench_accounts]
 target_database = "demo"

--- a/docker/ch-config.toml
+++ b/docker/ch-config.toml
@@ -1,6 +1,6 @@
-# walshadow CH emitter mapping. attnum values match
-# pg_attribute.attnum (1-based) on demo.users; column types are the CH
-# destination types walshadow advertises in its INSERT block.
+# walshadow CH emitter config. With replicate_all on (the default) a bare [ch]
+# block replicates every user table into [ch] database, which must already exist
+# (walshadow creates tables, not databases).
 
 [ch]
 host = "clickhouse"
@@ -11,11 +11,10 @@ password = ""
 compression = "lz4"
 # soft_delete = true
 
-# [table.<namespace>.<relname>]; destination defaults to
-# [ch] database + source relname, override via target_database / target_table
-[table.demo.users]
-columns = [
-    { attnum = 1, target = "id",    type = "UInt64" },
-    { attnum = 2, target = "name",  type = "String" },
-    { attnum = 3, target = "email", type = "String" },
-]
+# Opt a table out:
+# [table.public.audit_log]
+# replicate = false
+
+# Explicit mode — replicate only what you list:
+# [stream]
+# replicate_all = false

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,16 +1,17 @@
 # walshadow demo. Three services:
 #   source     — postgres:18 with wal_level=logical, demo.users seeded
 #                via init script, REPLICA IDENTITY FULL set
-#   clickhouse — clickhouse-server with the demo.users destination
-#                table pre-created
-#   walshadow  — custom image carrying walshadow-stream + the
-#                walshadow PG extension. Boots an in-container shadow
-#                PG via --bootstrap-mode=direct on empty volume, resumes it
-#                on later starts, then streams source WAL into clickhouse
+#   clickhouse — clickhouse-server; only the demo database is pre-created,
+#                walshadow auto-creates the tables (replicate_all, on by default)
+#   walshadow  — custom image carrying walshadow-stream + the walshadow PG
+#                extension. Boots an in-container shadow PG on the empty volume,
+#                copies every source table into clickhouse, then streams live;
+#                resumes from the cursor on later starts
 #
 # Quick start (from repo root):
 #   git submodule update --init --recursive
 #   docker compose -f docker/docker-compose.yml up --build
+#   docker compose -f docker/docker-compose.yml logs -f walshadow   # wait for bootstrap
 #
 # Drive the pipeline:
 #   docker compose -f docker/docker-compose.yml exec source \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,18 +19,22 @@ mkdir -p "$OUT_DIR" "$SPILL_DIR" "$SOCKET_DIR"
 CH_CONFIG="${WALSHADOW_CH_CONFIG:-/etc/walshadow/ch-config.toml}"
 mkdir -p "${CH_CONFIG%.toml}.d"
 
-# Pool sizes default here for the local stack, but the EC2 deploy.sh forwards
-# explicit --decoder-pool-size/--inserter-pool-size via "$@"; clap rejects a
-# flag passed twice, so only inject our defaults when the caller didn't.
+# Pool sizes fall through to the binary's compiled defaults unless overridden
+# via env. clap rejects a flag passed twice, so only inject when the caller
+# (e.g. EC2 deploy.sh via "$@") didn't already pass it.
 POOL_ARGS=()
-case " $* " in
-    *" --decoder-pool-size "*) ;;
-    *) POOL_ARGS+=(--decoder-pool-size "${WALSHADOW_DECODER_POOL:-1}") ;;
-esac
-case " $* " in
-    *" --inserter-pool-size "*) ;;
-    *) POOL_ARGS+=(--inserter-pool-size "${WALSHADOW_INSERTER_POOL:-4}") ;;
-esac
+if [ -n "${WALSHADOW_DECODER_POOL:-}" ]; then
+    case " $* " in
+        *" --decoder-pool-size "*) ;;
+        *) POOL_ARGS+=(--decoder-pool-size "$WALSHADOW_DECODER_POOL") ;;
+    esac
+fi
+if [ -n "${WALSHADOW_INSERTER_POOL:-}" ]; then
+    case " $* " in
+        *" --inserter-pool-size "*) ;;
+        *) POOL_ARGS+=(--inserter-pool-size "$WALSHADOW_INSERTER_POOL") ;;
+    esac
+fi
 case " $* " in
     *" --xact-buffer-max "*) ;;
     *) POOL_ARGS+=(--xact-buffer-max "${WALSHADOW_XACT_BUFFER_MAX:-1073741824}") ;;

--- a/docker/init/clickhouse/01-schema.sql
+++ b/docker/init/clickhouse/01-schema.sql
@@ -1,17 +1,5 @@
--- walshadow demo destination table. Synthetic columns (_lsn, _xid,
--- _commit_ts, _is_deleted) match the emitter's TablePlan; their types
--- are fixed by walshadow::ch_emitter::TablePlan::build.
+-- walshadow creates tables, not databases. Pre-create the target database
+-- so replicate_all can auto-create demo.users (and any other source table)
+-- into it on first boot.
 
 CREATE DATABASE IF NOT EXISTS demo;
-
-CREATE TABLE IF NOT EXISTS demo.users (
-    id          UInt64,
-    name        String,
-    email       String,
-    _lsn        UInt64,
-    _xid        UInt32,
-    _commit_ts  DateTime64(6, 'UTC'),
-    _is_deleted Bool
-)
-ENGINE = ReplacingMergeTree(_lsn, _is_deleted)
-ORDER BY id;

--- a/plans/config.md
+++ b/plans/config.md
@@ -80,8 +80,12 @@ so an absent slot is the operator's to pre-create; the pump refuses the swap
 and keeps streaming from the current feed until it exists. The old slot is
 left as it stands, since its retention is what a rollback to that server
 reads.
-`target_database` and `soft_delete` thread into the DDL applicator at
-construction and carry across refreshes unchanged.
+`target_database`, `soft_delete`, `[stream] replicate_all`, and the
+`[runtime_config] schema` name thread into the DDL applicator at construction
+and carry across refreshes unchanged. `replicate_all` (default `true`)
+auto-creates and replicates every user table whose namespace is not a system
+schema (`pg_*`, `information_schema`, the runtime-config schema); an explicit
+`auto_create` namespace or a `replicate = false` opt-out still wins.
 
 ## `[backup]` archive
 
@@ -115,10 +119,14 @@ TOML.
 
 ```toml
 [bootstrap]
-mode = "object_store"            # off | direct | object_store; default off
+mode = "object_store"            # off | direct | object_store
 backup_name = "LATEST"           # LATEST, or a literal base_… name
 object_store_parallelism = 8     # unset keeps min(4, num_cpus)
 ```
+
+Default `mode` is `direct` when `--bootstrap-shadow-data-dir` is set (fresh
+boot does an initial copy, then streams), else `off`: external-shadow runs
+have nothing to seed and `resolve_shadow_start` rejects a non-`off` mode there.
 
 An unrecognised `mode` and a non-positive `object_store_parallelism` both
 fail at parse, so a typo cannot read as `off` and silently skip bootstrap.

--- a/src/bin/stream.rs
+++ b/src/bin/stream.rs
@@ -133,7 +133,14 @@ fn resolve_bootstrap(args: &Args, ch: Option<&EmitterConfig>) -> Result<Bootstra
         None => None,
         Some(other) => anyhow::bail!("[bootstrap] mode {other:?} unsupported"),
     };
-    let mode = cli_over_toml(args.bootstrap_mode, toml_mode).unwrap_or(BootstrapMode::Off);
+    // External-shadow (no data dir) can't bootstrap; only default to Direct when
+    // a shadow data dir is configured.
+    let default_mode = if args.bootstrap_shadow_data_dir.is_some() {
+        BootstrapMode::Direct
+    } else {
+        BootstrapMode::Off
+    };
+    let mode = cli_over_toml(args.bootstrap_mode, toml_mode).unwrap_or(default_mode);
     let backup_name = cli_over_toml(
         args.bootstrap_backup_name.clone(),
         toml.and_then(|b| b.backup_name.clone()),
@@ -1495,6 +1502,8 @@ async fn run_session(
             &config_rx.borrow(),
             emitter_cfg.database.clone(),
             emitter_cfg.soft_delete,
+            emitter_cfg.replicate_all,
+            emitter_cfg.runtime_config_schema.clone(),
         );
         let mut applicator = walshadow::ch_ddl::DdlApplicator::new(
             &emitter_cfg,
@@ -4288,6 +4297,8 @@ async fn bootstrap_build_mapping(
         &config_rx.borrow(),
         emitter_cfg.database.clone(),
         emitter_cfg.soft_delete,
+        emitter_cfg.replicate_all,
+        emitter_cfg.runtime_config_schema.clone(),
     );
     let mut applicator =
         walshadow::ch_ddl::DdlApplicator::new(emitter_cfg, ddl_cfg, mapping.clone(), config_rx)
@@ -4888,6 +4899,8 @@ mod tests {
         };
         let off = |d: &str| {
             args_from(&[
+                "--bootstrap-mode",
+                "off",
                 "--bootstrap-shadow-data-dir",
                 d,
                 "--walsender-bind",

--- a/src/config.rs
+++ b/src/config.rs
@@ -973,7 +973,7 @@ mod tests {
             &OptInState::default(),
             &HashMap::new(),
         );
-        DdlConfig::from_resolved(&r, "db".into(), false).auto_create_namespaces
+        DdlConfig::from_resolved(&r, "db".into(), false, false, None).auto_create_namespaces
     }
 
     #[test]

--- a/src/emit/ch_ddl.rs
+++ b/src/emit/ch_ddl.rs
@@ -50,6 +50,9 @@ pub struct DdlConfig {
     /// Namespaces whose `Added` events run `CREATE TABLE IF NOT EXISTS`
     /// automatically (`auto_create = true`)
     pub auto_create_namespaces: HashSet<String>,
+    pub replicate_all: bool,
+    /// Excluded from `replicate_all` so the overlay's `config_*` tables aren't swept in
+    pub runtime_config_schema: Option<String>,
     /// CH database DDL targets when neither per-table mapping nor source
     /// namespace overrides the destination
     pub target_database: String,
@@ -62,13 +65,15 @@ pub struct DdlConfig {
 }
 
 impl DdlConfig {
-    /// Build from a resolved snapshot. `target_database` (`[ch] database`)
-    /// and `soft_delete` are boot-only connection knobs the resolver does
-    /// not republish, so callers thread them through unchanged.
+    /// Build from a resolved snapshot. `target_database`, `soft_delete`,
+    /// `replicate_all` and `runtime_config_schema` are boot-only knobs the
+    /// resolver does not republish, so callers thread them through unchanged.
     pub fn from_resolved(
         resolved: &ResolvedConfig,
         target_database: String,
         soft_delete: bool,
+        replicate_all: bool,
+        runtime_config_schema: Option<String>,
     ) -> Self {
         let auto_create_namespaces: HashSet<String> = resolved
             .namespaces
@@ -81,6 +86,8 @@ impl DdlConfig {
         Self {
             drop_table_strategy,
             auto_create_namespaces,
+            replicate_all,
+            runtime_config_schema,
             target_database,
             namespaces: resolved.namespaces.clone(),
             soft_delete,
@@ -106,6 +113,14 @@ impl DdlConfig {
         self.drop_table_strategy = s;
         self
     }
+}
+
+fn is_system_namespace(ns: &str, runtime_config_schema: Option<&str>) -> bool {
+    ns == "pg_catalog"
+        || ns == "information_schema"
+        || ns == "pg_toast"
+        || ns.starts_with("pg_")
+        || runtime_config_schema.is_some_and(|s| !s.is_empty() && s == ns)
 }
 
 /// CH-side DDL writer. Owns one AsyncClient over its own TCP.
@@ -199,6 +214,8 @@ impl DdlApplicator {
                 &snap,
                 self.config.target_database.clone(),
                 self.config.soft_delete,
+                self.config.replicate_all,
+                self.config.runtime_config_schema.clone(),
             );
             let conn = (
                 snap.host.clone(),
@@ -258,11 +275,11 @@ impl DdlApplicator {
             self.stats.skipped += 1;
             return Ok(());
         }
-        if !self
-            .config
-            .auto_create_namespaces
-            .contains(&*desc.rel_name.namespace)
-        {
+        let ns = &*desc.rel_name.namespace;
+        let auto = self.config.auto_create_namespaces.contains(ns)
+            || (self.config.replicate_all
+                && !is_system_namespace(ns, self.config.runtime_config_schema.as_deref()));
+        if !auto {
             self.stats.skipped += 1;
             return Ok(());
         }
@@ -750,6 +767,18 @@ mod tests {
     use crate::schema::{RelAttr, RelDescriptor, ReplIdent, SchemaDiff};
 
     #[test]
+    fn system_namespaces_excluded_from_replicate_all() {
+        assert!(is_system_namespace("pg_catalog", None));
+        assert!(is_system_namespace("pg_toast", None));
+        assert!(is_system_namespace("information_schema", None));
+        assert!(is_system_namespace("pg_temp_3", None));
+        assert!(!is_system_namespace("public", None));
+        assert!(is_system_namespace("walshadow", Some("walshadow")));
+        assert!(!is_system_namespace("walshadow", Some("")));
+        assert!(!is_system_namespace("public", Some("walshadow")));
+    }
+
+    #[test]
     fn per_namespace_target_and_drop_override_global() {
         use crate::mapping::NamespaceMapping;
         use ahash::{HashMap, HashMapExt};
@@ -773,6 +802,8 @@ mod tests {
         let cfg = DdlConfig {
             drop_table_strategy: DropTableStrategy::Retain,
             auto_create_namespaces: HashSet::new(),
+            replicate_all: false,
+            runtime_config_schema: None,
             target_database: "default".into(),
             namespaces,
             soft_delete: false,
@@ -794,6 +825,8 @@ mod tests {
         let cfg = DdlConfig {
             drop_table_strategy: DropTableStrategy::Retain,
             auto_create_namespaces: HashSet::new(),
+            replicate_all: false,
+            runtime_config_schema: None,
             target_database: "default".into(),
             namespaces: HashMap::new(),
             soft_delete: false,

--- a/src/emit/ch_emitter.rs
+++ b/src/emit/ch_emitter.rs
@@ -56,9 +56,9 @@ pub(crate) const OP_INSERT: i8 = 1;
 pub(crate) const OP_UPDATE: i8 = 2;
 pub(crate) const OP_DELETE: i8 = 3;
 
-/// Default block accumulator budgets. Mirror common CH server defaults
-pub(crate) const DEFAULT_ROW_BUDGET: usize = 65_536;
-pub(crate) const DEFAULT_BYTE_BUDGET: usize = 1 << 20; // 1 MiB
+/// Default block accumulator budgets.
+pub(crate) const DEFAULT_ROW_BUDGET: usize = 4_194_304;
+pub(crate) const DEFAULT_BYTE_BUDGET: usize = 256 << 20; // 256 MiB
 
 /// Default commit-drain slice budgets
 /// ([`crate::xact::xact_buffer::CommittedDrain::next_batch`]). Bytes sized at
@@ -68,13 +68,10 @@ pub(crate) const DEFAULT_DRAIN_BATCH_ROWS: usize = 65_536;
 pub(crate) const DEFAULT_DRAIN_BATCH_BYTES: usize = 32 << 20; // 32 MiB
 pub(crate) const DEFAULT_PLAN_DISK_MAX: u64 = 8 << 30; // 8 GiB
 
-/// Default flush timeout (ms). `0` keeps serial emitter's
-/// close-INSERT-on-every-xact-end behaviour (bootstrap backfill only);
-/// live pipeline substitutes a 100ms partial-batch deadline for `0` so
-/// cold tables can't pin the watermark. Positive value holds INSERTs
-/// open across xacts, seals on a deadline armed at first row of a fresh
-/// INSERT.
-pub(crate) const DEFAULT_FLUSH_TIMEOUT_MS: u64 = 0;
+/// Default flush timeout (ms). Holds INSERTs open across xacts, sealing on a
+/// deadline armed at the first row of a fresh INSERT. An explicit `0` keeps the
+/// serial emitter's close-on-every-xact behaviour (bootstrap backfill).
+pub(crate) const DEFAULT_FLUSH_TIMEOUT_MS: u64 = 1000;
 
 /// Rows one decode worker coalesces before routing
 pub(crate) const DEFAULT_DECODE_CHUNK_ROWS: usize = 1024;
@@ -120,6 +117,9 @@ pub struct EmitterConfig {
     /// `[stream] paused`: pump idles (stops consuming source WAL) when true.
     /// Live via reload.
     pub paused: bool,
+    /// `[stream] replicate_all` (default true): replicate every user table in
+    /// non-system namespaces. Per-table `replicate = false` still opts out.
+    pub replicate_all: bool,
     /// Pending capture cost controls, boot-only
     pub pending_capture: crate::source::catalog_capture::PendingCaptureConfig,
     /// Per-namespace defaults keyed on PG schema name; per-table
@@ -263,8 +263,8 @@ fn parse_bootstrap(tbl: &toml::value::Table) -> Result<BootstrapSettings, Emitte
 pub(crate) const DEFAULT_RESIDENT_PAYLOAD_MAX: usize = 512 << 20;
 pub(crate) const DEFAULT_INLINE_VALUE_MAX: usize = 64 << 20;
 
-pub const DEFAULT_DECODER_POOL: usize = 1;
-pub const DEFAULT_INSERTER_POOL: usize = 4;
+pub const DEFAULT_DECODER_POOL: usize = 3;
+pub const DEFAULT_INSERTER_POOL: usize = 3;
 
 pub(crate) const DEFAULT_INSERT_TIMEOUT_SECS: u64 = 30;
 pub(crate) const DEFAULT_IDLE_RECONNECT_SECS: u64 = 30;
@@ -307,6 +307,7 @@ impl Default for EmitterConfig {
             table_initial_loads: HashMap::new(),
             table_opt_ins: HashMap::new(),
             paused: false,
+            replicate_all: true,
             pending_capture: Default::default(),
             namespaces: HashMap::new(),
             drop_table_strategy: "retain".into(),
@@ -634,6 +635,9 @@ impl EmitterConfig {
         if let Some(st) = root.get("stream").and_then(Value::as_table) {
             if let Some(v) = st.get("paused").and_then(Value::as_bool) {
                 out.paused = v;
+            }
+            if let Some(v) = st.get("replicate_all").and_then(Value::as_bool) {
+                out.replicate_all = v;
             }
             if let Some(v) = st
                 .get("pending_max_boundaries_per_xact")
@@ -1814,6 +1818,27 @@ mod tests {
     use super::*;
     use crate::decode::heap_decoder::{DecodedHeap, DecodedTuple};
     use walrus::pg::walparser::RelFileNode;
+
+    #[test]
+    fn defaults_match_high_throughput_profile() {
+        let c = EmitterConfig::from_toml_str("[ch]\nhost = \"h\"\n").expect("parses");
+        assert_eq!(c.row_budget, 4_194_304);
+        assert_eq!(c.byte_budget, 256 << 20);
+        assert_eq!(c.flush_timeout, Duration::from_millis(1000));
+        assert_eq!(c.decoder_pool_size, 3);
+        assert_eq!(c.inserter_pool_size, 3);
+        assert_eq!(c.decoder_batch_size, 512);
+        assert_eq!(c.decoder_queue_capacity, 131_072);
+        assert!(c.replicate_all);
+    }
+
+    #[test]
+    fn replicate_all_disabled_via_stream_flag() {
+        let c =
+            EmitterConfig::from_toml_str("[ch]\nhost = \"h\"\n[stream]\nreplicate_all = false\n")
+                .expect("parses");
+        assert!(!c.replicate_all);
+    }
 
     #[test]
     fn decimal_type_error_wraps_message_in_type_variant() {

--- a/src/source/queueing_record_sink.rs
+++ b/src/source/queueing_record_sink.rs
@@ -36,16 +36,15 @@ use crate::ops::trace::TxnSpanRegistry;
 use crate::record::{Record, RecordSink, SinkError, rmgr_label};
 
 /// Records batched before a channel send. Amortises per-send overhead
-/// (atomic + alloc + wakeup); 64 lands channel cost near 8ns/record
-/// over the clone-into-owned baseline.
-pub const DEFAULT_QUEUEING_BATCH_SIZE: usize = 64;
+/// (atomic + alloc + wakeup).
+pub const DEFAULT_QUEUEING_BATCH_SIZE: usize = 512;
 
 /// Hard in-flight cap (channel batches + pump buffer). The channel is bounded
 /// at `max_records / batch_size`, so past it the pump's `send` blocks — real
 /// backpressure to the source instead of unbounded RAM growth. Deadlock-safe:
 /// shadow is fed by an independent walsender task (+keepalive), so a parked
 /// pump can't starve `wait_for_replay`.
-pub const DEFAULT_QUEUEING_RECORD_SINK_CAPACITY: usize = 16_384;
+pub const DEFAULT_QUEUEING_RECORD_SINK_CAPACITY: usize = 131_072;
 
 /// Worker `on_idle` cadence. Lets CH emitter's hold-INSERT-open
 /// deadline fire shortly after `flush_timeout` without piling on

--- a/tests/common/inproc_harness.rs
+++ b/tests/common/inproc_harness.rs
@@ -848,6 +848,8 @@ async fn build_pipeline_inner(
         &config_rx.borrow(),
         emitter_cfg.database.clone(),
         emitter_cfg.soft_delete,
+        emitter_cfg.replicate_all,
+        emitter_cfg.runtime_config_schema.clone(),
     );
     let applicator = DdlApplicator::new(&emitter_cfg, ddl_cfg, mapping.clone(), config_rx.clone())
         .await

--- a/tests/control_plane_e2e.rs
+++ b/tests/control_plane_e2e.rs
@@ -119,6 +119,9 @@ impl Harness {
                  database = \"demo\"\n\
                  compression = \"lz4\"\n\
                  \n\
+                 [stream]\n\
+                 replicate_all = false\n\
+                 \n\
                  [table.demo.users]\n\
                  columns = [\n  \
                    {{ attnum = 1, target = \"id\",    type = \"Int64\"  }},\n  \

--- a/tests/pipeline_parallel_e2e.rs
+++ b/tests/pipeline_parallel_e2e.rs
@@ -97,18 +97,21 @@ async fn parallel_pipeline_replicates_dml() {
         ],
     }];
 
-    let mut pipeline = fx::build_pipeline(fx::BuildPipelineArgs {
-        tmp: &tmp,
-        source: &source,
-        shadow: &shadow,
-        shadow_filter_dir: &shadow_filter_dir,
-        shadow_stream_state,
-        ch_database: "walshadow_test",
-        ch_tcp_port: slot.ch_tcp,
-        mappings,
-        app_name: "walshadow-pipeline-parallel",
-        ddl: None,
-    })
+    let mut pipeline = fx::build_pipeline_with(
+        fx::BuildPipelineArgs {
+            tmp: &tmp,
+            source: &source,
+            shadow: &shadow,
+            shadow_filter_dir: &shadow_filter_dir,
+            shadow_stream_state,
+            ch_database: "walshadow_test",
+            ch_tcp_port: slot.ch_tcp,
+            mappings,
+            app_name: "walshadow-pipeline-parallel",
+            ddl: None,
+        },
+        |c| c.replicate_all = false,
+    )
     .await;
 
     // Each `-c` is its own autocommit xact, so every COMMIT lands in the

--- a/tests/runtime_config_e2e.rs
+++ b/tests/runtime_config_e2e.rs
@@ -880,18 +880,21 @@ async fn pre_opt_in_xact_discards_post_opt_in_routes() {
     ch.query("CREATE DATABASE IF NOT EXISTS walshadow_test")
         .expect("create db");
 
-    let mut pipeline = fx::build_pipeline(fx::BuildPipelineArgs {
-        tmp: &tmp,
-        source: &source,
-        shadow: &shadow,
-        shadow_filter_dir: &shadow_filter_dir,
-        shadow_stream_state,
-        ch_database: "walshadow_test",
-        ch_tcp_port: slot.ch_tcp,
-        mappings: vec![],
-        app_name: "walshadow-config-pre-opt-in-discard",
-        ddl: Some(overlay_ddl_args()),
-    })
+    let mut pipeline = fx::build_pipeline_with(
+        fx::BuildPipelineArgs {
+            tmp: &tmp,
+            source: &source,
+            shadow: &shadow,
+            shadow_filter_dir: &shadow_filter_dir,
+            shadow_stream_state,
+            ch_database: "walshadow_test",
+            ch_tcp_port: slot.ch_tcp,
+            mappings: vec![],
+            app_name: "walshadow-config-pre-opt-in-discard",
+            ddl: Some(overlay_ddl_args()),
+        },
+        |c| c.replicate_all = false,
+    )
     .await;
 
     // Commit order fixes semantics: id=1 plans against no route (discard),


### PR DESCRIPTION
 Retune the defaults so a bare [ch] config performs well and replicates everything out of the box. 

  Emitter batch/throughput defaults :
  - row_budget:              65_536      -> 4_194_304
  - byte_budget:            1 MiB        -> 256 MiB
  - flush_timeout_ms:        0           -> 1000
  - decoder_pool_size:       1           -> 3
  - inserter_pool_size:      4           -> 3
  - decoder_batch_size:      64          -> 512   (DEFAULT_QUEUEING_BATCH_SIZE)
  - decoder_queue_capacity:  16_384      -> 131_072 (DEFAULT_QUEUEING_RECORD_SINK_CAPACITY)

  New [stream] replicate_all (default true): auto-create and replicate every
  user table in non-system namespaces (skips pg_*, information_schema, the
  [runtime_config] schema). Per-table `replicate = false` still opts out; set
  `replicate_all = false` for explicit list mode. Threaded boot-only through
  DdlConfig into apply_added.

  Bootstrap mode now defaults to "direct" when --bootstrap-shadow-data-dir is
  set (fresh boot does an initial copy, then streams); stays "off" for
  external-shadow runs, which cannot bootstrap.