### PR TITLE
 Make WAL position and progress tracking safer

### DIFF
--- a/plans/emitter.md
+++ b/plans/emitter.md
@@ -214,18 +214,44 @@ source slot recycling) must not. Per seq track rows *placed* (decoder
 routed) and *acked* (inserter drained `EndOfStream`); a seq is done
 once `placed == acked` (rows=0 seqs done at placement). Watermark is
 highest contiguous done seq's `commit_lsn`, published into the
-`emitter_ack` atomic the status loop persists to the manifest
+`emitter_ack` value the status loop persists to the manifest
 
-`Trailing { lsn }` advances past non-commit WAL only when every
-registered seq is done and the xact buffer is empty (reorder's
-`on_idle_advance` guard). A `placed_frontier` watch channel serves the
-barrier's placed-wait. The frontier scan resumes from `placed_frontier`,
-not `next_expected` — the O(N²) re-walk variant pegged the collector
-at 100% CPU and presented as a chc recv/INSERT hang
+Event handlers only update stored state. `AckState::publish` updates the
+watermark, both progress values, and the diagnostic snapshot. `apply`
+calls it after every event. This ensures each event rechecks all
+conditions that can advance progress. Updating these values in separate
+event handlers caused a bug where `Trailing` was ignored if it arrived
+while a seq was still in flight
 
-`emitter_ack` is seeded at the WAL re-read start (`raw_start`), not 0:
-the status loop persists the atomic with no monotonic guard, and a
-zero first write would clobber a resumed manifest
+`Trailing { lsn }` reports how far the pump has read after all buffered
+transactions. Reorder sends it only when the transaction buffer is empty
+(`on_idle_advance`). Collector saves this position and publishes it after
+all registered seqs finish. `Gate<PlacedFrontier>` lets a barrier wait for
+all rows to be routed. `Gate<AckFrontier>` lets it wait for those rows to
+be durable. If collector exits, both waits return an error. Both scans
+continue from their previous stopping point. Starting over for every
+event made this work O(N²), used 100% CPU, and looked like a stuck chc
+receive or INSERT
+
+Each seq records how many rows decoder routed and how many ClickHouse
+acknowledged. Reporting routed count twice or acknowledging more rows than
+routed is an error. Collector counts error instead of leaving seq silently
+incomplete. Events below completed frontier are harmless late messages.
+Events for unknown seqs at or above frontier can leave work incomplete and
+stop watermark. Collector counts these events separately and logs first one
+while seq and frontier details are still available
+
+`AckSnapshot` shows why watermark cannot advance: oldest incomplete seq,
+reported and acknowledged row counts, saved trailing position, protocol
+error count, and late event count. Collector updates snapshot after every
+event, and daemon's stall watchdog reads it. Transaction buffer stats
+cannot diagnose this case after rows have left buffer
+
+`emitter_ack` is a `Monotone<EmitterAck>` seeded at the WAL re-read
+start (`raw_start`), not 0: the status loop persists it and a zero first
+write would overwrite progress loaded from a previous run. Updates use
+`join`, which keeps larger of current and new values, so watermark cannot
+move backward
 
 ### Fatal — `pipeline/mod.rs`
 

--- a/plans/source.md
+++ b/plans/source.md
@@ -310,7 +310,13 @@ when apply advances. Bulk WAL keeps the batching tick: waking per enqueue
 costs more in listener/pump lock traffic than the latency is worth, and
 only a hold needs bytes out early. `poll_interval` stays as the backstop
 that paces the deadline and worker-liveness checks, so a lost wake
-degrades to polling rather than hanging. What remains is shadow's
+degrades to polling rather than hanging. Polling is also required because
+reported progress is the lowest position across all walreceivers. Adding a
+walreceiver can lower that position, and removing one can raise it. Both
+changes now wake the waiter, but waiter must still read current minimum
+before releasing hold. Hold checks this value first, requests one status
+update before each wait, and includes progress seen by final check in timeout
+error. What remains is shadow's
 own replay — sub-millisecond warm, ~10ms for the first catalog record
 after an idle period. Waiter is result-bearing:
 decoder-worker death (`QueueingRecordSink::worker_alive`, channel

--- a/plans/xact.md
+++ b/plans/xact.md
@@ -71,7 +71,10 @@ case is a handful of control events per xact
 
 `inflight_snapshot` is the diagnostic surface for "a commit for this
 xid never arrived" investigations — heap / chunk / event / spill
-counters per xid
+counters per xid. It only describes work still in transaction buffer.
+After rows move to decode or insert pool, `xacts_active` can be zero while
+watermark remains stuck. Stall watchdog also reads ack collector's
+`AckSnapshot` ([emitter.md](emitter.md)), which identifies seq blocking it
 
 ## TOAST reassembly
 

--- a/src/backfill/backfill_staging.rs
+++ b/src/backfill/backfill_staging.rs
@@ -83,7 +83,8 @@ pub async fn prepare(
     reqs: &[BackupRequest],
 ) -> Result<StagingPlan> {
     let mut sess = StagingSession::connect(emitter).await?;
-    let live_map = live.read().await.clone();
+    // Freeze routing for entire staging plan
+    let live_map = live.snapshot().await;
     let mut staged: HashMap<RelName, TableMapping> = HashMap::new();
     let mut rels = Vec::new();
     for r in reqs {

--- a/src/backfill/backup_backfill.rs
+++ b/src/backfill/backup_backfill.rs
@@ -42,7 +42,6 @@
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
 
 use anyhow::{Context, Result, bail};
 use tokio::sync::{Mutex, mpsc, oneshot};
@@ -303,7 +302,7 @@ async fn walk_and_ship(
         &ctx.emitter,
         1,
         ctx.stats.clone(),
-        Arc::new(AtomicU64::new(0)),
+        Arc::new(crate::pos::Monotone::new(0)),
         fatal.clone(),
         ctx.config_rx.clone(),
     )
@@ -899,7 +898,7 @@ async fn replay_gap(
         filter_rfns,
         targets,
         b_redo,
-        mapping: ctx.mapping.read().await.clone(),
+        mapping: ctx.mapping.snapshot().await,
         stats: ctx.stats.clone(),
         budget: ctx.budget.clone(),
         soft_delete: ctx.emitter.soft_delete,

--- a/src/backfill/copy_backfill.rs
+++ b/src/backfill/copy_backfill.rs
@@ -71,6 +71,7 @@ use crate::emit::ch_emitter::{EmitterConfig, EmitterStats};
 use crate::emit::pipeline::{Fatal, bootstrap, tail};
 use crate::mapping::MappingHandle;
 use crate::pg::{current_wal_lsn, quote_ident};
+use crate::pos::{Pos, Snapshot};
 use crate::runtime_config::InitialLoadMode;
 use crate::schema::{
     BOOLOID, BPCHAROID, BYTEAOID, CHAROID, DATEOID, FLOAT4OID, FLOAT8OID, INT2OID, INT4OID,
@@ -104,7 +105,7 @@ struct LedgerFile {
 struct LedgerEntry {
     namespace: String,
     relname: String,
-    s_lsn: crate::source::manifest::Lsn,
+    s_lsn: Pos<Snapshot>,
     done: bool,
     /// [`InitialLoadMode`] string; absent ⇒ `copy`
     #[serde(default = "default_ledger_mode")]
@@ -129,7 +130,7 @@ fn default_ledger_mode() -> String {
 /// `!done`, or resumes the swap tail while `swapped`.
 #[derive(Debug, Clone)]
 struct LedgerRec {
-    s_lsn: u64,
+    s_lsn: Pos<Snapshot>,
     done: bool,
     mode: InitialLoadMode,
     swapped: bool,
@@ -162,7 +163,7 @@ impl Ledger {
                             (
                                 RelName::new(&e.namespace, &e.relname),
                                 LedgerRec {
-                                    s_lsn: e.s_lsn.0,
+                                    s_lsn: e.s_lsn,
                                     done: e.done,
                                     mode,
                                     swapped: e.swapped,
@@ -204,7 +205,7 @@ impl Ledger {
                 .map(|(rel, rec)| LedgerEntry {
                     namespace: rel.namespace.to_string(),
                     relname: rel.name.to_string(),
-                    s_lsn: crate::source::manifest::Lsn(rec.s_lsn),
+                    s_lsn: rec.s_lsn,
                     done: rec.done,
                     mode: rec.mode.as_str().into(),
                     swapped: rec.swapped,
@@ -653,7 +654,7 @@ impl CopyBackfiller {
                     inner.ledger.entries.insert(
                         rel.clone(),
                         LedgerRec {
-                            s_lsn: opt_in_lsn,
+                            s_lsn: opt_in_lsn.into(),
                             done: false,
                             mode,
                             swapped: false,
@@ -668,7 +669,7 @@ impl CopyBackfiller {
                             "backfill ledger persist failed; a crash before completion re-streams without backfill",
                         );
                     }
-                    (opt_in_lsn, mode)
+                    (opt_in_lsn.into(), mode)
                 }
             };
             if !inner.active.insert(rel.clone()) {
@@ -696,7 +697,7 @@ impl CopyBackfiller {
                 spawn_pass = q.is_empty();
                 q.push(BackupRequest {
                     desc: desc.clone(),
-                    s_lsn,
+                    s_lsn: s_lsn.get(),
                 });
             }
             (s_lsn, mode, spawn_pass, resume)
@@ -898,7 +899,7 @@ impl CopyBackfiller {
     /// or DDL moved the destination shape mid-pass (the loaded copy has the
     /// pre-DDL shape; entry stays pending, next boot re-loads).
     async fn swap_rel(&self, sess: &mut StagingSession, rel: &StagingRel) -> anyhow::Result<bool> {
-        if !self.mapping.read().await.contains_key(&rel.rel) {
+        if !self.mapping.with(|m| m.contains_key(&rel.rel)).await {
             sess.drop_staging(rel).await?;
             tracing::info!(
                 target: "walshadow::backfill",
@@ -966,16 +967,14 @@ impl CopyBackfiller {
     async fn resume_swap_inner(&self, name: &RelName, rec: &LedgerRec) -> anyhow::Result<()> {
         let target = self
             .mapping
-            .read()
+            .with(|m| m.get(name).map(|t| t.target.clone()))
             .await
-            .get(name)
-            .map(|m| m.target.clone())
             .with_context(|| format!("swapped entry {name} unmapped; staging table orphaned"))?;
         let rel = StagingRel {
             rel: name.clone(),
             database: target.database,
             table: target.table,
-            s_lsn: rec.s_lsn,
+            s_lsn: rec.s_lsn.get(),
         };
         let mut sess = StagingSession::connect(self.dest_emitter()).await?;
         match sess.table_uuid(&rel.database, &rel.staging_table()).await? {
@@ -1066,7 +1065,7 @@ impl CopyBackfiller {
         self.refresh_gauges(&inner.ledger);
     }
 
-    async fn run(self: Arc<Self>, desc: Arc<RelDescriptor>, s_lsn: u64) {
+    async fn run(self: Arc<Self>, desc: Arc<RelDescriptor>, s_lsn: Pos<Snapshot>) {
         let res = self.copy_once(&desc, s_lsn).await;
         let mut inner = self.inner.lock().await;
         inner.active.remove(&desc.rel_name);
@@ -1087,7 +1086,7 @@ impl CopyBackfiller {
                     target: "walshadow::backfill",
                     qname = %desc.rel_name,
                     rows = outcome.rows,
-                    s_lsn = %format_pg_lsn(s_lsn),
+                    s_lsn = %s_lsn,
                     p_hi = %format_pg_lsn(outcome.p_hi),
                     copied = !outcome.skipped_empty,
                     "backfill complete; converged once WAL apply passes p_hi",
@@ -1110,7 +1109,7 @@ impl CopyBackfiller {
     async fn copy_once(
         &self,
         desc: &Arc<RelDescriptor>,
-        s_lsn: u64,
+        s_lsn: Pos<Snapshot>,
     ) -> anyhow::Result<CopyOutcome> {
         let qtable = format!(
             "{}.{}",
@@ -1142,7 +1141,7 @@ impl CopyBackfiller {
             &self.dest_emitter(),
             1,
             self.stats.clone(),
-            Arc::new(AtomicU64::new(0)),
+            Arc::new(crate::pos::Monotone::new(0)),
             fatal.clone(),
             self.config_rx.clone(),
         )
@@ -1202,7 +1201,7 @@ impl CopyBackfiller {
                         xid: 0,
                         xmax: 0,
                         infomask: 0,
-                        source_lsn: s_lsn,
+                        source_lsn: s_lsn.get(),
                         // COPY text rows have no on-page TID (values arrive
                         // detoasted, no chunks flow here)
                         blkno: 0,
@@ -1413,7 +1412,7 @@ mod tests {
         ledger.entries.insert(
             RelName::new("app", "orders"),
             LedgerRec {
-                s_lsn: 0x1000,
+                s_lsn: 0x1000.into(),
                 done: false,
                 mode: InitialLoadMode::Copy,
                 swapped: false,
@@ -1423,7 +1422,7 @@ mod tests {
         ledger.entries.insert(
             RelName::new("app", "done"),
             LedgerRec {
-                s_lsn: 0x800,
+                s_lsn: 0x800.into(),
                 done: true,
                 mode: InitialLoadMode::ObjectStore,
                 swapped: false,
@@ -1433,7 +1432,7 @@ mod tests {
         ledger.entries.insert(
             RelName::new("app", "mid_swap"),
             LedgerRec {
-                s_lsn: 0x2000,
+                s_lsn: 0x2000.into(),
                 done: false,
                 mode: InitialLoadMode::ObjectStore,
                 swapped: true,
@@ -1444,11 +1443,11 @@ mod tests {
 
         let again = Ledger::load(tmp.path()).await;
         let orders = again.entries.get(&RelName::new("app", "orders")).unwrap();
-        assert_eq!((orders.s_lsn, orders.done), (0x1000, false));
+        assert_eq!((orders.s_lsn.get(), orders.done), (0x1000, false));
         assert_eq!(orders.mode, InitialLoadMode::Copy);
         assert!(!orders.swapped);
         let done = again.entries.get(&RelName::new("app", "done")).unwrap();
-        assert_eq!((done.s_lsn, done.done), (0x800, true));
+        assert_eq!((done.s_lsn.get(), done.done), (0x800, true));
         assert_eq!(done.mode, InitialLoadMode::ObjectStore, "mode round-trips");
         let mid = again.entries.get(&RelName::new("app", "mid_swap")).unwrap();
         assert!(mid.swapped, "swap phase round-trips");

--- a/src/bin/stream.rs
+++ b/src/bin/stream.rs
@@ -65,6 +65,10 @@ use walshadow::mapping::MappingHandle;
 use walshadow::metrics::{MetricsRegistry, MetricsSnapshot, RateEstimator};
 use walshadow::pg::{quote_ident, socket_conninfo};
 use walshadow::pipeline::{Fatal, PipelineConfig, TailKind, bootstrap, tail};
+use walshadow::pos::{
+    Drain, EmitterAck, FilterDispatched, FilterDurable, Floor, Gate, Monotone, Pos, ShadowFlush,
+    ShadowReplay, SourceReceived,
+};
 use walshadow::queueing_record_sink::{
     DEFAULT_QUEUEING_BATCH_SIZE, DEFAULT_QUEUEING_RECORD_SINK_CAPACITY, QueueingRecordSink,
 };
@@ -902,16 +906,17 @@ async fn run_session(
         }
     };
     let backup_settings = ch_config.as_ref().and_then(|c| c.backup.clone());
-    let start_lsn_override = args
+    let start_lsn_override: Option<Pos<Floor>> = args
         .start_lsn
         .as_deref()
         .map(|s| walshadow::pg::parse_pg_lsn(s).context("--start-lsn"))
-        .transpose()?;
+        .transpose()?
+        .map(Pos::new);
 
     let live_identity = manifest::SourceIdentity {
         system_id: ident.sysid.parse().context("IDENTIFY_SYSTEM sysid")?,
         timeline: ident.timeline,
-        timeline_begin: manifest::Lsn(0),
+        timeline_begin: Pos::ZERO,
     };
     // Identity gate runs before `--ignore-cursor`: the flag discards resume
     // LSNs, not artifact ownership. Foreign system_id is fatal regardless
@@ -951,15 +956,15 @@ async fn run_session(
     };
     let raw_start = manifest::resolve_resume_lsn(
         start_lsn_override,
-        bootstrap_end_lsn,
-        manifest_at_boot.as_ref().map(|m| m.lsn.emitter_ack.0),
+        bootstrap_end_lsn.map(Pos::new),
+        manifest_at_boot.as_ref().map(|m| m.lsn.emitter_ack),
         ident.xlogpos,
     );
     let pinned = bootstrap_end_lsn.is_some() || start_lsn_override.is_some();
     let floor_at_boot = manifest_at_boot
         .as_ref()
-        .map(|m| m.floor.0)
-        .filter(|f| *f != 0);
+        .map(|m| m.floor)
+        .filter(|f| !f.is_zero());
     // Archive-end scan only feeds the greenfield clamp (keep archive
     // continuous until live streaming begins: starting after last sealed
     // segment leaves shadow missing WAL; re-read from earlier LSN, CH
@@ -975,8 +980,8 @@ async fn run_session(
     let aligned = manifest::resolve_start(raw_start, floor_at_boot, pinned, archive_end);
     tracing::info!(
         target: "walshadow",
-        raw = format_pg_lsn(raw_start).to_string(),
-        aligned = format_pg_lsn(aligned).to_string(),
+        raw = %raw_start,
+        aligned = %aligned,
         from_bootstrap = bootstrap_end_lsn.is_some() && args.start_lsn.is_none(),
         from_floor = floor_at_boot.is_some() && !pinned,
         "start LSN",
@@ -991,10 +996,10 @@ async fn run_session(
         .map(|m| m.source.timeline)
         .unwrap_or(ident.timeline);
     let mut history = load_boot_history(&mut feed, ident.timeline, stored_timeline).await?;
-    let start_timeline = match history.resume_branch(stored_timeline, aligned, WAL_SEG_SIZE) {
+    let start_timeline = match history.resume_branch(stored_timeline, aligned.get(), WAL_SEG_SIZE) {
         Some(tli) => tli,
         None if args.ignore_cursor => {
-            let found = history.tli_of_segment(aligned, WAL_SEG_SIZE);
+            let found = history.tli_of_segment(aligned.get(), WAL_SEG_SIZE);
             tracing::warn!(
                 target: "walshadow",
                 stored_timeline,
@@ -1009,9 +1014,9 @@ async fn run_session(
             "timeline_not_descendant: stored timeline {stored_timeline} does not reach \
              {} on live timeline {}'s history (it serves {:?}); \
              --ignore-cursor re-baselines onto the live branch",
-            format_pg_lsn(aligned),
+            aligned,
             ident.timeline,
-            history.tli_of_segment(aligned, WAL_SEG_SIZE),
+            history.tli_of_segment(aligned.get(), WAL_SEG_SIZE),
         ),
     };
     // Same number, different branch: the chain places a sibling exactly where it
@@ -1020,7 +1025,7 @@ async fn run_session(
     // (plans/failover.md §Lineage)
     let stored_begin = manifest_at_boot
         .as_ref()
-        .map(|m| m.source.timeline_begin.0)
+        .map(|m| m.source.timeline_begin.get())
         .unwrap_or(0);
     let live_begin = history.begin_of(stored_timeline).unwrap_or(0);
     match stored_begin {
@@ -1075,9 +1080,9 @@ async fn run_session(
     // deadlocks: shadow's replay LSN never advances since segment-sink fires
     // after per-record dispatch in the current ordering.
     let mut shadow_boot = walshadow::shadow_stream::ShadowStreamState::new(
-        history.shadow_boot_branch(stored_timeline, aligned, start_timeline),
+        history.shadow_boot_branch(stored_timeline, aligned.get(), start_timeline),
         ident.sysid.clone(),
-        aligned,
+        aligned.get(),
         args.walsender_slow_threshold,
     );
     seed_shadow_branches(
@@ -1251,18 +1256,18 @@ async fn run_session(
     if let Some(end_lsn) = bootstrap_end_lsn {
         let initial = manifest::Manifest {
             version: manifest::MANIFEST_VERSION,
-            floor: manifest::Lsn(manifest::resolved_floor(end_lsn, end_lsn)),
+            floor: manifest::resolved_floor(end_lsn, end_lsn),
             source: live_identity.clone(),
             wal: manifest::WalBranch {
                 stream_timeline: start_timeline,
             },
             lsn: manifest::LsnSet {
-                source_received: manifest::Lsn(end_lsn),
-                filter_durable: manifest::Lsn(end_lsn),
-                shadow_replay: manifest::Lsn(end_lsn),
-                drain: manifest::Lsn(end_lsn),
-                emitter_ack: manifest::Lsn(end_lsn),
-                shadow_flush: manifest::Lsn(end_lsn),
+                source_received: end_lsn.into(),
+                filter_durable: end_lsn.into(),
+                shadow_replay: end_lsn.into(),
+                drain: end_lsn.into(),
+                emitter_ack: end_lsn.into(),
+                shadow_flush: end_lsn.into(),
             },
         };
         manifest::write(&args.spill_dir, &initial)
@@ -1332,15 +1337,15 @@ async fn run_session(
             lsn >= desc_log.floor_at_write(),
             "--start-lsn {} below descriptor log floor {}; no shape history \
              survives there — --ignore-cursor or re-bootstrap",
-            format_pg_lsn(lsn),
-            format_pg_lsn(desc_log.floor_at_write()),
+            lsn,
+            desc_log.floor_at_write(),
         );
         let head = desc_log.head();
         anyhow::ensure!(
-            head == 0 || lsn <= head,
+            head == 0 || lsn.get() <= head,
             "--start-lsn {} beyond descriptor log head {}; boundaries in \
              between were never captured — --ignore-cursor re-baselines",
-            format_pg_lsn(lsn),
+            lsn,
             format_pg_lsn(head),
         );
     }
@@ -1355,12 +1360,12 @@ async fn run_session(
             .fetch_all_descriptors()
             .await
             .context("descriptor log boot seed")?;
-        let covered_through = raw_start.max(replay_lsn);
+        let covered_through = raw_start.get().max(replay_lsn);
         let entries = descs
             .into_iter()
             .map(|d| {
                 Arc::new(walshadow::desc_log::LogEntry {
-                    valid_from: aligned,
+                    valid_from: aligned.get(),
                     oid: d.oid,
                     rfn: d.rfn,
                     value: walshadow::desc_log::LogValue::Present(Arc::new(d)),
@@ -1407,22 +1412,15 @@ async fn run_session(
     let decoder_stats_handle = decoder.stats_handle();
 
     let mut emitter_stats_handle: Option<Arc<EmitterStats>> = None;
-    // Durable watermark (ack collector atomic). Seed at `raw_start`, not 0:
-    // status loop persists this atomic into the manifest's `emitter_ack`
-    // each interval with no monotonic guard, first write at boot before any
-    // WAL re-read acks. Seeding 0 would clobber a resumed manifest; a crash
-    // before [aligned, raw_start] re-reads acks then resumes from
-    // ident.xlogpos next boot (precedence skips a zero ack), silently
-    // dropping [raw_start, head] WAL that never reached CH. tail's
-    // `fetch_max` keeps it monotonic as WAL re-reads [aligned, raw_start].
-    // See plans/future/pipeline_backpressure_and_scaling.md (Handoff step 3).
-    let emitter_ack = Arc::new(AtomicU64::new(raw_start));
+    // Seed at resume point so first status write cannot replace persisted ack
+    // with zero before WAL re-read catches up
+    let emitter_ack = Arc::new(Monotone::<EmitterAck>::new(raw_start.retag()));
     // Persisted resolved floor. Seed with the resolved start: aligned +
     // archive-clamped, the exact position a crash-now restart replays from.
     // Any Dropped queued during the boot re-read of [aligned, raw_start] has
     // commit_lsn ≥ aligned, so its retire holds until a later manifest write
     // moves the floor past it.
-    let resume_floor = Arc::new(AtomicU64::new(aligned));
+    let resume_floor = Arc::new(Monotone::<Floor>::new(aligned));
     // Deferred retires queued before a stop; entries below `aligned` never
     // replay their drop, so the post-spawn flush below is their only route
     // to the wipe. Loaded in metrics-only runs too (inert without a chunk
@@ -1559,7 +1557,7 @@ async fn run_session(
                     backfiller_effects.as_ref(),
                     rel,
                     row,
-                    raw_start,
+                    raw_start.get(),
                 )
                 .await
                 .with_context(|| format!("seed opt-in for {rel}"))?;
@@ -1574,7 +1572,7 @@ async fn run_session(
                     backfiller_effects.as_ref(),
                     rel,
                     row,
-                    raw_start,
+                    raw_start.get(),
                 )
                 .await
                 .with_context(|| format!("config opt-in for {rel}"))?;
@@ -1592,7 +1590,7 @@ async fn run_session(
             &emitter_cfg.table_initial_loads,
             &active_tables,
             &sql_scoped_tables,
-            raw_start,
+            raw_start.get(),
         )
         .await?;
         // Baseline seeding suppresses the Added event for pinned mappings, so a
@@ -1685,7 +1683,7 @@ async fn run_session(
             decoder_pool_size: decoders,
             inserter_pool_size: inserters,
             catalog: catalog.clone(),
-            mapping: Arc::new(tokio::sync::RwLock::new(Default::default())),
+            mapping: walshadow::mapping::mapping_handle(Default::default()),
             oracle: None,
             applicator: None,
             tail: TailKind::Null,
@@ -1706,12 +1704,13 @@ async fn run_session(
         .spawn(emitter_ack.clone())
         .await
         .context("spawn decode+insert pipeline")?;
+    let ack_probe = pipeline_handle.ack_probe.clone();
     reorder_sink
         .flush_due_retires()
         .await
         .context("boot flush of due toast-mirror retires")?;
     reorder_sink
-        .apply_boot_events(desc_log.active_present_at(raw_start), raw_start)
+        .apply_boot_events(desc_log.active_present_at(raw_start.get()), raw_start.get())
         .await
         .context("boot Added pass over descriptor log")?;
     let decoder_xact = QueueingRecordSink::spawn(
@@ -1750,7 +1749,7 @@ async fn run_session(
     };
     // Segment fsync off the hot path: sink writes+renames, the task fsyncs and
     // publishes `durable_lsn`. Seed at the resume point.
-    let durable_lsn = Arc::new(AtomicU64::new(stream.dispatched_lsn()));
+    let durable_lsn = Arc::new(Monotone::<FilterDurable>::new(stream.dispatched_lsn()));
     let fsync_fatal = walshadow::pipeline::Fatal::new();
     let (fsync_tx, fsync_rx) = tokio::sync::mpsc::channel::<SegFsync>(SEGMENT_FSYNC_QUEUE);
     let fsync_task = spawn_segment_fsync(
@@ -1766,8 +1765,10 @@ async fn run_session(
     // floor, the task compacts. Coalesces by construction — a watch holds
     // only the latest floor.
     let gc_fatal = walshadow::pipeline::Fatal::new();
-    let (gc_floor_tx, gc_floor_rx) = tokio::sync::watch::channel(0u64);
-    let gc_task = spawn_desc_log_gc(desc_log.clone(), gc_floor_rx, gc_fatal.clone());
+    // Pruner's own cell, not `resume_floor`: dropping it is what tells the gc
+    // task the session is done
+    let gc_floor = Monotone::<Floor>::default();
+    let gc_task = spawn_desc_log_gc(desc_log.clone(), gc_floor.watch(), gc_fatal.clone());
     let mut chunk_buf = Vec::with_capacity(64 * 1024);
 
     // Metrics endpoint + control socket + SIGHUP are process-lifetime (bound in
@@ -1781,10 +1782,10 @@ async fn run_session(
     // Retention sweeper writes shadow's `pg_last_wal_replay_lsn` here;
     // status loop reads it for the cursor's `shadow_replay_lsn` slot + the
     // standby-status `apply_lsn` ceiling.
-    let shadow_replay_lsn = Arc::new(AtomicU64::new(0));
+    let shadow_replay_lsn = Arc::new(Monotone::<ShadowReplay>::default());
     // Aggregate flush across ShadowStreamSink connections, fed into the
     // cursor for shadow's `START_REPLICATION PHYSICAL` resume on restart.
-    let shadow_flush_lsn = Arc::new(AtomicU64::new(0));
+    let shadow_flush_lsn = Arc::new(Monotone::<ShadowFlush>::default());
 
     // Retention sweeper drops filtered segments more than `retention_bytes`
     // behind shadow's replay LSN. Its poll doubles as the only feed of
@@ -1847,7 +1848,7 @@ async fn run_session(
     if let Err(e) = feed
         .start_physical_replication(
             source_conn.slot.as_deref(),
-            stream.next_lsn(),
+            stream.next_lsn().get(),
             start_timeline,
         )
         .await
@@ -1881,7 +1882,7 @@ async fn run_session(
     // Inflight-stall watchdog: xacts_active > 0 with stalled
     // `emitter_ack_lsn` dumps the parked xids holding the slot. One-shot
     // per stall, re-arms when ack advances.
-    let mut last_emitter_ack_observed: u64 = 0;
+    let mut last_emitter_ack_observed = Pos::<EmitterAck>::ZERO;
     let mut inflight_stall_since: Option<Instant> = None;
     let mut inflight_stall_logged = false;
     // Pump reads `paused` and the source endpoint live off the resolver watch;
@@ -1962,7 +1963,7 @@ async fn run_session(
                 source_conn.slot.as_deref(),
                 stream.next_lsn(),
                 stream_branch(&history, live_identity.system_id, &stream),
-                resume_floor.load(Ordering::Acquire),
+                resume_floor.get(),
                 Duration::from_secs(args.status_interval),
             )
             .await
@@ -1976,7 +1977,7 @@ async fn run_session(
                     tracing::info!(
                         target: "walshadow",
                         endpoint = source_conn.endpoint(),
-                        resume_lsn = %format_pg_lsn(stream.next_lsn()),
+                        resume_lsn = %stream.next_lsn(),
                         slot = source_conn.slot.as_deref(),
                         "source feed swapped",
                     );
@@ -1998,8 +1999,8 @@ async fn run_session(
         }
         // `durable` (fsynced) lags `dispatched`; advertise it as flush/cursor.
         let dispatched = stream.dispatched_lsn();
-        let durable = durable_lsn.load(Ordering::Acquire);
-        let received = feed.last_server_wal_end().max(dispatched);
+        let durable = durable_lsn.get();
+        let received: Pos<SourceReceived> = Pos::new(feed.last_server_wal_end().max(dispatched));
         // Two frontiers, two questions. `consumed` is where resume asks the
         // promoted target to start; `received` is the source head last heard
         // about, which the target must reach before promotion. Bytes cannot
@@ -2007,7 +2008,10 @@ async fn run_session(
         // reported a head yet reads as level with the consumed frontier
         match (paused, pause_frontier) {
             (true, None) => {
-                pause_frontier = Some((stream.next_lsn(), received.max(stream.next_lsn())));
+                pause_frontier = Some((
+                    stream.next_lsn().get(),
+                    received.get().max(stream.next_lsn().get()),
+                ));
                 // A pause this process never saw lifted was taken before it
                 // booted, so these two numbers replace ones an operator may
                 // already hold. Both re-freeze conservatively — consumed drops
@@ -2053,17 +2057,17 @@ async fn run_session(
                 }
             };
         }
-        let shadow_replay = shadow_replay_lsn.load(Ordering::Acquire);
+        let shadow_replay = shadow_replay_lsn.get();
         let (shadow_agg, shadow_served_tli) = {
             let state = shadow_state.lock().await;
             (state.aggregate(), state.timeline)
         };
         if let Some(flush) = shadow_agg.min_flush_lsn {
-            shadow_flush_lsn.fetch_max(flush, Ordering::Release);
+            shadow_flush_lsn.join(flush);
         }
-        let (drain_lsn, emitter_ack_lsn) = {
+        let (drain_lsn, resume_safe_lsn) = {
             let mut b = xact_buffer.lock().await;
-            let ea = emitter_ack.load(Ordering::Acquire);
+            let ea = emitter_ack.get();
             let drain_lsn = b.stats().drain_lsn;
             // Keep every undurable transaction reachable after restart
             // Read acknowledgment first so no transaction escapes floor
@@ -2072,41 +2076,40 @@ async fn run_session(
         // shadow_replay==0 (sweeper off or not yet reported) means "no
         // constraint from shadow", not the literal min: else a fresh boot
         // with retention off pins apply_lsn at 0 and source's slot never recycles.
-        let apply_ceiling = match shadow_replay {
-            0 => emitter_ack_lsn,
-            s => s.min(emitter_ack_lsn),
+        let apply_ceiling = match shadow_replay.get() {
+            0 => resume_safe_lsn,
+            s => s.min(resume_safe_lsn.get()).into(),
         };
         // Never walks back. A crossing commits the fork segment's start, which
         // `align_down(emitter_ack)` reaches only once descendant WAL fills that
         // segment; the natural terms must not undo the position a restart
         // resumes from. A rewind (`--start-lsn`, `--ignore-cursor`) lowers it by
         // seeding `resume_floor` at the rewind point instead
-        let floor = manifest::resolved_floor(emitter_ack_lsn, durable)
-            .max(resume_floor.load(Ordering::Acquire));
+        let floor = manifest::resolved_floor(resume_safe_lsn, durable).max(resume_floor.get());
         let floor_timeline = history.floor_branch(
-            floor,
+            floor.get(),
             live_identity.timeline,
             stream.timeline(),
             WAL_SEG_SIZE,
         );
         let cur = manifest::Manifest {
             version: manifest::MANIFEST_VERSION,
-            floor: manifest::Lsn(floor),
+            floor,
             source: manifest::SourceIdentity {
                 system_id: live_identity.system_id,
                 timeline: floor_timeline,
-                timeline_begin: manifest::Lsn(history.begin_of(floor_timeline).unwrap_or(0)),
+                timeline_begin: history.begin_of(floor_timeline).unwrap_or(0).into(),
             },
             wal: manifest::WalBranch {
                 stream_timeline: stream.timeline(),
             },
             lsn: manifest::LsnSet {
-                source_received: manifest::Lsn(received),
-                filter_durable: manifest::Lsn(durable),
-                shadow_replay: manifest::Lsn(shadow_replay),
-                drain: manifest::Lsn(drain_lsn),
-                emitter_ack: manifest::Lsn(emitter_ack_lsn),
-                shadow_flush: manifest::Lsn(shadow_flush_lsn.load(Ordering::Acquire)),
+                source_received: received,
+                filter_durable: durable,
+                shadow_replay,
+                drain: drain_lsn,
+                emitter_ack: resume_safe_lsn,
+                shadow_flush: shadow_flush_lsn.get(),
             },
         };
         if last_cursor_write.is_none_or(|t| t.elapsed() >= cursor_write_interval) {
@@ -2116,18 +2119,19 @@ async fn run_session(
             last_cursor_write = Some(Instant::now());
             // Publish only after persist: pruners cut against what a
             // crash-now restart actually resumes from.
-            resume_floor.store(cur.floor.0, Ordering::Release);
+            resume_floor.join(cur.floor);
             // Descriptor log prunes against the same floor, off this task: a
             // compaction rewrites the whole ckpt inline and would stall WAL
             // consumption past the source's wal_sender_timeout
-            gc_floor_tx.send_replace(cur.floor.0);
+            gc_floor.join(cur.floor);
         }
         // flush caps physical slot's restart_lsn.
         // Manifest writes are cadence-gated above while keepalive replies inside
         // next_event can send this status at any time.
         let status = StandbyStatus {
             write_lsn: received,
-            flush_lsn: apply_ceiling.min(resume_floor.load(Ordering::Acquire)),
+            // Keep source slot behind crash-safe resume floor
+            flush_lsn: resume_floor.get().min(apply_ceiling.retag()),
             apply_lsn: apply_ceiling,
         };
         let dispatched_before = stream.dispatched_lsn();
@@ -2157,11 +2161,11 @@ async fn run_session(
                 // resumable there, so this is the crossing arriving as a socket
                 // close rather than as a next-timeline result
                 Ok(SourceEvent::Shutdown) | Err(_)
-                if history.branch_exhausted(stream.timeline(), stream.next_lsn()) =>
+                if history.branch_exhausted(stream.timeline(), stream.next_lsn().get()) =>
             {
                     tracing::info!(
                         target: "walshadow",
-                        switch_lsn = %format_pg_lsn(stream.next_lsn()),
+                        switch_lsn = %stream.next_lsn(),
                         finished_timeline = stream.timeline(),
                         "source stream ended where the branch does — crossing",
                     );
@@ -2174,7 +2178,7 @@ async fn run_session(
                 Ok(SourceEvent::Shutdown) => {
                     tracing::info!(
                         target: "walshadow",
-                        resume_lsn = format_pg_lsn(stream.next_lsn()).to_string(),
+                        resume_lsn = %stream.next_lsn(),
                         "source shut down its walsender — reconnecting",
                     );
                     feed = source_recovery
@@ -2193,7 +2197,7 @@ async fn run_session(
                     None
                 }
                 Err(e) => {
-                    let resume = stream.next_lsn();
+                    let resume = stream.next_lsn().get();
                     tracing::warn!(
                         target: "walshadow",
                         error = %e,
@@ -2214,7 +2218,7 @@ async fn run_session(
                     // Recovery dialed the live endpoint, so a queued swap is done
                     source_swap_pending = false;
                     source_swap_retry_at = None;
-                    let resumed = stream.next_lsn();
+                    let resumed = stream.next_lsn().get();
                     tracing::info!(
                         target: "walshadow",
                         resume_lsn = format_pg_lsn(resumed).to_string(),
@@ -2224,7 +2228,10 @@ async fn run_session(
                 }
             },
         };
-        let server_end = chunk.as_ref().map(|c| c.server_wal_end).unwrap_or(received);
+        let server_end = chunk
+            .as_ref()
+            .map(|c| c.server_wal_end)
+            .unwrap_or(received.get());
         if let Some(chunk) = chunk {
             stream
                 .push(
@@ -2310,7 +2317,7 @@ async fn run_session(
                     );
                     crossing.retry_from_source(Instant::now() + SOURCE_SWAP_RETRY);
                 }
-                Err(e) => crossing.park(e, stream.next_lsn(), None),
+                Err(e) => crossing.park(e, stream.next_lsn().get(), None),
             }
         }
         if crossing_due
@@ -2326,13 +2333,26 @@ async fn run_session(
                 .flush()
                 .await
                 .context("flush queueing decoder sink at the fork")?;
-            let fence_deadline = Instant::now() + FORK_FENCE_DRAIN;
-            while record_sink.decoder_xact.in_flight() > 0 && Instant::now() < fence_deadline {
+            let fence = Instant::now();
+            let in_flight = loop {
+                let n = record_sink.decoder_xact.in_flight();
+                if n == 0 || fence.elapsed() >= FORK_FENCE_DRAIN {
+                    break n;
+                }
                 tokio::time::sleep(Duration::from_millis(10)).await;
+            };
+            // Timeout stops queue drain only, fork guards remain authoritative
+            if in_flight != 0 {
+                tracing::warn!(
+                    target: "walshadow",
+                    in_flight,
+                    waited = ?fence.elapsed(),
+                    "fork fence gave up draining the pump queue — guards decide",
+                );
             }
             let (guards, resume_safe) = {
                 let mut b = xact_buffer.lock().await;
-                let ea = emitter_ack.load(Ordering::Acquire);
+                let ea = emitter_ack.get();
                 let resume_safe = b.resume_safe_lsn(ea);
                 let stats = b.stats();
                 (
@@ -2351,7 +2371,7 @@ async fn run_session(
                 resume_safe_lsn: resume_safe,
                 shadow_apply_lsn: shadow_agg.min_apply_lsn,
                 filter_durable: durable,
-                floor: resume_floor.load(Ordering::Acquire),
+                floor: resume_floor.get(),
             }
             .pending(probed.switch_lsn, WAL_SEG_SIZE);
             if let Some(wait) = waiting_on {
@@ -2376,15 +2396,16 @@ async fn run_session(
                         &live_identity,
                         resume,
                         manifest::LsnSet {
-                            source_received: manifest::Lsn(received.max(resume.switch_lsn)),
-                            filter_durable: manifest::Lsn(durable),
-                            shadow_replay: manifest::Lsn(shadow_replay),
-                            drain: manifest::Lsn(guards.drain_lsn),
-                            emitter_ack: manifest::Lsn(resume_safe),
-                            shadow_flush: manifest::Lsn(shadow_flush_lsn.load(Ordering::Acquire)),
+                            // Fork cannot precede last observed source head
+                            source_received: received.get().max(resume.switch_lsn.get()).into(),
+                            filter_durable: durable,
+                            shadow_replay,
+                            drain: guards.drain_lsn,
+                            emitter_ack: resume_safe,
+                            shadow_flush: shadow_flush_lsn.get(),
                         },
                         &resume_floor,
-                        &gc_floor_tx,
+                        &gc_floor,
                     )
                     .await
                 };
@@ -2411,9 +2432,9 @@ async fn run_session(
                             next_timeline = crossed.next_tli,
                             live_timeline = crossed.live_tli,
                             switch_lsn = %format_pg_lsn(crossed.switch_lsn),
-                            resume_lsn = %format_pg_lsn(stream.next_lsn()),
-                            floor_lsn = %format_pg_lsn(resume_floor.load(Ordering::Acquire)),
-                            drain_lsn = %format_pg_lsn(guards.drain_lsn),
+                            resume_lsn = %stream.next_lsn(),
+                            floor_lsn = %resume_floor.get(),
+                            drain_lsn = %guards.drain_lsn,
                             prefix_bytes_verified = crossed.prefix_bytes,
                             slot = source_conn.slot.as_deref(),
                             "crossed source timeline",
@@ -2439,7 +2460,7 @@ async fn run_session(
                         crossing.retry_from_source(Instant::now() + SOURCE_SWAP_RETRY);
                         crossing.hold_fork(probed);
                     }
-                    Err(e) => crossing.park(e, stream.next_lsn(), Some(probed.switch_lsn)),
+                    Err(e) => crossing.park(e, stream.next_lsn().get(), Some(probed.switch_lsn)),
                 }
             }
         }
@@ -2465,9 +2486,9 @@ async fn run_session(
         // Re-read rather than reuse the top-of-iteration pair: a crossing commits
         // a new floor and branch mid-iteration, and this is what an operator
         // watches to know the crossing is durable
-        let published_floor = floor.max(resume_floor.load(Ordering::Acquire));
+        let published_floor = floor.max(resume_floor.get());
         let published_branch = history.floor_branch(
-            published_floor,
+            published_floor.get(),
             live_identity.timeline,
             stream.timeline(),
             WAL_SEG_SIZE,
@@ -2498,18 +2519,18 @@ async fn run_session(
         let decoder_stats: &walshadow::decoder_sink::DecoderStats = &record_sink.decoder_stats;
         let emitter_stats: Option<&walshadow::ch_emitter::EmitterStats> =
             record_sink.emitter_stats.as_deref();
-        let shadow_apply_lsn = shadow_agg.min_apply_lsn.unwrap_or(0);
-        let lag_bytes = received.saturating_sub(shadow_apply_lsn);
-        rate_estimator.observe(Instant::now(), received);
+        let shadow_apply_lsn = shadow_agg.min_apply_lsn.map_or(0, Pos::get);
+        let lag_bytes = received.get().saturating_sub(shadow_apply_lsn);
+        rate_estimator.observe(Instant::now(), received.get());
         let lag_seconds = rate_estimator.seconds_for(lag_bytes);
         // Post-worker snapshots so the metric reflects what the worker
         // drained, not the top-of-iteration values.
-        let emitter_ack_for_metric = emitter_ack.load(Ordering::Acquire);
+        let emitter_ack_for_metric = emitter_ack.get();
         let drain_for_metric = xact_stats.drain_lsn;
         populate_metrics(
             &metrics,
             received,
-            now_dispatched,
+            now_dispatched.into(),
             shadow_replay,
             drain_for_metric,
             emitter_ack_for_metric,
@@ -2594,7 +2615,9 @@ async fn run_session(
             inflight_stall_since = None;
             inflight_stall_logged = false;
         }
-        if xact_stats.xacts_active > 0 {
+        // Ack can pin after transaction leaves buffer
+        let ack_snap = *ack_probe.borrow();
+        if xact_stats.xacts_active > 0 || !ack_snap.all_done() || ack_snap.wedged != 0 {
             let since = inflight_stall_since.get_or_insert(Instant::now());
             if !inflight_stall_logged && since.elapsed() >= Duration::from_secs(5) {
                 let snap = xact_buffer.lock().await.inflight_snapshot();
@@ -2619,12 +2642,14 @@ async fn run_session(
                 tracing::warn!(
                     target: "walshadow",
                     xacts_active = xact_stats.xacts_active,
-                    emitter_ack_lsn = format_pg_lsn(emitter_ack_for_metric).to_string(),
-                    drain_lsn = format_pg_lsn(xact_stats.drain_lsn).to_string(),
-                    source_received = format_pg_lsn(received).to_string(),
+                    emitter_ack_lsn = %emitter_ack_for_metric,
+                    drain_lsn = %xact_stats.drain_lsn,
+                    source_received = %received,
                     filter_dispatched = format_pg_lsn(now_dispatched).to_string(),
                     inflight = %summary,
-                    "xact inflight parked — emitter ack pinned by these xids",
+                    ack = ?ack_snap,
+                    waiting_on = ack_snap.stall_reason().unwrap_or("buffered xacts"),
+                    "emitter ack pinned",
                 );
                 inflight_stall_logged = true;
             }
@@ -2652,7 +2677,7 @@ async fn run_session(
     }
     // Close the floor channel and join: nothing else may own desc_log.ckpt
     // after the session returns
-    drop(gc_floor_tx);
+    drop(gc_floor);
     gc_task.await.ok();
     if let Some(msg) = gc_fatal.message() {
         anyhow::bail!("{msg}");
@@ -2889,7 +2914,7 @@ fn spawn_mapping_refresher(
         // Boot value already seeded into `mapping`; react to republishes.
         while config_rx.changed().await.is_ok() {
             let tables = config_rx.borrow_and_update().tables.clone();
-            *mapping.write().await = Arc::new(tables);
+            mapping.publish(Arc::new(tables)).await;
             tracing::info!(
                 target: "walshadow::config",
                 "routing map refreshed from resolved config",
@@ -2930,7 +2955,7 @@ fn sync_filesystem(_fd: std::os::fd::RawFd) -> std::io::Result<()> {
 fn spawn_segment_fsync(
     out_dir: PathBuf,
     mut rx: tokio::sync::mpsc::Receiver<SegFsync>,
-    durable_lsn: Arc<AtomicU64>,
+    durable_lsn: Arc<Monotone<FilterDurable>>,
     fatal: walshadow::pipeline::Fatal,
 ) -> tokio::task::JoinHandle<()> {
     use std::os::unix::io::AsRawFd;
@@ -2960,7 +2985,7 @@ fn spawn_segment_fsync(
                     return;
                 }
             }
-            durable_lsn.fetch_max(max_lsn, Ordering::Release);
+            durable_lsn.join(max_lsn);
         }
     })
 }
@@ -2973,16 +2998,20 @@ fn spawn_segment_fsync(
 /// for boundary-free stretches, which is the common case.
 fn spawn_desc_log_gc(
     desc_log: Arc<walshadow::desc_log::DescriptorLog>,
-    mut floor_rx: tokio::sync::watch::Receiver<u64>,
+    floor: Gate<Floor>,
     fatal: walshadow::pipeline::Fatal,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        while floor_rx.changed().await.is_ok() {
-            let floor = *floor_rx.borrow_and_update();
-            if let Err(e) = desc_log.maybe_gc(floor).await {
-                fatal.set(format!("descriptor log gc at {floor:#X}: {e}"));
+        let mut cut = floor.current();
+        loop {
+            if let Err(e) = desc_log.maybe_gc(cut).await {
+                fatal.set(format!("descriptor log gc at {cut}: {e}"));
                 return;
             }
+            let Ok(next) = floor.advance(cut).await else {
+                return;
+            };
+            cut = next;
         }
     })
 }
@@ -2996,7 +3025,7 @@ fn spawn_retention(
     out_dir: PathBuf,
     retention_bytes: u64,
     shadow_conninfo: String,
-    shadow_replay_lsn: Arc<AtomicU64>,
+    shadow_replay_lsn: Arc<Monotone<ShadowReplay>>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut client: Option<tokio_postgres::Client> = None;
@@ -3026,8 +3055,8 @@ fn spawn_retention(
             };
             // Wait until shadow replays first record
             let Some(lsn) = replay else { continue };
-            shadow_replay_lsn.fetch_max(lsn, Ordering::Release);
-            let cutoff = manifest::retention_cutoff(lsn, retention_bytes, redo);
+            shadow_replay_lsn.join(lsn);
+            let cutoff = manifest::retention_cutoff(lsn, retention_bytes, redo.map(Pos::new));
             match trim_below_lsn(&out_dir, cutoff).await {
                 Ok(r) if r.segments_removed > 0 => {
                     tracing::info!(
@@ -3036,7 +3065,7 @@ fn spawn_retention(
                         manifests = r.manifests_removed,
                         partials = r.partials_removed,
                         bytes_freed = r.bytes_freed,
-                        cutoff_lsn = format_pg_lsn(cutoff).to_string(),
+                        cutoff_lsn = %cutoff,
                         "trim cycle",
                     );
                 }
@@ -3099,7 +3128,7 @@ struct TimelineView {
     shadow_served_timeline: u32,
     /// Branch the shadow is replaying
     shadow_replay_timeline: u32,
-    floor_lsn: u64,
+    floor_lsn: Pos<Floor>,
     stats: TimelineStats,
     /// `(consumed, received)` frozen when the pump observed a pause
     pause_frontier: Option<(u64, u64)>,
@@ -3156,11 +3185,11 @@ struct DrainResident {
 #[allow(clippy::too_many_arguments)]
 async fn populate_metrics(
     registry: &MetricsRegistry,
-    source_received_lsn: u64,
-    filter_lsn: u64,
-    shadow_replay_lsn: u64,
-    decoder_commit_lsn: u64,
-    emitter_ack_lsn: u64,
+    source_received_lsn: Pos<SourceReceived>,
+    filter_lsn: Pos<FilterDispatched>,
+    shadow_replay_lsn: Pos<ShadowReplay>,
+    decoder_commit_lsn: Pos<Drain>,
+    emitter_ack_lsn: Pos<EmitterAck>,
     rec_metrics: &MetricsRecordSink,
     pump_queue_depth: u64,
     queue_records_out_total: u64,
@@ -3472,9 +3501,9 @@ fn bridge_ops(
 async fn reconnect_source(
     cfg: &PgConfig,
     slot: Option<&str>,
-    resume_lsn: u64,
+    resume_lsn: Pos<Floor>,
     branch: SourceBranch,
-    floor: u64,
+    floor: Pos<Floor>,
     status_interval: Duration,
 ) -> Result<SourceFeed> {
     use backon::{ExponentialBuilder, Retryable};
@@ -3611,18 +3640,18 @@ async fn commit_fork_resume(
     identity: &manifest::SourceIdentity,
     resume: walshadow::transition::ForkResume,
     lsn: manifest::LsnSet,
-    resume_floor: &AtomicU64,
-    gc_floor_tx: &tokio::sync::watch::Sender<u64>,
+    resume_floor: &Monotone<Floor>,
+    gc_floor: &Monotone<Floor>,
 ) -> Result<()> {
     let committed = manifest::Manifest {
         version: manifest::MANIFEST_VERSION,
-        floor: manifest::Lsn(resume.floor),
+        floor: resume.floor,
         source: manifest::SourceIdentity {
             system_id: identity.system_id,
             timeline: resume.timeline,
             // The fork is where the descendant begins, so the next boot can
             // refuse a sibling that shares its number
-            timeline_begin: manifest::Lsn(resume.switch_lsn),
+            timeline_begin: resume.switch_lsn,
         },
         wal: manifest::WalBranch {
             stream_timeline: resume.timeline,
@@ -3632,13 +3661,14 @@ async fn commit_fork_resume(
     manifest::write(spill_dir, &committed)
         .await
         .context("write resume manifest at the fork")?;
-    resume_floor.store(resume.floor, Ordering::Release);
-    gc_floor_tx.send_replace(resume.floor);
+    // Descendant floor starts new position space
+    resume_floor.rebase(resume.floor);
+    gc_floor.rebase(resume.floor);
     tracing::info!(
         target: "walshadow",
         timeline = resume.timeline,
-        floor = %format_pg_lsn(resume.floor),
-        switch_lsn = %format_pg_lsn(resume.switch_lsn),
+        floor = %resume.floor,
+        switch_lsn = %resume.switch_lsn,
         "committed the fork resume position",
     );
     Ok(())
@@ -3741,9 +3771,9 @@ struct SourceBranch {
 async fn resume_source_feed(
     cfg: &PgConfig,
     slot: Option<&str>,
-    resume_lsn: u64,
+    resume_lsn: Pos<Floor>,
     branch: SourceBranch,
-    floor: u64,
+    floor: Pos<Floor>,
     status_interval: Duration,
 ) -> Result<SourceFeed> {
     let mut feed = SourceFeed::connect(cfg)
@@ -3779,7 +3809,7 @@ async fn resume_source_feed(
                     source,
                 }
             })?;
-            prove_branch(&history, branch, resume_lsn)?;
+            prove_branch(&history, branch, resume_lsn.get())?;
         }
         // Timeline 1 has no history file, and a source serving none for a newer
         // branch can place nothing; only a run that never left the branch it is
@@ -3794,9 +3824,9 @@ async fn resume_source_feed(
             .await
             .map_err(TransitionError::from)?;
     }
-    feed.start_physical_replication(slot, resume_lsn, branch.timeline)
+    feed.start_physical_replication(slot, resume_lsn.get(), branch.timeline)
         .await
-        .with_context(|| format!("START_REPLICATION at {}", format_pg_lsn(resume_lsn)))?;
+        .with_context(|| format!("START_REPLICATION at {resume_lsn}"))?;
     Ok(feed)
 }
 
@@ -3827,7 +3857,7 @@ fn prove_branch(
     }
     if !history.proves_ancestor(branch.timeline, resume_lsn) {
         return Err(TransitionError::ResumePastFork {
-            next_lsn: resume_lsn,
+            next_lsn: resume_lsn.into(),
             switch_lsn: history.switchpoint_of(branch.timeline).unwrap_or(0),
         });
     }
@@ -3849,7 +3879,7 @@ struct SourceRecovery<'a> {
     spill_dir: &'a Path,
     /// Published resume floor, which is what a slot on the far end has to still
     /// reach — the reconnect's own `resume_lsn` sits above it
-    floor: &'a AtomicU64,
+    floor: &'a Monotone<Floor>,
 }
 
 impl SourceRecovery<'_> {
@@ -3877,7 +3907,7 @@ impl SourceRecovery<'_> {
         // reaching for the archive. A removed-WAL (58P01) error means the
         // source genuinely can't serve it — skip straight to the archive.
         if !source_missing {
-            let floor = self.floor.load(Ordering::Acquire);
+            let floor = self.floor.get();
             match resume_source_feed(cfg, slot, resume_lsn, branch, floor, self.status_interval)
                 .await
             {
@@ -3885,7 +3915,7 @@ impl SourceRecovery<'_> {
                 Err(retry_error) => tracing::warn!(
                     target: "walshadow",
                     error = %retry_error,
-                    resume_lsn = %format_pg_lsn(resume_lsn),
+                    resume_lsn = %resume_lsn,
                     "source still unavailable — trying archive",
                 ),
             }
@@ -3893,7 +3923,7 @@ impl SourceRecovery<'_> {
             tracing::warn!(
                 target: "walshadow",
                 error = %source_error,
-                resume_lsn = %format_pg_lsn(resume_lsn),
+                resume_lsn = %resume_lsn,
                 "source recycled resume point — trying archive",
             );
         }
@@ -3929,9 +3959,14 @@ impl SourceRecovery<'_> {
         let seg_dir = self.spill_dir.join("resume_wal");
 
         loop {
-            let archive_segment =
-                fetch_archive_segment(settings, &storage, &seg_dir, branch.timeline, resume_lsn)
-                    .await;
+            let archive_segment = fetch_archive_segment(
+                settings,
+                &storage,
+                &seg_dir,
+                branch.timeline,
+                resume_lsn.get(),
+            )
+            .await;
             let (name, bytes) = match archive_segment {
                 Ok(segment) => segment,
                 Err(archive_error) => {
@@ -3939,7 +3974,7 @@ impl SourceRecovery<'_> {
                     tracing::info!(
                         target: "walshadow",
                         error = %archive_error,
-                        resume_lsn = %format_pg_lsn(resume_lsn),
+                        resume_lsn = %resume_lsn,
                         "archive lacks next WAL — switching back to source",
                     );
                     return self
@@ -3955,7 +3990,7 @@ impl SourceRecovery<'_> {
             };
 
             stream
-                .push(resume_lsn, &bytes, record_sink, segment_sink)
+                .push(resume_lsn.get(), &bytes, record_sink, segment_sink)
                 .await
                 .with_context(|| format!("replay archived WAL {name}"))?;
             tracing::info!(
@@ -3972,7 +4007,7 @@ impl SourceRecovery<'_> {
         cfg: &PgConfig,
         slot: Option<&str>,
         branch: SourceBranch,
-        resume_lsn: u64,
+        resume_lsn: Pos<Floor>,
         archive_error: &str,
     ) -> Result<SourceFeed> {
         reconnect_source(
@@ -3980,15 +4015,14 @@ impl SourceRecovery<'_> {
             slot,
             resume_lsn,
             branch,
-            self.floor.load(Ordering::Acquire),
+            self.floor.get(),
             self.status_interval,
         )
         .await
         .map_err(|source_error| {
             source_error.context(format!(
-                "source cannot serve WAL at {}; {archive_error}; \
+                "source cannot serve WAL at {resume_lsn}; {archive_error}; \
                  base-backup refresh requires operator action",
-                format_pg_lsn(resume_lsn),
             ))
         })
     }
@@ -4140,10 +4174,10 @@ async fn run_bootstrap(
         // defaults 0 to its own partial-flush deadline.
         let addr = format!("{}:{}", emitter_cfg.host, emitter_cfg.port);
         let stats = bootstrap_stats.clone();
-        // Throwaway watermark atomic: durability proof is `wait_through(K)`,
+        // Throwaway watermark: durability proof is `wait_through(K)`,
         // resume LSN is carried via the WAL pipeline's emitter_ack seed
         // (see `run`), so uniform `commit_lsn = start_lsn` here is fine.
-        let emitter_ack = Arc::new(AtomicU64::new(0));
+        let emitter_ack = Arc::new(Monotone::<EmitterAck>::new(0));
         let fatal = Fatal::new();
         let inserter_pool_size = emitter_cfg.inserter_pool_size;
         let (msg_tx, ack, tail) = tail::spawn(

--- a/src/catalog/desc_log.rs
+++ b/src/catalog/desc_log.rs
@@ -82,6 +82,7 @@ use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 use tokio_postgres::types::Oid;
 use walrus::pg::walparser::RelFileNode;
 
+use crate::pos::{Floor, Pos};
 use crate::schema::{RelAttr, RelDescriptor, RelName, ReplIdent};
 use ahash::{HashMap, HashSet, HashSetExt};
 
@@ -264,7 +265,7 @@ struct Index {
     amb_db: HashMap<Oid, Vec<Arc<Ambiguity>>>,
     batches: BTreeMap<u64, Arc<BatchRecord>>,
     covered_through: u64,
-    floor_at_write: u64,
+    floor_at_write: Pos<Floor>,
     entries_total: usize,
 }
 
@@ -434,7 +435,7 @@ impl DescriptorLog {
 
     /// Floor recorded by the last GC ckpt write; `--start-lsn` below it has
     /// no descriptor history
-    pub fn floor_at_write(&self) -> u64 {
+    pub fn floor_at_write(&self) -> Pos<Floor> {
         self.index.read().unwrap().floor_at_write
     }
 
@@ -756,18 +757,19 @@ impl DescriptorLog {
     /// predate the drop, and the floor never exceeds the re-read start).
     /// Batches above the floor survive whole (stubs included) for boot
     /// replay; below it they exist only as carriers of retained entries.
-    pub async fn maybe_gc(&self, floor: u64) -> Result<bool> {
+    pub async fn maybe_gc(&self, floor: impl Into<Pos<Floor>>) -> Result<bool> {
+        let floor = floor.into();
         let w = self.writer.lock().await;
         let tail_bytes = w.tail_len - w.header_len;
         let (retained, dropped_entries) = {
             let idx = self.index.read().unwrap();
             // Count before rebuilding: this runs at cursor-write cadence and
             // usually declines, while compute_retained re-sorts every chain
-            let dropped = droppable_entries(&idx, floor);
+            let dropped = droppable_entries(&idx, floor.get());
             if dropped < GC_DEAD_ENTRIES && tail_bytes < GC_TAIL_BYTES {
                 return Ok(false);
             }
-            (compute_retained(&idx, floor), dropped)
+            (compute_retained(&idx, floor.get()), dropped)
         };
         self.gc_locked(w, retained, dropped_entries as u64, floor)
             .await?;
@@ -775,11 +777,12 @@ impl DescriptorLog {
     }
 
     #[cfg(test)]
-    pub async fn force_gc(&self, floor: u64) -> Result<()> {
+    pub async fn force_gc(&self, floor: impl Into<Pos<Floor>>) -> Result<()> {
+        let floor = floor.into();
         let w = self.writer.lock().await;
         let (retained, dropped) = {
             let idx = self.index.read().unwrap();
-            let retained = compute_retained(&idx, floor);
+            let retained = compute_retained(&idx, floor.get());
             let dropped = idx.entries_total - retained.entries_total;
             (retained, dropped)
         };
@@ -791,12 +794,15 @@ impl DescriptorLog {
         mut w: tokio::sync::MutexGuard<'_, Writer>,
         mut retained: Index,
         dropped_entries: u64,
-        floor: u64,
+        floor: Pos<Floor>,
     ) -> Result<()> {
         use std::sync::atomic::Ordering::Relaxed;
         retained.floor_at_write = floor;
         let mut bytes = encode_header(&self.identity);
-        push_frame(&mut bytes, &encode_meta(retained.covered_through, floor));
+        push_frame(
+            &mut bytes,
+            &encode_meta(retained.covered_through, floor.get()),
+        );
         for batch in retained.batches.values() {
             push_frame(&mut bytes, &encode_batch(batch));
         }
@@ -1295,7 +1301,7 @@ fn load_frames(
         match body_cur.u8()? {
             TAG_META => {
                 index.covered_through = body_cur.u64()?;
-                index.floor_at_write = body_cur.u64()?;
+                index.floor_at_write = Pos::new(body_cur.u64()?);
             }
             TAG_BATCH => {
                 let batch = decode_batch(&mut body_cur)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -572,15 +572,15 @@ impl ConfigResolver {
             &prev.columns,
         );
         self.rejections.store(rejections, Ordering::Relaxed);
-        *self.mapping.write().await = Arc::new(resolved.tables.clone());
+        self.mapping
+            .publish(Arc::new(resolved.tables.clone()))
+            .await;
         tracing::info!(
             target: "walshadow::config",
             opt_ins = resolved.table_opt_ins.len(),
             tables = resolved.tables.len(),
             "republish",
         );
-        // hits skip the mapping read; bump after every swap so no worker
-        // routes against the pre-publish map
         // Err only when every receiver dropped (daemon tearing down); ignore
         let _ = self.tx.send(Arc::new(resolved));
     }
@@ -1137,7 +1137,7 @@ mod tests {
         assert_eq!(t.target.table, "events", "target derived from descriptor");
         assert!(!t.columns.is_empty(), "columns derived from descriptor");
         // Fenced routing map written for the decode pool.
-        assert!(mapping.read().await.contains_key(&rel));
+        assert!(mapping.with(|m| m.contains_key(&rel)).await);
         assert_eq!(resolver.opt_in_total(), 1);
     }
 
@@ -1164,7 +1164,7 @@ mod tests {
             !rx.borrow_and_update().tables.contains_key(&rel),
             "opt-out drops the mapping"
         );
-        assert!(!mapping.read().await.contains_key(&rel));
+        assert!(!mapping.with(|m| m.contains_key(&rel)).await);
         assert_eq!(resolver.opt_out_total(), 1);
     }
 
@@ -1191,7 +1191,7 @@ mod tests {
             .await;
         assert!(rx.changed().await.is_ok());
         assert!(rx.borrow_and_update().tables.contains_key(&rel));
-        assert!(mapping.read().await.contains_key(&rel));
+        assert!(mapping.with(|m| m.contains_key(&rel)).await);
         // An unrelated overlay apply full-swaps the handle; the derived
         // mapping must survive (the [config.md] "Known limitation" clobber)
         resolver
@@ -1199,10 +1199,10 @@ mod tests {
             .await;
         assert!(rx.changed().await.is_ok());
         assert!(rx.borrow_and_update().tables.contains_key(&rel));
-        assert!(mapping.read().await.contains_key(&rel));
+        assert!(mapping.with(|m| m.contains_key(&rel)).await);
         // Source DROP TABLE under strategy=Drop forgets it everywhere
         resolver.forget_derived_mapping(&rel).await;
-        assert!(!mapping.read().await.contains_key(&rel));
+        assert!(!mapping.with(|m| m.contains_key(&rel)).await);
         assert!(rx.changed().await.is_ok());
         assert!(!rx.borrow_and_update().tables.contains_key(&rel));
     }
@@ -1231,11 +1231,11 @@ mod tests {
         resolver
             .materialize_opt_in(&rel_desc("public", "events"), None, None)
             .await;
-        assert!(mapping.read().await.contains_key(&rel));
+        assert!(mapping.with(|m| m.contains_key(&rel)).await);
         // Source DROP under strategy=Drop: mapping forgotten, opt-in row
         // re-parked so the next CREATE re-materialises it
         resolver.forget_derived_mapping(&rel).await;
-        assert!(!mapping.read().await.contains_key(&rel));
+        assert!(!mapping.with(|m| m.contains_key(&rel)).await);
         assert_eq!(resolver.pending_decl_count(), 1);
         let row = resolver.take_pending_decl(&rel).await.expect("re-parked");
         assert_eq!(row.replicate, Some(true));
@@ -1285,12 +1285,15 @@ mod tests {
             m.get(&RelName::new("public", "events"))
                 .is_some_and(|t| t.columns.iter().any(|c| c.src_attnum == 2))
         };
-        assert!(has_note(&*mapping.read().await), "fold reaches the handle");
+        assert!(
+            mapping.with(|m| has_note(m)).await,
+            "fold reaches the handle"
+        );
         resolver
             .apply_config_event(ConfigEvent::GlobalCleared)
             .await;
         assert!(
-            has_note(&*mapping.read().await),
+            mapping.with(|m| has_note(m)).await,
             "fold survives the republish full-swap"
         );
     }

--- a/src/emit/ch_ddl.rs
+++ b/src/emit/ch_ddl.rs
@@ -34,8 +34,8 @@ use crate::ch::{
 use crate::config::{ConfigResolver, ResolvedConfig};
 use crate::emit::ch_emitter::{EmitterConfig, RetryConfig};
 use crate::mapping::{
-    DropTableStrategy, MappingHandle, NamespaceMapping, TableMapping, TableTarget,
-    derive_columns_for_mapping, fold_diff_into_mapping,
+    ColumnMapping, DropTableStrategy, MappingHandle, MappingSnapshot, NamespaceMapping,
+    TableMapping, TableTarget, derive_columns_for_mapping, fold_diff_into_mapping,
 };
 use crate::schema::{RelDescriptor, RelName, SchemaDiff, SchemaEvent, replident_key_attnums};
 use ahash::{HashMap, HashSet, HashSetExt};
@@ -125,11 +125,6 @@ pub struct DdlApplicator {
     /// half-open CH socket can't park the reorder barrier past this
     query_timeout: Duration,
     last_used: std::time::Instant,
-    /// Decode-pool `RelCache`s key mapping snapshots on this epoch, but it
-    /// bumps when the DDL record passes the decoder worker, before the
-    /// barrier mutates the mapping here. Bump again on every mapping write
-    /// so a worker whose refresh consumed the record-time bump drops its
-    /// pre-apply snapshot
     /// Owner of runtime-derived mapping state. Set: auto-created mappings,
     /// diff folds, and DROP forgets record into the resolver so the
     /// republish full-swap preserves them. Unset (bootstrap drain, tests
@@ -323,7 +318,7 @@ impl DdlApplicator {
         diff: &SchemaDiff,
     ) -> Result<(), EmitterError> {
         let key = new.rel_name.clone();
-        let Some(target) = self.mapping_target(&key).await else {
+        let Some((mapped_at, target)) = self.mapping_target(&key).await else {
             // No target, can't ALTER; `Added` handles the
             // not-yet-learned case
             self.stats.skipped += 1;
@@ -336,15 +331,10 @@ impl DdlApplicator {
             // Operator TOML rename makes the source rename a no-op from
             // CH's POV (TOML still maps src_attnum to the same CH name);
             // detect via whether the CH column name changed
-            let mapping_lookup = self.mapping.read().await;
-            let m = mapping_lookup
-                .get(&key)
-                .expect("just resolved via mapping_target");
-            let _ = old_name;
-            let needs_rename = m.columns.iter().any(|c| &c.target_name == new_name)
-                || !m.columns.iter().any(|c| &c.target_name == old_name);
-            drop(mapping_lookup);
-            if needs_rename {
+            let columns = mapping_columns_at(&self.mapping, &key, &mapped_at).await?;
+            let already_renamed = columns.iter().any(|c| &c.target_name == new_name)
+                || !columns.iter().any(|c| &c.target_name == old_name);
+            if already_renamed {
                 // Pre-declared TOML mapping already encodes the rename
                 continue;
             }
@@ -410,7 +400,7 @@ impl DdlApplicator {
     }
 
     async fn apply_dropped(&mut self, rel: &RelName) -> Result<(), EmitterError> {
-        let Some(target) = self.mapping_target(rel).await else {
+        let Some((_, target)) = self.mapping_target(rel).await else {
             self.stats.skipped += 1;
             return Ok(());
         };
@@ -455,20 +445,23 @@ impl DdlApplicator {
     /// durable) so the truncate orders correctly against inserts despite
     /// the otherwise out-of-order pipeline.
     pub async fn truncate(&mut self, rel: &RelName) -> Result<(), EmitterError> {
-        let Some(target) = self.mapping_target(rel).await else {
+        let Some((_, target)) = self.mapping_target(rel).await else {
             return Ok(());
         };
         self.execute(&format!("TRUNCATE TABLE {}", target.sql()))
             .await
     }
 
-    async fn mapping_target(&mut self, rel: &RelName) -> Option<TableTarget> {
-        let m = self.mapping.read().await;
-        m.get(rel).map(|t| t.target.clone())
+    /// Resolve target against a held snapshot, which later ALTER steps
+    /// re-check for displacement
+    async fn mapping_target(&mut self, rel: &RelName) -> Option<(MappingSnapshot, TableTarget)> {
+        let at = self.mapping.snapshot().await;
+        let target = at.get(rel).map(|t| t.target.clone())?;
+        Some((at, target))
     }
 
     async fn mapping_for(&mut self, rel: &RelName) -> Option<TableMapping> {
-        self.mapping.read().await.get(rel).cloned()
+        self.mapping.with(|m| m.get(rel).cloned()).await
     }
 
     /// Operator opt-out (`replicate=false`); nothing excluded without a
@@ -482,72 +475,43 @@ impl DdlApplicator {
         }
     }
 
-    /// Mapping writes route per `resolver` field: resolver-owned entries
-    /// survive the republish full-swap; resolver-less path mutates the live
-    /// handle directly. Decode workers memoise per job and mapping writes
-    /// land inside the barrier fence, between jobs — no epoch needed
+    /// Route writes through resolver so derived mappings survive republish
     async fn register_mapping(&mut self, rel: &RelName, mapping: TableMapping) {
         if let Some(r) = &self.resolver {
             r.register_derived_mapping(rel, mapping).await;
         } else {
-            Arc::make_mut(&mut *self.mapping.write().await).insert(rel.clone(), mapping);
+            self.mapping
+                .mutate(|m| Arc::make_mut(m).insert(rel.clone(), mapping))
+                .await;
         }
     }
 
-    /// Predict `apply(event)`'s routing-map effect without executing DDL or
-    /// touching shared state, for plan-time route resolution: `None` = map
-    /// unchanged, `Some((rel, Some(m)))` = insert/replace, `Some((rel,
-    /// None))` = remove. Mirrors the apply_added / apply_changed /
-    /// apply_dropped gates; the executor later applies the real effects
     pub async fn predict_route_mapping(
         &mut self,
         event: &SchemaEvent,
+        mapping: &MappingSnapshot,
+        config: Option<&ResolvedConfig>,
     ) -> Result<Option<(RelName, Option<TableMapping>)>, EmitterError> {
-        self.refresh_config().await?;
-        match event {
-            SchemaEvent::Added { desc } => {
-                if self.mapping_for(&desc.rel_name).await.is_some()
-                    || self.is_excluded(&desc.rel_name).await
-                    || !self
-                        .config
-                        .auto_create_namespaces
-                        .contains(&*desc.rel_name.namespace)
-                {
-                    return Ok(None);
-                }
-                let target_db = self
-                    .config
-                    .target_database_for(&desc.rel_name.namespace)
-                    .to_owned();
-                if render_create_table(desc, &target_db, self.config.soft_delete)?.is_none() {
-                    return Ok(None);
-                }
-                let target = TableTarget::new(&target_db, &desc.rel_name.name);
-                let columns = derive_columns_for_mapping(desc);
-                Ok(Some((
-                    desc.rel_name.clone(),
-                    Some(TableMapping { target, columns }),
-                )))
+        // Resolver owns opt-outs, frozen routing state does not include them
+        let excluded = match event {
+            SchemaEvent::Added { desc } if !mapping.contains_key(&desc.rel_name) => {
+                self.is_excluded(&desc.rel_name).await
             }
-            SchemaEvent::Changed { new, diff, .. } => {
-                let Some(mut m) = self.mapping_for(&new.rel_name).await else {
-                    return Ok(None);
-                };
-                fold_diff_into_mapping(&mut m, new, diff);
-                Ok(Some((new.rel_name.clone(), Some(m))))
-            }
-            SchemaEvent::Dropped { rel_name, .. } => {
-                if self.mapping_target(rel_name).await.is_none()
-                    || !matches!(
-                        self.config.drop_strategy_for(&rel_name.namespace),
-                        DropTableStrategy::Drop
-                    )
-                {
-                    return Ok(None);
-                }
-                Ok(Some((rel_name.clone(), None)))
-            }
-        }
+            _ => false,
+        };
+        predict_route_effect(&self.plan_config(config), mapping, event, excluded)
+    }
+
+    fn plan_config(&self, frozen: Option<&ResolvedConfig>) -> DdlConfig {
+        frozen
+            .map(|rc| {
+                DdlConfig::from_resolved(
+                    rc,
+                    self.config.target_database.clone(),
+                    self.config.soft_delete,
+                )
+            })
+            .unwrap_or_else(|| self.config.clone())
     }
 
     async fn fold_mapping_diff(&mut self, new: &RelDescriptor, diff: &SchemaDiff) {
@@ -562,7 +526,7 @@ impl DdlApplicator {
         if let Some(r) = &self.resolver {
             r.forget_derived_mapping(rel).await;
         } else {
-            Arc::make_mut(&mut *self.mapping.write().await).remove(rel);
+            self.mapping.mutate(|m| Arc::make_mut(m).remove(rel)).await;
         }
     }
 
@@ -610,16 +574,83 @@ impl DdlApplicator {
     }
 }
 
+/// Predict mapping edit without executing DDL
+///
+/// Return `None` to keep map, `Some((rel, None))` to remove relation
+fn predict_route_effect(
+    cfg: &DdlConfig,
+    mapping: &MappingSnapshot,
+    event: &SchemaEvent,
+    excluded: bool,
+) -> Result<Option<(RelName, Option<TableMapping>)>, EmitterError> {
+    match event {
+        SchemaEvent::Added { desc } => {
+            if mapping.contains_key(&desc.rel_name)
+                || excluded
+                || !cfg
+                    .auto_create_namespaces
+                    .contains(&*desc.rel_name.namespace)
+            {
+                return Ok(None);
+            }
+            let target_db = cfg.target_database_for(&desc.rel_name.namespace).to_owned();
+            if render_create_table(desc, &target_db, cfg.soft_delete)?.is_none() {
+                return Ok(None);
+            }
+            let target = TableTarget::new(&target_db, &desc.rel_name.name);
+            let columns = derive_columns_for_mapping(desc);
+            Ok(Some((
+                desc.rel_name.clone(),
+                Some(TableMapping { target, columns }),
+            )))
+        }
+        SchemaEvent::Changed { new, diff, .. } => {
+            let Some(mut m) = mapping.get(&new.rel_name).cloned() else {
+                return Ok(None);
+            };
+            fold_diff_into_mapping(&mut m, new, diff);
+            Ok(Some((new.rel_name.clone(), Some(m))))
+        }
+        SchemaEvent::Dropped { rel_name, .. } => {
+            if !mapping.contains_key(rel_name)
+                || !matches!(
+                    cfg.drop_strategy_for(&rel_name.namespace),
+                    DropTableStrategy::Drop
+                )
+            {
+                return Ok(None);
+            }
+            Ok(Some((rel_name.clone(), None)))
+        }
+    }
+}
+
+/// Reject ALTER continuation after concurrent route republish
+async fn mapping_columns_at(
+    mapping: &MappingHandle,
+    rel: &RelName,
+    at: &MappingSnapshot,
+) -> Result<Vec<ColumnMapping>, EmitterError> {
+    if !mapping.unmoved(at).await {
+        return Err(EmitterError::Config(format!(
+            "routing map for `{rel}` republished mid-ALTER"
+        )));
+    }
+    Ok(at.get(rel).map(|t| t.columns.clone()).unwrap_or_default())
+}
+
 /// Fold a `Changed` diff into the live mapping. Renames touch only entries
 /// whose `target_name` still equals the OLD source name; an operator-pinned
 /// different name is left alone (CH runs no ALTER for it either, see
 /// `apply_changed`)
 async fn mutate_mapping_for_diff(mapping: &MappingHandle, new: &RelDescriptor, diff: &SchemaDiff) {
-    let mut m = mapping.write().await;
-    let Some(target_mapping) = Arc::make_mut(&mut *m).get_mut(&new.rel_name) else {
-        return;
-    };
-    fold_diff_into_mapping(target_mapping, new, diff);
+    mapping
+        .mutate(|m| {
+            if let Some(target_mapping) = Arc::make_mut(m).get_mut(&new.rel_name) {
+                fold_diff_into_mapping(target_mapping, new, diff);
+            }
+        })
+        .await;
 }
 
 /// The fold itself, shared with `ConfigResolver::apply_schema_diff` (the
@@ -1096,10 +1127,10 @@ mod tests {
         assert_eq!(diff.dropped_columns[0], 2);
     }
 
-    #[test]
-    fn mapping_target_returns_pinned_table() {
-        let map: ahash::HashMap<RelName, TableMapping> = [(
-            RelName::new("public", "orders"),
+    fn orders_mapping() -> (RelName, ahash::HashMap<RelName, TableMapping>) {
+        let rel = RelName::new("public", "orders");
+        let map = [(
+            rel.clone(),
             TableMapping {
                 target: TableTarget::new("default", "orders"),
                 columns: vec![ColumnMapping {
@@ -1111,33 +1142,67 @@ mod tests {
         )]
         .into_iter()
         .collect();
+        (rel, map)
+    }
+
+    #[tokio::test]
+    async fn mapping_target_returns_pinned_table() {
+        let (rel, map) = orders_mapping();
         let handle = crate::mapping::mapping_handle(map);
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .build()
-            .unwrap();
-        let target = rt.block_on(async {
-            let m = handle.read().await;
-            m.get(&RelName::new("public", "orders"))
-                .map(|t| t.target.clone())
-        });
+        let target = handle.with(|m| m.get(&rel).map(|t| t.target.clone())).await;
         assert_eq!(target, Some(TableTarget::new("default", "orders")));
     }
 
-    #[test]
-    fn mapping_mutation_bumps_invalidation_epoch() {
-        let map: ahash::HashMap<RelName, TableMapping> = [(
-            RelName::new("public", "orders"),
-            TableMapping {
-                target: TableTarget::new("default", "orders"),
-                columns: vec![ColumnMapping {
-                    src_attnum: 1,
-                    target_name: "id".into(),
-                    target_type: "Int32".into(),
-                }],
-            },
-        )]
-        .into_iter()
-        .collect();
+    #[tokio::test]
+    async fn republish_mid_alter_fails_instead_of_panicking() {
+        let (rel, map) = orders_mapping();
+        let handle = crate::mapping::mapping_handle(map);
+        let at = handle.snapshot().await;
+        assert_eq!(
+            mapping_columns_at(&handle, &rel, &at).await.unwrap().len(),
+            1
+        );
+        handle.publish(Arc::new(ahash::HashMap::default())).await;
+        let err = mapping_columns_at(&handle, &rel, &at)
+            .await
+            .expect_err("republish invalidates the resolved target");
+        assert!(matches!(err, EmitterError::Config(_)), "{err}");
+    }
+
+    #[tokio::test]
+    async fn prediction_ignores_a_republish_under_the_frozen_version() {
+        let (rel, map) = orders_mapping();
+        let handle = crate::mapping::mapping_handle(map);
+        let frozen = handle.snapshot().await;
+        handle.publish(Arc::new(ahash::HashMap::default())).await;
+        let cfg = DdlConfig {
+            drop_table_strategy: DropTableStrategy::Drop,
+            auto_create_namespaces: HashSet::new(),
+            target_database: "default".into(),
+            namespaces: ahash::HashMap::default(),
+            soft_delete: false,
+        };
+        let dropped = SchemaEvent::Dropped {
+            oid: 16400,
+            rel_name: rel.clone(),
+        };
+        let predicted = predict_route_effect(&cfg, &frozen, &dropped, false).unwrap();
+        assert!(
+            matches!(predicted, Some((r, None)) if r == rel),
+            "frozen version still maps the rel"
+        );
+        let live = handle.snapshot().await;
+        assert!(
+            predict_route_effect(&cfg, &live, &dropped, false)
+                .unwrap()
+                .is_none(),
+            "live handle moved on"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_fold_adds_column_and_skips_unmapped_rel() {
+        let (_, map) = orders_mapping();
         let handle = crate::mapping::mapping_handle(map);
         let new = desc(
             "orders",
@@ -1153,22 +1218,20 @@ mod tests {
             renamed_columns: vec![],
             type_changes: vec![],
         };
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            // Mapped relation: column folded in
-            mutate_mapping_for_diff(&handle, &new, &diff).await;
-            let m = handle.read().await;
-            let cols = &m.get(&RelName::new("public", "orders")).unwrap().columns;
-            assert!(
-                cols.iter()
+        mutate_mapping_for_diff(&handle, &new, &diff).await;
+        let folded = handle
+            .with(|m| {
+                m.get(&RelName::new("public", "orders"))
+                    .unwrap()
+                    .columns
+                    .iter()
                     .any(|c| c.src_attnum == 2 && c.target_name == "c")
-            );
-        });
+            })
+            .await;
+        assert!(folded);
 
         // Unmapped relation: early return
         let ghost = desc("ghost", vec![att(1, "id", INT4OID, true, None)], None);
-        rt.block_on(mutate_mapping_for_diff(&handle, &ghost, &diff));
+        mutate_mapping_for_diff(&handle, &ghost, &diff).await;
     }
 }

--- a/src/emit/pipeline/ack.rs
+++ b/src/emit/pipeline/ack.rs
@@ -1,38 +1,23 @@
-//! Cumulative-ack durability watermark for the parallel pipeline.
+//! Cumulative-ack durability watermark for the parallel pipeline
 //!
-//! Refcount-driven contiguous watermark. Downstream completes out of order;
-//! `emitter_ack_lsn` (advertised as the standby `apply_lsn`, bounding source
-//! slot recycling) must not.
+//! Downstream work completes out of order, but `emitter_ack_lsn` cannot
+//! advance past gaps because it bounds source slot recycling. Each
+//! transaction gets a dense `seq` plus a monotonic `commit_lsn`; the
+//! watermark advances through contiguous done seqs only
 //!
-//! Each xact gets a dense `seq` + `commit_lsn` (monotonic in `seq`). Per
-//! `seq` track rows *placed* (routed by a decoder) and *acked* (inserter
-//! drained to `EndOfStream`). A `seq` is **done** once `placed == Some(R)`
-//! and `acked == R` (rows=0 xacts — abort/empty/filtered — done once placed).
-//! Watermark is highest contiguous done `seq`, its `commit_lsn` published
-//! into `emitter_ack`. Contiguity is the safety property: commit_lsn
-//! monotonic in seq, so the contiguous-done commit_lsn never claims
-//! durability for a later seq whose rows are still in flight.
+//! One commit may span several seqs. Only the final seq publishes its
+//! `commit_lsn`, earlier slices gate contiguity via
+//! [`AckHandle::register_partial`]
 //!
-//! ## Commit groups
-//!
-//! One commit may span several seqs (drain-stream batches, DDL-barrier
-//! segments), all carrying the same `commit_lsn`. Only the commit's *final*
-//! seq publishes: a non-final slice registered via
-//! [`AckHandle::register_partial`] gates contiguity but never advances
-//! `emitter_ack` — else the first durable slice would claim the whole
-//! commit while later slices are still in flight, and a restart would
-//! resume past never-inserted rows.
-//!
-//! Invariant: inserter sends [`AckEvent::Acked`] only *after* drain-to-
-//! `EndOfStream`. A row placed but never acked pins the watermark forever;
-//! the daemon's stall watchdog escalates that.
+//! Inserter sends [`AckEvent::Acked`] only after draining `EndOfStream`
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
+
+use crate::pos::{AckFrontier, EmitterAck, Gate, GateClosed, Monotone, PlacedFrontier, Pos};
 
 pub enum AckEvent {
     /// In seq order, no gaps. `publish: false` marks a non-final slice of a
@@ -50,64 +35,141 @@ pub enum AckEvent {
     Acked {
         counts: Vec<(u64, u64)>,
     },
-    /// Advance to `lsn` once every registered seq is done. Reorder sends only
-    /// when the xact buffer is empty; the seqs it already dispatched can still
-    /// be in flight, so the collector holds the position and publishes it when
-    /// the frontier catches up.
+    /// Pump position beyond buffered transactions, held until dispatched seqs finish
     Trailing {
         lsn: u64,
     },
 }
 
-struct SeqState {
-    commit_lsn: u64,
-    publish: bool,
-    placed: Option<u64>,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SeqFault {
+    DoublePlaced,
+    OverAcked,
+}
+
+/// Per-seq progress; placement and acks arrive in either order
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct Progress {
+    /// `None` while waiting on decode, `Some` while waiting on ClickHouse
+    rows: Option<u64>,
     acked: u64,
 }
 
-impl SeqState {
-    fn done(&self) -> bool {
-        self.placed.is_some_and(|r| r == self.acked)
+/// A fault leaves the counts untouched, so the wedged seq stays diagnosable
+impl Progress {
+    fn place(&mut self, rows: u64) -> Result<(), SeqFault> {
+        if self.rows.is_some() {
+            return Err(SeqFault::DoublePlaced);
+        }
+        if self.acked > rows {
+            return Err(SeqFault::OverAcked);
+        }
+        self.rows = Some(rows);
+        Ok(())
+    }
+
+    fn ack(&mut self, n: u64) -> Result<(), SeqFault> {
+        let acked = self.acked + n;
+        if self.rows.is_some_and(|rows| acked > rows) {
+            return Err(SeqFault::OverAcked);
+        }
+        self.acked = acked;
+        Ok(())
+    }
+
+    fn is_done(self) -> bool {
+        self.rows == Some(self.acked)
+    }
+
+    /// Row count reported, safe for the `FlushAll` placement barrier
+    fn is_placed(self) -> bool {
+        self.rows.is_some()
     }
 }
 
-/// Sync core; actor is a thin loop over [`Self::apply`]. Split out for
-/// unit-testing without a task.
+struct Seq {
+    commit_lsn: u64,
+    publish: bool,
+    progress: Progress,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IncompleteSeq {
+    pub seq: u64,
+    pub commit_lsn: Pos<EmitterAck>,
+    /// `None` while waiting on decode, `Some` while waiting on ClickHouse
+    pub rows: Option<u64>,
+    pub acked: u64,
+}
+
+/// Watermark state exposed to stall diagnostics
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AckSnapshot {
+    pub registered: u64,
+    pub frontier: u64,
+    pub placed_frontier: u64,
+    pub oldest_incomplete: Option<IncompleteSeq>,
+    pub trailing_held: Pos<EmitterAck>,
+    /// Protocol faults, each of which pins a seq forever
+    pub wedged: u64,
+    /// Events for retired seqs, benign: inserter batches straddle retirement
+    pub late: u64,
+}
+
+impl AckSnapshot {
+    pub fn all_done(&self) -> bool {
+        self.oldest_incomplete.is_none()
+    }
+
+    pub fn stall_reason(&self) -> Option<&'static str> {
+        let inc = self.oldest_incomplete?;
+        Some(match inc.rows {
+            None => "decode has not reported rows",
+            Some(_) => "clickhouse has not acked rows",
+        })
+    }
+}
+
 pub struct AckState {
-    map: BTreeMap<u64, SeqState>,
+    map: BTreeMap<u64, Seq>,
     /// Lowest seq not yet done == count of contiguous done seqs (dense from 0)
-    next_expected: u64,
+    frontier: u64,
     /// Lowest seq not yet placed. DDL barrier waits on this so `FlushAll`
     /// can't run ahead of rows still in flight from the decode pool.
     placed_frontier: u64,
-    /// Seqs registered so far (dense from 0).
     registered: u64,
-    /// Highest position the pump reported past every buffered xact, published
-    /// as soon as the frontier is all-done. Sticky: a quiescent source sends
-    /// no further records, so a dropped position would pin the watermark at
-    /// the last commit forever.
-    trailing_lsn: u64,
-    emitter_ack: Arc<AtomicU64>,
-    frontier_tx: watch::Sender<u64>,
-    placed_tx: watch::Sender<u64>,
+    /// Highest publishing `commit_lsn` retired from map
+    watermark: u64,
+    /// Retained across events because quiescent source cannot resend it
+    trailing: u64,
+    emitter_ack: Arc<Monotone<EmitterAck>>,
+    frontier_cell: Monotone<AckFrontier>,
+    placed_cell: Monotone<PlacedFrontier>,
+    wedged: u64,
+    late: u64,
+    probe_tx: watch::Sender<AckSnapshot>,
 }
 
 impl AckState {
     fn new(
-        emitter_ack: Arc<AtomicU64>,
-        frontier_tx: watch::Sender<u64>,
-        placed_tx: watch::Sender<u64>,
+        emitter_ack: Arc<Monotone<EmitterAck>>,
+        frontier_cell: Monotone<AckFrontier>,
+        placed_cell: Monotone<PlacedFrontier>,
+        probe_tx: watch::Sender<AckSnapshot>,
     ) -> Self {
         Self {
             map: BTreeMap::new(),
-            next_expected: 0,
+            frontier: 0,
             placed_frontier: 0,
             registered: 0,
-            trailing_lsn: 0,
+            watermark: 0,
+            trailing: 0,
             emitter_ack,
-            frontier_tx,
-            placed_tx,
+            frontier_cell,
+            placed_cell,
+            wedged: 0,
+            late: 0,
+            probe_tx,
         }
     }
 
@@ -117,111 +179,132 @@ impl AckState {
                 seq,
                 commit_lsn,
                 publish,
-            } => self.register(seq, commit_lsn, publish),
-            AckEvent::Placed { seq, rows } => self.placed(seq, rows),
+            } => self.open_seq(seq, commit_lsn, publish),
+            AckEvent::Placed { seq, rows } => self.step(seq, |p| p.place(rows)),
             AckEvent::Acked { counts } => {
                 for (seq, n) in counts {
-                    self.acked(seq, n);
+                    self.step(seq, |p| p.ack(n));
                 }
             }
-            AckEvent::Trailing { lsn } => self.trailing(lsn),
+            AckEvent::Trailing { lsn } => self.trailing = self.trailing.max(lsn),
         }
+        self.publish();
     }
 
-    fn register(&mut self, seq: u64, commit_lsn: u64, publish: bool) {
+    fn open_seq(&mut self, seq: u64, commit_lsn: u64, publish: bool) {
+        // Preserve live counts, never resurrect retired seqs
+        if seq < self.frontier || self.map.contains_key(&seq) {
+            self.wedge(seq, "seq registered twice");
+            return;
+        }
         self.map.insert(
             seq,
-            SeqState {
+            Seq {
                 commit_lsn,
                 publish,
-                placed: None,
-                acked: 0,
+                progress: Progress::default(),
             },
         );
-        // Dense from 0, so count is highest+1
         self.registered = self.registered.max(seq + 1);
-        self.advance();
     }
 
-    fn placed(&mut self, seq: u64, rows: u64) {
-        if let Some(s) = self.map.get_mut(&seq) {
-            s.placed = Some(rows);
-        }
-        self.advance();
-    }
-
-    fn acked(&mut self, seq: u64, n: u64) {
-        if let Some(s) = self.map.get_mut(&seq) {
-            s.acked += n;
-        }
-        self.advance();
-    }
-
-    fn trailing(&mut self, lsn: u64) {
-        self.trailing_lsn = self.trailing_lsn.max(lsn);
-        self.publish_trailing();
-    }
-
-    /// Publish the held trailing position once nothing is in flight. Every
-    /// seq registered after it carries a later `commit_lsn`, so a late
-    /// publication never claims durability the frontier hasn't reached.
-    fn publish_trailing(&mut self) {
-        if self.trailing_lsn != 0 && self.all_done() {
-            self.emitter_ack
-                .fetch_max(self.trailing_lsn, Ordering::Release);
+    fn step(&mut self, seq: u64, f: impl FnOnce(&mut Progress) -> Result<(), SeqFault>) {
+        let Some(s) = self.map.get_mut(&seq) else {
+            self.absent(seq);
+            return;
+        };
+        match f(&mut s.progress) {
+            Ok(()) => {}
+            Err(SeqFault::DoublePlaced) => self.wedge(seq, "seq placed twice"),
+            Err(SeqFault::OverAcked) => self.wedge(seq, "seq acked past its row count"),
         }
     }
 
-    /// Drain the contiguous done prefix, advancing `emitter_ack` to the last
-    /// done *publishing* seq's `commit_lsn` and publishing the new frontier.
-    fn advance(&mut self) {
-        let mut moved = false;
-        while let Some(s) = self.map.get(&self.next_expected) {
-            if !s.done() {
+    /// Distinguish benign retired events from unregistered seqs that pin frontier
+    fn absent(&mut self, seq: u64) {
+        if seq < self.frontier {
+            self.late += 1;
+            return;
+        }
+        self.wedge(seq, "ack event for an unregistered seq");
+    }
+
+    /// Log the first fault only; the rest are noise once the watermark pins
+    fn wedge(&mut self, seq: u64, what: &'static str) {
+        self.wedged += 1;
+        if self.wedged == 1 {
+            tracing::error!(
+                target: "walshadow::pipeline",
+                seq,
+                frontier = self.frontier,
+                registered = self.registered,
+                "{what} — watermark will pin here",
+            );
+        }
+    }
+
+    /// Sole writer of every published output, called after every event
+    ///
+    /// Both scans resume at their own frontier, never at the done frontier:
+    /// placement runs far ahead of acks, so re-walking that span per event is
+    /// O(N²)
+    fn publish(&mut self) {
+        while let Some(s) = self.map.get(&self.frontier) {
+            if !s.progress.is_done() {
                 break;
             }
-            if s.publish {
-                self.emitter_ack.fetch_max(s.commit_lsn, Ordering::Release);
+            let (publish, commit_lsn) = (s.publish, s.commit_lsn);
+            self.map.remove(&self.frontier);
+            if publish {
+                self.watermark = self.watermark.max(commit_lsn);
             }
-            self.map.remove(&self.next_expected);
-            self.next_expected += 1;
-            moved = true;
+            self.frontier += 1;
         }
-        if moved {
-            self.frontier_tx.send_replace(self.next_expected);
-            self.publish_trailing();
-        }
-        // Resume from `placed_frontier`, not `next_expected`: done implies
-        // placed, so `[next_expected, placed_frontier)` is already placed and
-        // no bump strands a gap. Restarting at `next_expected` re-walked the
-        // whole run per event — O(N^2), pegging the collector at 100% CPU and
-        // stalling `emitter_ack` when the pool placed far ahead of durable.
-        // Resuming here visits each seq once: O(1) amortized.
-        let mut pf = self.placed_frontier.max(self.next_expected);
-        while self.map.get(&pf).is_some_and(|s| s.placed.is_some()) {
+        let mut pf = self.placed_frontier.max(self.frontier);
+        while self.map.get(&pf).is_some_and(|s| s.progress.is_placed()) {
             pf += 1;
         }
-        if pf != self.placed_frontier {
-            self.placed_frontier = pf;
-            self.placed_tx.send_replace(pf);
-        }
-    }
+        self.placed_frontier = pf;
 
-    /// True once every registered seq is done (nothing in flight).
-    pub fn all_done(&self) -> bool {
-        self.next_expected == self.registered
-    }
-
-    /// Oldest seq still incomplete (watermark pinned behind it), for the
-    /// daemon's stall watchdog. `None` when fully caught up.
-    pub fn oldest_incomplete(&self) -> Option<(u64, u64)> {
-        if self.all_done() {
-            None
+        // Later registrations carry later commit LSNs, so publish trailing only at idle
+        let ack = if self.all_done() {
+            self.watermark.max(self.trailing)
         } else {
-            self.map
-                .get(&self.next_expected)
-                .map(|s| (self.next_expected, s.commit_lsn))
+            self.watermark
+        };
+        self.emitter_ack.join(ack);
+        self.frontier_cell.join(self.frontier);
+        self.placed_cell.join(self.placed_frontier);
+        self.probe_tx.send_replace(self.snapshot());
+    }
+
+    pub fn snapshot(&self) -> AckSnapshot {
+        AckSnapshot {
+            registered: self.registered,
+            frontier: self.frontier,
+            placed_frontier: self.placed_frontier,
+            oldest_incomplete: self.oldest_incomplete(),
+            trailing_held: self.trailing.into(),
+            wedged: self.wedged,
+            late: self.late,
         }
+    }
+
+    pub fn all_done(&self) -> bool {
+        self.frontier == self.registered
+    }
+
+    pub fn oldest_incomplete(&self) -> Option<IncompleteSeq> {
+        if self.all_done() {
+            return None;
+        }
+        let s = self.map.get(&self.frontier)?;
+        Some(IncompleteSeq {
+            seq: self.frontier,
+            commit_lsn: s.commit_lsn.into(),
+            rows: s.progress.rows,
+            acked: s.progress.acked,
+        })
     }
 }
 
@@ -230,9 +313,10 @@ impl AckState {
 #[derive(Clone)]
 pub struct AckHandle {
     tx: mpsc::UnboundedSender<AckEvent>,
-    emitter_ack: Arc<AtomicU64>,
-    frontier: watch::Receiver<u64>,
-    placed: watch::Receiver<u64>,
+    emitter_ack: Arc<Monotone<EmitterAck>>,
+    frontier: Gate<AckFrontier>,
+    placed: Gate<PlacedFrontier>,
+    probe: watch::Receiver<AckSnapshot>,
 }
 
 impl AckHandle {
@@ -270,42 +354,33 @@ impl AckHandle {
         let _ = self.tx.send(AckEvent::Trailing { lsn });
     }
 
-    pub fn emitter_ack(&self) -> u64 {
-        self.emitter_ack.load(Ordering::Acquire)
+    pub fn emitter_ack(&self) -> Pos<EmitterAck> {
+        self.emitter_ack.get()
     }
 
-    /// Block until the contiguous-done frontier covers all seqs `< seq` (every
-    /// earlier xact durable on CH). Used by the DDL barrier; returns early if
-    /// the collector actor shut down.
-    pub async fn wait_through(&self, seq: u64) {
-        let mut r = self.frontier.clone();
-        while *r.borrow_and_update() < seq {
-            if r.changed().await.is_err() {
-                break;
-            }
-        }
+    pub fn probe(&self) -> watch::Receiver<AckSnapshot> {
+        self.probe.clone()
     }
 
-    /// Block until every seq `< seq` is *placed*. Barrier waits on this before
-    /// `FlushAll` so the flush can't seal ahead of rows still in flight from
-    /// the decode pool.
-    pub async fn wait_placed_through(&self, seq: u64) {
-        let mut r = self.placed.clone();
-        while *r.borrow_and_update() < seq {
-            if r.changed().await.is_err() {
-                break;
-            }
-        }
+    /// Wait until every seq below `seq` is durable on ClickHouse
+    pub async fn wait_through(&self, seq: u64) -> Result<(), GateClosed> {
+        self.frontier.wait(seq).await.map(|_| ())
+    }
+
+    /// Wait until every seq below `seq` reports its row count
+    pub async fn wait_placed_through(&self, seq: u64) -> Result<(), GateClosed> {
+        self.placed.wait(seq).await.map(|_| ())
     }
 }
 
 /// Spawn the collector actor. When all [`AckHandle`] clones drop it drains
 /// and exits, completing the [`JoinHandle`].
-pub fn spawn(emitter_ack: Arc<AtomicU64>) -> (AckHandle, JoinHandle<()>) {
+pub fn spawn(emitter_ack: Arc<Monotone<EmitterAck>>) -> (AckHandle, JoinHandle<()>) {
     let (tx, mut rx) = mpsc::unbounded_channel::<AckEvent>();
-    let (frontier_tx, frontier) = watch::channel(0u64);
-    let (placed_tx, placed) = watch::channel(0u64);
-    let mut state = AckState::new(emitter_ack.clone(), frontier_tx, placed_tx);
+    let (frontier_cell, placed_cell) = (Monotone::default(), Monotone::default());
+    let (frontier, placed) = (frontier_cell.watch(), placed_cell.watch());
+    let (probe_tx, probe) = watch::channel(AckSnapshot::default());
+    let mut state = AckState::new(emitter_ack.clone(), frontier_cell, placed_cell, probe_tx);
     let handle = tokio::spawn(async move {
         while let Some(ev) = rx.recv().await {
             state.apply(ev);
@@ -317,207 +392,427 @@ pub fn spawn(emitter_ack: Arc<AtomicU64>) -> (AckHandle, JoinHandle<()>) {
             emitter_ack,
             frontier,
             placed,
+            probe,
         },
         handle,
     )
 }
 
 #[cfg(test)]
+impl AckState {
+    fn register(&mut self, seq: u64, commit_lsn: u64, publish: bool) {
+        self.apply(AckEvent::Register {
+            seq,
+            commit_lsn,
+            publish,
+        });
+    }
+
+    fn placed(&mut self, seq: u64, rows: u64) {
+        self.apply(AckEvent::Placed { seq, rows });
+    }
+
+    fn acked(&mut self, seq: u64, n: u64) {
+        self.apply(AckEvent::Acked {
+            counts: vec![(seq, n)],
+        });
+    }
+
+    fn trailing(&mut self, lsn: u64) {
+        self.apply(AckEvent::Trailing { lsn });
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
-    fn state() -> (AckState, Arc<AtomicU64>) {
-        let ack = Arc::new(AtomicU64::new(0));
-        let (ftx, _frx) = watch::channel(0u64);
-        let (ptx, _prx) = watch::channel(0u64);
-        (AckState::new(ack.clone(), ftx, ptx), ack)
+    pub(super) fn state() -> (AckState, Arc<Monotone<EmitterAck>>) {
+        let (s, ack, _) = state_watching_placed();
+        (s, ack)
     }
 
-    #[test]
-    fn in_order_advances_to_each_commit() {
-        let (mut s, ack) = state();
-        for seq in 0..3u64 {
-            s.register(seq, (seq + 1) * 100, true);
-            s.placed(seq, 2);
-            s.acked(seq, 2);
-        }
-        assert_eq!(ack.load(Ordering::Acquire), 300);
-        assert!(s.all_done());
-    }
-
-    #[test]
-    fn out_of_order_done_holds_watermark_until_gap_fills() {
-        let (mut s, ack) = state();
-        s.register(0, 100, true);
-        s.register(1, 200, true);
-        s.register(2, 300, true);
-        // seq 2 done first, watermark stays at 0
-        s.placed(2, 1);
-        s.acked(2, 1);
-        assert_eq!(ack.load(Ordering::Acquire), 0);
-        // seq 0 done, but 1 still blocks 2
-        s.placed(0, 1);
-        s.acked(0, 1);
-        assert_eq!(ack.load(Ordering::Acquire), 100);
-        assert_eq!(s.oldest_incomplete(), Some((1, 200)));
-        // gap fills, frontier jumps over already-done 2
-        s.placed(1, 1);
-        s.acked(1, 1);
-        assert_eq!(ack.load(Ordering::Acquire), 300);
-        assert!(s.all_done());
-    }
-
-    #[test]
-    fn empty_or_abort_seq_is_done_when_placed_zero() {
-        let (mut s, ack) = state();
-        s.register(0, 100, true);
-        s.placed(0, 0); // abort/empty
-        assert_eq!(ack.load(Ordering::Acquire), 100);
-        assert!(s.all_done());
-    }
-
-    #[test]
-    fn rows_split_across_batches_complete_at_total() {
-        let (mut s, ack) = state();
-        s.register(0, 100, true);
-        s.placed(0, 5);
-        s.acked(0, 2);
-        assert_eq!(ack.load(Ordering::Acquire), 0); // 2/5 acked
-        s.acked(0, 3);
-        assert_eq!(ack.load(Ordering::Acquire), 100);
-    }
-
-    #[test]
-    fn acked_before_placed_still_completes() {
-        let (mut s, ack) = state();
-        s.register(0, 100, true);
-        s.acked(0, 3);
-        assert_eq!(ack.load(Ordering::Acquire), 0); // placed still unknown
-        s.placed(0, 3);
-        assert_eq!(ack.load(Ordering::Acquire), 100);
+    fn state_watching_placed() -> (AckState, Arc<Monotone<EmitterAck>>, Gate<PlacedFrontier>) {
+        let ack = Arc::new(Monotone::default());
+        let (frontier, placed) = (Monotone::default(), Monotone::default());
+        let prx = placed.watch();
+        let (probe_tx, _probe) = watch::channel(AckSnapshot::default());
+        (
+            AckState::new(ack.clone(), frontier, placed, probe_tx),
+            ack,
+            prx,
+        )
     }
 
     #[test]
     fn placed_frontier_tracks_contiguous_placed_seqs() {
-        let ack = Arc::new(AtomicU64::new(0));
-        let (ftx, _frx) = watch::channel(0u64);
-        let (ptx, prx) = watch::channel(0u64);
-        let mut s = AckState::new(ack, ftx, ptx);
+        let (mut s, _ack, prx) = state_watching_placed();
         s.register(0, 100, true);
         s.register(1, 200, true);
         s.register(2, 300, true);
-        // Place 0 and 2 out of order; frontier stops at gap (1)
         s.placed(2, 1);
-        assert_eq!(*prx.borrow(), 0);
+        assert_eq!(prx.current(), 0);
         s.placed(0, 1);
-        assert_eq!(*prx.borrow(), 1, "placed through seq 0");
-        // Filling gap advances past already-placed 2
+        assert_eq!(prx.current(), 1, "placed through seq 0");
         s.placed(1, 1);
-        assert_eq!(*prx.borrow(), 3, "placed through all three");
+        assert_eq!(prx.current(), 3, "placed through all three");
     }
 
-    /// Pool places far ahead of the durable watermark. `advance` must resume
-    /// the placed-frontier scan at `placed_frontier`, not re-walk
-    /// `[next_expected, placed_frontier)` every event — else O(N^2), pegging
-    /// the collector. Many seqs make the O(N^2) form visibly slow.
+    /// Guard against O(N²) placement scan when placement runs ahead of acks
     #[test]
     fn placed_far_ahead_of_acked_stays_linear() {
         let (mut s, ack) = state();
         let n = 50_000u64;
         for seq in 0..n {
             s.register(seq, (seq + 1) * 10, true);
-            s.placed(seq, 1); // nothing acked yet
+            s.placed(seq, 1);
         }
-        assert_eq!(ack.load(Ordering::Acquire), 0);
+        assert_eq!(ack.get(), 0);
         assert!(!s.all_done());
         for seq in 0..n {
             s.acked(seq, 1);
         }
         assert!(s.all_done());
-        assert_eq!(ack.load(Ordering::Acquire), n * 10);
+        assert_eq!(ack.get(), n * 10);
     }
 
-    /// A commit registered after the held position publishes its own
-    /// `commit_lsn`; the stale position must not pull the watermark back.
     #[test]
-    fn trailing_never_lowers_a_later_commit() {
-        let (mut s, ack) = state();
-        s.trailing(500);
-        s.register(0, 900, true);
-        s.placed(0, 1);
+    fn probe_names_what_holds_the_watermark() {
+        let (mut s, _ack) = state();
+        s.register(0, 100, true);
+        let snap = s.snapshot();
+        assert_eq!(snap.stall_reason(), Some("decode has not reported rows"));
+        assert_eq!(
+            snap.oldest_incomplete.map(|o| (o.seq, o.rows, o.acked)),
+            Some((0, None, 0))
+        );
+        s.placed(0, 4);
         s.acked(0, 1);
-        assert_eq!(ack.load(Ordering::Acquire), 900);
+        s.trailing(9_999);
+        let snap = s.snapshot();
+        assert_eq!(snap.stall_reason(), Some("clickhouse has not acked rows"));
+        assert_eq!(
+            snap.oldest_incomplete.map(|o| (o.rows, o.acked)),
+            Some((Some(4), 1))
+        );
+        assert_eq!(snap.trailing_held, 9_999, "held, not yet published");
+        s.acked(0, 3);
+        let snap = s.snapshot();
+        assert_eq!(snap.stall_reason(), None);
+        assert!(snap.all_done());
+        assert_eq!((snap.wedged, snap.late), (0, 0));
     }
 
-    /// First durable slice of a multi-slice commit must not publish the
-    /// commit LSN: a restart at that point would resume past rows still in
-    /// the later slices.
     #[test]
-    fn partial_slices_never_publish_commit_lsn() {
-        let (mut s, ack) = state();
-        s.register(0, 500, false);
-        s.register(1, 500, false);
-        s.register(2, 500, true); // final slice
-        s.placed(0, 1);
-        s.acked(0, 1);
-        assert_eq!(ack.load(Ordering::Acquire), 0, "first slice durable");
-        s.placed(1, 1);
-        s.acked(1, 1);
-        assert_eq!(ack.load(Ordering::Acquire), 0, "second slice durable");
-        s.placed(2, 1);
-        s.acked(2, 1);
-        assert_eq!(ack.load(Ordering::Acquire), 500, "final slice publishes");
-        assert!(s.all_done());
-    }
-
-    /// Final slice done out of order still waits for earlier partial slices
-    /// (contiguity), then one advance publishes exactly once.
-    #[test]
-    fn final_slice_blocked_by_earlier_partial_gap() {
-        let (mut s, ack) = state();
-        s.register(0, 500, false);
-        s.register(1, 500, true);
-        s.placed(1, 1);
-        s.acked(1, 1);
-        assert_eq!(ack.load(Ordering::Acquire), 0, "gap at partial seq 0");
-        s.placed(0, 1);
-        s.acked(0, 1);
-        assert_eq!(ack.load(Ordering::Acquire), 500);
-    }
-
-    /// Barrier shape: data segments as partial seqs, trailing rows=0 final
-    /// marker carries the publication.
-    #[test]
-    fn rows_zero_final_marker_publishes_after_partial_segments() {
-        let (mut s, ack) = state();
-        s.register(0, 500, false);
-        s.register(1, 500, false);
-        s.register(2, 500, true);
-        s.placed(2, 0); // marker done immediately once placed
-        s.placed(0, 2);
-        s.acked(0, 2);
-        s.placed(1, 3);
-        assert_eq!(ack.load(Ordering::Acquire), 0, "segment 1 not acked");
-        s.acked(1, 3);
-        assert_eq!(ack.load(Ordering::Acquire), 500);
-        // Next commit publishes independently
-        s.register(3, 600, true);
-        s.placed(3, 0);
-        assert_eq!(ack.load(Ordering::Acquire), 600);
-    }
-
-    /// Pump reports its position past the last commit while that commit is
-    /// still in flight. A quiescent source sends no further records, so the
-    /// position has to be held and published once the frontier catches up.
-    #[test]
-    fn trailing_held_until_all_done_then_published() {
-        let (mut s, ack) = state();
+    fn events_for_retired_seqs_are_benign() {
+        let (mut s, _ack) = state();
         s.register(0, 100, true);
         s.placed(0, 1);
-        // Not acked, trailing must not advance past the buffered row
-        s.trailing(9_999);
-        assert_eq!(ack.load(Ordering::Acquire), 0);
         s.acked(0, 1);
-        assert_eq!(ack.load(Ordering::Acquire), 9_999, "held position lands");
+        s.acked(0, 1);
+        let snap = s.snapshot();
+        assert_eq!((snap.late, snap.wedged), (1, 0));
+    }
+
+    #[test]
+    fn illegal_transitions_pin_the_seq_instead_of_being_absorbed() {
+        let (mut s, ack) = state();
+        s.register(0, 100, true);
+        s.placed(0, 2);
+        s.placed(0, 5);
+        s.acked(0, 3);
+        s.register(0, 100, true);
+        assert_eq!(s.snapshot().wedged, 3);
+        assert!(!s.all_done(), "a faulted seq stays incomplete");
+        assert_eq!(ack.get(), 0);
+        s.placed(7, 3);
+        assert_eq!(s.snapshot().wedged, 4, "seq past the registration frontier");
+    }
+}
+
+/// Compare incremental collector with full-history model across legal schedules
+#[cfg(test)]
+mod interleavings {
+    use super::*;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum Ev {
+        Reg { seq: u64, lsn: u64, publish: bool },
+        Place { seq: u64, rows: u64 },
+        Ack { seq: u64, n: u64 },
+        Trail { lsn: u64 },
+    }
+
+    impl Ev {
+        fn seq(self) -> Option<u64> {
+            match self {
+                Self::Reg { seq, .. } | Self::Place { seq, .. } | Self::Ack { seq, .. } => {
+                    Some(seq)
+                }
+                Self::Trail { .. } => None,
+            }
+        }
+
+        fn is_reg(self) -> bool {
+            matches!(self, Self::Reg { .. })
+        }
+    }
+
+    fn reg(seq: u64, lsn: u64, publish: bool) -> Ev {
+        Ev::Reg { seq, lsn, publish }
+    }
+
+    fn place(seq: u64, rows: u64) -> Ev {
+        Ev::Place { seq, rows }
+    }
+
+    fn ack(seq: u64, n: u64) -> Ev {
+        Ev::Ack { seq, n }
+    }
+
+    #[derive(Clone, Copy)]
+    struct ModelSeq {
+        lsn: u64,
+        publish: bool,
+        rows: Option<u64>,
+        acked: u64,
+    }
+
+    #[derive(Default)]
+    struct Model {
+        seqs: Vec<ModelSeq>,
+        trailing: u64,
+        high: u64,
+    }
+
+    impl Model {
+        fn apply(&mut self, ev: Ev) {
+            match ev {
+                Ev::Reg { seq, lsn, publish } => {
+                    assert_eq!(seq as usize, self.seqs.len(), "dense registration");
+                    self.seqs.push(ModelSeq {
+                        lsn,
+                        publish,
+                        rows: None,
+                        acked: 0,
+                    });
+                }
+                Ev::Place { seq, rows } => self.seqs[seq as usize].rows = Some(rows),
+                Ev::Ack { seq, n } => self.seqs[seq as usize].acked += n,
+                Ev::Trail { lsn } => self.trailing = self.trailing.max(lsn),
+            }
+            self.high = self.high.max(self.expected());
+        }
+
+        fn expected(&self) -> u64 {
+            let mut w = 0;
+            let mut done = 0;
+            for s in &self.seqs {
+                if s.rows != Some(s.acked) {
+                    break;
+                }
+                if s.publish {
+                    w = w.max(s.lsn);
+                }
+                done += 1;
+            }
+            if done == self.seqs.len() {
+                w.max(self.trailing)
+            } else {
+                w
+            }
+        }
+    }
+
+    fn interleave(events: &[Ev], visit: &mut impl FnMut(&[Ev])) -> u64 {
+        assert!(events.len() <= 32, "mask is a u32");
+        let mut order = Vec::with_capacity(events.len());
+        let mut count = 0;
+        walk(events, 0, &mut order, &mut count, visit);
+        count
+    }
+
+    fn walk(
+        events: &[Ev],
+        used: u32,
+        order: &mut Vec<Ev>,
+        count: &mut u64,
+        visit: &mut impl FnMut(&[Ev]),
+    ) {
+        if order.len() == events.len() {
+            *count += 1;
+            visit(order);
+            return;
+        }
+        let registered = |seq: u64| {
+            events
+                .iter()
+                .enumerate()
+                .any(|(i, e)| e.is_reg() && e.seq() == Some(seq) && used & (1 << i) != 0)
+        };
+        for (i, ev) in events.iter().enumerate() {
+            if used & (1 << i) != 0 {
+                continue;
+            }
+            let ready = match ev.seq() {
+                None => true,
+                Some(seq) if ev.is_reg() => (0..seq).all(registered),
+                Some(seq) => registered(seq),
+            };
+            if !ready {
+                continue;
+            }
+            order.push(*ev);
+            walk(events, used | (1 << i), order, count, visit);
+            order.pop();
+        }
+    }
+
+    fn to_event(ev: Ev) -> AckEvent {
+        match ev {
+            Ev::Reg { seq, lsn, publish } => AckEvent::Register {
+                seq,
+                commit_lsn: lsn,
+                publish,
+            },
+            Ev::Place { seq, rows } => AckEvent::Placed { seq, rows },
+            Ev::Ack { seq, n } => AckEvent::Acked {
+                counts: vec![(seq, n)],
+            },
+            Ev::Trail { lsn } => AckEvent::Trailing { lsn },
+        }
+    }
+
+    fn check(schedule: &[Ev]) {
+        let (mut s, ack) = super::tests::state();
+        let mut m = Model::default();
+        let mut prev = Pos::ZERO;
+        for (i, ev) in schedule.iter().enumerate() {
+            s.apply(to_event(*ev));
+            m.apply(*ev);
+            let got = ack.get();
+            assert!(
+                got >= prev,
+                "watermark went backwards at step {i} of {schedule:?}"
+            );
+            assert_eq!(
+                got, m.high,
+                "step {i} of {schedule:?}: collector {got}, model {}",
+                m.high
+            );
+            prev = got;
+        }
+        assert_eq!(
+            s.all_done(),
+            m.seqs.iter().all(|q| q.rows == Some(q.acked)),
+            "all_done disagrees for {schedule:?}"
+        );
+        assert_eq!(
+            s.snapshot().wedged,
+            0,
+            "legal schedule produced a fault: {schedule:?}"
+        );
+    }
+
+    #[test]
+    fn two_commits_and_a_trailing_position() {
+        let events = [
+            reg(0, 100, true),
+            place(0, 1),
+            ack(0, 1),
+            reg(1, 200, true),
+            place(1, 1),
+            ack(1, 1),
+            Ev::Trail { lsn: 9_999 },
+        ];
+        let n = interleave(&events, &mut check);
+        assert_eq!(n, 280, "every legal interleaving covered");
+    }
+
+    #[test]
+    fn barrier_segments_then_a_rows_zero_marker() {
+        let events = [
+            reg(0, 500, false),
+            place(0, 1),
+            ack(0, 1),
+            reg(1, 500, false),
+            place(1, 1),
+            ack(1, 1),
+            reg(2, 500, true),
+            place(2, 0),
+        ];
+        let n = interleave(&events, &mut check);
+        assert_eq!(n, 504, "every legal interleaving covered");
+    }
+
+    #[test]
+    fn split_acks_across_two_commits() {
+        let events = [
+            reg(0, 100, true),
+            place(0, 2),
+            ack(0, 1),
+            ack(0, 1),
+            reg(1, 200, true),
+            place(1, 2),
+            ack(1, 2),
+        ];
+        let n = interleave(&events, &mut check);
+        assert_eq!(n, 240, "every legal interleaving covered");
+    }
+
+    #[test]
+    fn seeded_sweep_over_wider_schedules() {
+        let mut rng = 0x5EED_1234_ABCD_0001u64;
+        let mut next = move || {
+            rng ^= rng << 13;
+            rng ^= rng >> 7;
+            rng ^= rng << 17;
+            rng
+        };
+        for round in 0..300u64 {
+            let seqs = 3 + (round % 4) as usize;
+            let mut pending: Vec<Vec<Ev>> = Vec::new();
+            let mut events = Vec::new();
+            for seq in 0..seqs as u64 {
+                let rows = next() % 3;
+                let publish = next() % 4 != 0;
+                events.push(reg(seq, (seq + 1) * 100, publish));
+                let mut per = vec![place(seq, rows)];
+                per.extend((0..rows).map(|_| ack(seq, 1)));
+                pending.push(per);
+            }
+            let mut schedule = Vec::new();
+            let mut regs = events.into_iter();
+            let mut open: Vec<usize> = Vec::new();
+            loop {
+                let more_regs = open.len() < seqs;
+                let pick_reg = more_regs && (open.is_empty() || next() % 3 == 0);
+                if pick_reg {
+                    schedule.push(regs.next().expect("one reg per seq"));
+                    open.push(open.len());
+                    continue;
+                }
+                let live: Vec<usize> = open
+                    .iter()
+                    .copied()
+                    .filter(|i| !pending[*i].is_empty())
+                    .collect();
+                if live.is_empty() {
+                    if more_regs {
+                        continue;
+                    }
+                    break;
+                }
+                let pick = live[(next() % live.len() as u64) as usize];
+                schedule.push(pending[pick].remove(0));
+            }
+            if next() % 2 == 0 {
+                let at = (next() % (schedule.len() as u64 + 1)) as usize;
+                // Below and above every commit: trailing must not lower one
+                let lsn = if next() % 2 == 0 { 50 } else { 1_000_000 };
+                schedule.insert(at, Ev::Trail { lsn });
+            }
+            check(&schedule);
+        }
     }
 }

--- a/src/emit/pipeline/bootstrap.rs
+++ b/src/emit/pipeline/bootstrap.rs
@@ -51,7 +51,7 @@ pub async fn drain(
 ) -> Result<BootstrapDrainOutcome, String> {
     // Routes frozen once per pass from the caller's config snapshot
     let routes: HashMap<_, _> = mapping_handle
-        .read()
+        .snapshot()
         .await
         .iter()
         .map(|(name, mapping)| {
@@ -357,7 +357,6 @@ mod tests {
     use crate::schema::{RelAttr, RelDescriptor, RelName, ReplIdent};
     use crate::toast::MemChunkStore;
     use ahash::{HashMap, HashMapExt};
-    use std::sync::atomic::AtomicU64;
     use walrus::pg::walparser::RelFileNode;
 
     fn rel(rel_node: u32) -> Arc<RelDescriptor> {
@@ -546,7 +545,7 @@ mod tests {
         tables.insert(RelName::new("public", "t16401"), mapping_for(16401));
         let mapping = crate::mapping::mapping_handle(tables);
 
-        let emitter_ack = Arc::new(AtomicU64::new(0));
+        let emitter_ack = Arc::new(crate::pos::Monotone::new(0));
         let (ack, collector) = ack::spawn(emitter_ack);
         let (msg_tx, mut msg_rx) = mpsc::channel::<BatcherMsg>(64);
         let (tup_tx, tup_rx) = mpsc::channel::<BackfillTuple>(64);
@@ -600,7 +599,7 @@ mod tests {
         tables.insert(RelName::new("public", "t16400"), mapping_for(16400));
         let mapping = crate::mapping::mapping_handle(tables);
 
-        let emitter_ack = Arc::new(AtomicU64::new(0));
+        let emitter_ack = Arc::new(crate::pos::Monotone::new(0));
         let (ack, collector) = ack::spawn(emitter_ack);
         let (msg_tx, mut msg_rx) = mpsc::channel::<BatcherMsg>(64);
         let (tup_tx, tup_rx) = mpsc::channel::<BackfillTuple>(64);
@@ -648,7 +647,7 @@ mod tests {
         tables.insert(RelName::new("public", "t16400"), bytea_mapping_for(16400));
         let mapping = crate::mapping::mapping_handle(tables);
 
-        let emitter_ack = Arc::new(AtomicU64::new(0));
+        let emitter_ack = Arc::new(crate::pos::Monotone::new(0));
         let (ack, collector) = ack::spawn(emitter_ack);
         let (msg_tx, mut msg_rx) = mpsc::channel::<BatcherMsg>(64);
         let (tup_tx, tup_rx) = mpsc::channel::<BackfillTuple>(64);
@@ -707,7 +706,7 @@ mod tests {
         tables.insert(RelName::new("public", "t16400"), bytea_mapping_for(16400));
         let mapping = crate::mapping::mapping_handle(tables);
 
-        let emitter_ack = Arc::new(AtomicU64::new(0));
+        let emitter_ack = Arc::new(crate::pos::Monotone::new(0));
         let (ack, collector) = ack::spawn(emitter_ack);
         let (msg_tx, mut msg_rx) = mpsc::channel::<BatcherMsg>(64);
         let (tup_tx, tup_rx) = mpsc::channel::<BackfillTuple>(64);
@@ -769,7 +768,7 @@ mod tests {
         tables.insert(RelName::new("public", "t16400"), bytea_mapping_for(16400));
         let mapping = crate::mapping::mapping_handle(tables);
 
-        let emitter_ack = Arc::new(AtomicU64::new(0));
+        let emitter_ack = Arc::new(crate::pos::Monotone::new(0));
         let (ack, collector) = ack::spawn(emitter_ack);
         let (msg_tx, mut msg_rx) = mpsc::channel::<BatcherMsg>(64);
         let (tup_tx, tup_rx) = mpsc::channel::<BackfillTuple>(64);
@@ -798,10 +797,12 @@ mod tests {
             None,
         ));
         // Wait for the referrer to defer, then unmap before walk EOF
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
         while stats.bootstrap_deferred_bytes.load(Ordering::Relaxed) == 0 {
+            assert!(std::time::Instant::now() < deadline, "referrer deferred");
             tokio::time::sleep(std::time::Duration::from_millis(2)).await;
         }
-        Arc::make_mut(&mut *mapping.write().await).clear();
+        mapping.mutate(|m| Arc::make_mut(m).clear()).await;
         drop(tup_tx);
 
         let mut rows = Vec::new();

--- a/src/emit/pipeline/mod.rs
+++ b/src/emit/pipeline/mod.rs
@@ -21,10 +21,9 @@ pub mod reorder;
 pub mod tail;
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::{Mutex, watch};
 use tokio::task::JoinHandle;
 
 use crate::catalog::shadow_catalog::ShadowCatalog;
@@ -34,16 +33,19 @@ use crate::emit::ch_emitter::{EmitterConfig, EmitterStats};
 use crate::mapping::MappingHandle;
 use crate::ops::oracle::Oracle;
 use crate::ops::trace::TxnSpanRegistry;
+use crate::pos::{EmitterAck, Floor, Monotone};
 use crate::xact::xact_buffer::{SubxactTracker, XactBuffer};
 
 /// One-shot fatal-error signal shared across pipeline stages. Pump polls
 /// [`Fatal::message`] to exit with the root cause; the DDL barrier `select`s
 /// on [`Fatal::wait`] so a CH outage mid-barrier surfaces instead of hanging.
-#[derive(Clone, Default)]
-pub struct Fatal {
-    flag: Arc<AtomicBool>,
-    msg: Arc<std::sync::Mutex<Option<String>>>,
-    notify: Arc<Notify>,
+#[derive(Clone)]
+pub struct Fatal(Arc<watch::Sender<Option<String>>>);
+
+impl Default for Fatal {
+    fn default() -> Self {
+        Self(Arc::new(watch::channel(None).0))
+    }
 }
 
 impl Fatal {
@@ -54,37 +56,28 @@ impl Fatal {
     /// Record the first message (root cause) and wake every waiter; later
     /// calls keep the first.
     pub fn set(&self, msg: String) {
-        {
-            let mut slot = self.msg.lock().expect("fatal slot poisoned");
-            if slot.is_none() {
-                tracing::error!(target: "walshadow::pipeline", error = %msg, "pipeline fatal");
-                *slot = Some(msg);
+        self.0.send_if_modified(|slot| {
+            if slot.is_some() {
+                return false;
             }
-        }
-        self.flag.store(true, Ordering::Release);
-        self.notify.notify_waiters();
+            tracing::error!(target: "walshadow::pipeline", error = %msg, "pipeline fatal");
+            *slot = Some(msg);
+            true
+        });
     }
 
     pub fn is_set(&self) -> bool {
-        self.flag.load(Ordering::Acquire)
+        self.0.borrow().is_some()
     }
 
     pub fn message(&self) -> Option<String> {
-        self.msg.lock().expect("fatal slot poisoned").clone()
+        self.0.borrow().clone()
     }
 
-    /// Resolve once the flag is set (now or later).
+    /// Resolve once the flag is set (now or later). Holding the sender keeps
+    /// the channel open, so this never resolves unset.
     pub async fn wait(&self) {
-        loop {
-            let notified = self.notify.notified();
-            if self.is_set() {
-                return;
-            }
-            notified.await;
-            if self.is_set() {
-                return;
-            }
-        }
+        let _ = self.0.subscribe().wait_for(Option::is_some).await;
     }
 }
 
@@ -135,7 +128,7 @@ pub struct PipelineConfig {
     pub retires: crate::toast::toast_retire::RetireLedger,
     /// Persisted resolved floor (aligned, archive-clamped), seeded at the
     /// resolved start; pruners cut against it verbatim
-    pub resume_floor: Arc<AtomicU64>,
+    pub resume_floor: Arc<Monotone<Floor>>,
     /// Shared resident-payload pool ([`build_budget`]); backup passes run
     /// concurrently with the pipeline and must draw from the same pool.
     /// `None` builds one at spawn
@@ -147,9 +140,10 @@ pub struct PipelineConfig {
 /// that sink drops the job queue closes and [`PipelineHandle::join`] drains
 /// the rest in order.
 pub struct PipelineHandle {
-    /// Durable watermark (contiguous-done commit_lsn). Pump advertises it as
-    /// the standby `apply_lsn` and writes it to the resume cursor.
-    pub emitter_ack: Arc<AtomicU64>,
+    /// Live contiguous-done watermark, floored before manifest persistence
+    pub emitter_ack: Arc<Monotone<EmitterAck>>,
+    /// Expose stalls after rows leave transaction buffer
+    pub ack_probe: tokio::sync::watch::Receiver<ack::AckSnapshot>,
     pub fatal: Fatal,
     pub toast: crate::toast::ToastResolver,
     /// Global resident-payload pool, exposed for the metrics loop
@@ -180,7 +174,7 @@ impl PipelineConfig {
     /// only if an inserter connection can't open.
     pub async fn spawn(
         self,
-        emitter_ack: Arc<AtomicU64>,
+        emitter_ack: Arc<Monotone<EmitterAck>>,
     ) -> Result<(reorder::ReorderSink, PipelineHandle), EmitterError> {
         let PipelineConfig {
             emitter,
@@ -247,6 +241,7 @@ impl PipelineConfig {
             resolver: resolver.clone(),
             chunk_rows: emitter.decode_chunk_rows,
         };
+        let ack_probe = ack.probe();
         let decoders = decode::spawn_pool(m, ctx, jobs_rx, ack.clone(), fatal.clone());
 
         let plan_dir = buffer.lock().await.spill_dir().to_path_buf();
@@ -281,6 +276,7 @@ impl PipelineConfig {
             reorder,
             PipelineHandle {
                 emitter_ack,
+                ack_probe,
                 fatal,
                 toast: resolver,
                 budget,

--- a/src/emit/pipeline/planner.rs
+++ b/src/emit/pipeline/planner.rs
@@ -57,8 +57,7 @@ use crate::xact::xact_buffer::{
 /// discard, counted by the implementation
 pub trait PlanRouteView {
     fn route_for(&mut self, heap: &DescribedHeap) -> Option<Arc<RouteSnapshot>>;
-    /// Fold one in-walk control entry into the local view. Async so
-    /// implementations can read shared config, never mutate it
+    /// Fold control entry into local view without mutating shared route state
     fn apply(
         &mut self,
         entry: &DrainEntry,

--- a/src/emit/pipeline/reorder.rs
+++ b/src/emit/pipeline/reorder.rs
@@ -17,7 +17,7 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 
 use tokio::sync::{Mutex, mpsc, oneshot, watch};
 use walrus::pg::walparser::RmId;
@@ -49,6 +49,7 @@ use crate::emit::pipeline::plan_spool::{PlanItem, SealedPlan};
 use crate::emit::pipeline::planner::{PlanRouteView, Planner, drain_reason};
 use crate::emit::route::{RouteSnapshot, RoutedHeap};
 use crate::mapping::{MappingHandle, MappingSnapshot, TableMapping};
+use crate::pos::{Floor, Monotone};
 use crate::runtime_config::{ConfigEvent, TableRow};
 use crate::toast::ToastResolver;
 use crate::toast::toast_retire::RetireLedger;
@@ -92,7 +93,7 @@ pub struct ReorderSink {
     /// Persisted resolved floor (aligned, archive-clamped) — the position
     /// a crash-now restart resumes from. Seeded at the resolved start,
     /// advanced only after each manifest persist.
-    resume_floor: Arc<AtomicU64>,
+    resume_floor: Arc<Monotone<Floor>>,
     /// Dense commit-order counter; one seq per dispatched data unit.
     next_seq: u64,
     /// Drain-slice budget: rows / bytes per [`DrainedBatch`] pulled from the
@@ -128,10 +129,7 @@ pub struct ReorderSink {
     /// Plan spool directory (the xact spill dir), cached at spawn so the
     /// per-commit path needs no buffer lock
     plan_dir: std::path::PathBuf,
-    /// Mapping version frozen with the memo reset: one transaction plans
-    /// against one mapping version, a concurrent republish (SIGHUP /
-    /// control-socket, no WAL position) can't split its rows. In-walk event
-    /// applies re-snapshot so trailing heaps see the event's own effect.
+    /// Frozen per transaction, with catalog events folded into local overlay
     route_mapping: Option<MappingSnapshot>,
     /// Resolved-config snapshot taken with the memo reset; every override in
     /// one interval comes from one snapshot, never a mid-interval republish.
@@ -162,7 +160,7 @@ impl ReorderSink {
         plan_dir: std::path::PathBuf,
         budget: Option<crate::budget::MemoryBudget>,
         retires: RetireLedger,
-        resume_floor: Arc<AtomicU64>,
+        resume_floor: Arc<Monotone<Floor>>,
         mapping: MappingHandle,
         soft_delete: bool,
     ) -> Self {
@@ -219,7 +217,7 @@ impl ReorderSink {
     /// whole-transaction snapshot; a non-WAL-positioned republish landing
     /// mid-plan can't reroute rows already planned or split the transaction.
     async fn reset_route_state(&mut self) {
-        self.route_mapping = Some(self.mapping.read().await.clone());
+        self.route_mapping = Some(self.mapping.snapshot().await);
         self.route_config = self.reload_rx.as_ref().map(|rx| rx.borrow().clone());
     }
 
@@ -398,8 +396,9 @@ impl ReorderSink {
     async fn dispatch_job(&mut self, job: DecodeJob) -> Result<(), SinkError> {
         self.stats.queue_jobs_out.fetch_add(1, Ordering::Relaxed);
         tokio::select! {
-            r = self.jobs_tx.send(job) => r.map_err(|_| SinkError::Other("decode job queue closed".into())),
+            biased;
             _ = self.fatal.wait() => Err(self.fatal_err()),
+            r = self.jobs_tx.send(job) => r.map_err(|_| SinkError::Other("decode job queue closed".into())),
         }
     }
 
@@ -411,18 +410,23 @@ impl ReorderSink {
             return Err(SinkError::Other("batcher channel closed".into()));
         }
         tokio::select! {
-            r = rx => r.map_err(|_| SinkError::Other("batcher dropped flush ack".into())),
+            biased;
             _ = self.fatal.wait() => Err(self.fatal_err()),
+            r = rx => r.map_err(|_| SinkError::Other("batcher dropped flush ack".into())),
         }
     }
 
+    // Barrier waits prefer concurrent fatal over successful completion
     /// Wait until every dispatched seq is *placed* (decode pool routed all
     /// their rows onto the shared channel), so a `FlushAll` orders after them.
     async fn wait_all_placed(&mut self) -> Result<(), SinkError> {
         let through = self.next_seq;
         tokio::select! {
-            _ = self.ack.wait_placed_through(through) => Ok(()),
+            biased;
             _ = self.fatal.wait() => Err(self.fatal_err()),
+            r = self.ack.wait_placed_through(through) => r.map_err(|e| {
+                SinkError::Other(format!("placed barrier through {through}: {e}"))
+            }),
         }
     }
 
@@ -431,8 +435,11 @@ impl ReorderSink {
     async fn wait_all_durable(&mut self) -> Result<(), SinkError> {
         let through = self.next_seq;
         tokio::select! {
-            _ = self.ack.wait_through(through) => Ok(()),
+            biased;
             _ = self.fatal.wait() => Err(self.fatal_err()),
+            r = self.ack.wait_through(through) => r.map_err(|e| {
+                SinkError::Other(format!("durability barrier through {through}: {e}"))
+            }),
         }
     }
 
@@ -513,7 +520,7 @@ impl ReorderSink {
         if !self.resolver.stores_chunks() || self.retires.is_empty() {
             return Ok(());
         }
-        let cut = self.resume_floor.load(Ordering::Acquire);
+        let cut = self.resume_floor.get();
         for (oid, commit_lsn) in self.retires.due(cut) {
             self.resolver
                 .retire_mirror(oid)
@@ -943,11 +950,9 @@ fn bump_plan_failure(stats: &EmitterStats, reason: &'static str) {
     counter.fetch_add(1, Ordering::Relaxed);
 }
 
-/// Plan-time route state for one transaction: frozen mapping + config
-/// versions plus a local fold of in-walk catalog entries. The applicator
-/// predicts what executing each event will leave in the routing map
-/// ([`DdlApplicator::predict_route_mapping`]) so post-event rows plan under
-/// post-event routes while the real side effects wait for the executor.
+/// Frozen route state plus transaction-local catalog changes
+///
+/// Predict route effects before executor applies matching DDL
 /// Config-table events are not folded: a same-xact config write followed
 /// by rows plans under the frozen version (whole-transaction granularity;
 /// the in-xact interval refinement lands with the config fold)
@@ -1021,11 +1026,13 @@ impl PlanRouteView for ReorderRouteView<'_> {
             // no route effect
             return Ok(());
         };
+        let mapping = self.mapping.clone().unwrap_or_default();
+        let config = self.config.clone();
         let Some(app) = self.applicator.as_deref_mut() else {
             return Ok(());
         };
         if let Some((rel, m)) = app
-            .predict_route_mapping(ev)
+            .predict_route_mapping(ev, &mapping, config.as_deref())
             .await
             .map_err(|e| e.to_string())?
         {
@@ -1086,5 +1093,69 @@ impl RecordSink for ReorderSink {
             // here so the flush doesn't wait for a later commit
             self.flush_due_retires().await
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decode::heap_decoder::DecodedHeap;
+    use crate::mapping::TableTarget;
+    use crate::xact::xact_buffer::raw_fixtures::int4_descriptor;
+
+    fn mapping_for(rel: &RelName) -> TableMapping {
+        TableMapping {
+            target: TableTarget::new("db", &rel.name),
+            columns: Vec::new(),
+        }
+    }
+
+    fn heap_of(rel: &RelName) -> DescribedHeap {
+        let mut desc = (*int4_descriptor(16400)).clone();
+        desc.rel_name = rel.clone();
+        DescribedHeap {
+            decoded: DecodedHeap {
+                rfn: desc.rfn,
+                xid: 1,
+                source_lsn: 0x100,
+                op: HeapOp::Insert,
+                new: None,
+                old: None,
+            },
+            descriptor: Arc::new(desc),
+            descriptor_valid_from: 0x40,
+        }
+    }
+
+    #[tokio::test]
+    async fn plan_view_holds_one_mapping_version_across_a_republish() {
+        let planned = RelName::new("public", "planned");
+        let added = RelName::new("public", "added");
+        let handle = crate::mapping::mapping_handle(HashMap::from_iter([(
+            planned.clone(),
+            mapping_for(&planned),
+        )]));
+
+        let stats = Arc::new(EmitterStats::default());
+        let mut view =
+            ReorderRouteView::new(Some(handle.snapshot().await), None, false, None, stats);
+        assert!(view.route_for(&heap_of(&planned)).is_some());
+        assert!(view.route_for(&heap_of(&added)).is_none());
+
+        handle
+            .publish(Arc::new(HashMap::from_iter([(
+                added.clone(),
+                mapping_for(&added),
+            )])))
+            .await;
+
+        assert!(
+            view.route_for(&heap_of(&planned)).is_some(),
+            "republish can't unroute rows already planned"
+        );
+        assert!(
+            view.route_for(&heap_of(&added)).is_none(),
+            "republish can't route rows this transaction planned unmapped"
+        );
     }
 }

--- a/src/emit/pipeline/tail.rs
+++ b/src/emit/pipeline/tail.rs
@@ -12,7 +12,6 @@
 //! collector exits.
 
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
 
 use clickhouse_c::Allocator;
 use tokio::sync::{mpsc, oneshot, watch};
@@ -25,6 +24,7 @@ use crate::emit::pipeline::ack::{self, AckHandle};
 use crate::emit::pipeline::batcher::{self, BatcherConfig, BatcherMsg, InsertBatch};
 use crate::emit::pipeline::inserter;
 use crate::emit::pipeline::{DEFAULT_PIPELINE_FLUSH, Fatal};
+use crate::pos::{EmitterAck, Monotone};
 use ahash::{HashMap, HashMapExt};
 
 /// Spawned tail stages; holding this keeps the tasks owned by the caller.
@@ -63,17 +63,20 @@ impl TailParts {
                 .message()
                 .unwrap_or_else(|| "tail closed before flush".into()));
         }
+        // Prefer concurrent fatal over successful completion
         tokio::select! {
-            r = reply_rx => r.map_err(|_| "batcher dropped flush ack".to_string())?,
+            biased;
             _ = fatal.wait() => {
                 return Err(fatal.message().unwrap_or_else(|| "tail fatal during flush".into()));
             }
+            r = reply_rx => r.map_err(|_| "batcher dropped flush ack".to_string())?,
         }
         tokio::select! {
-            _ = ack.wait_through(through) => {}
+            biased;
             _ = fatal.wait() => {
                 return Err(fatal.message().unwrap_or_else(|| "tail fatal during drain".into()));
             }
+            r = ack.wait_through(through) => r.map_err(|e| format!("tail drain: {e}"))?,
         }
         drop(msg_tx);
         drop(ack);
@@ -94,7 +97,7 @@ pub async fn spawn(
     emitter: &EmitterConfig,
     inserter_pool_size: usize,
     stats: Arc<EmitterStats>,
-    emitter_ack: Arc<AtomicU64>,
+    emitter_ack: Arc<Monotone<EmitterAck>>,
     fatal: Fatal,
 ) -> Result<(mpsc::Sender<BatcherMsg>, AckHandle, TailParts), EmitterError> {
     spawn_with_config(emitter, inserter_pool_size, stats, emitter_ack, fatal, None).await
@@ -105,7 +108,9 @@ pub async fn spawn(
 /// drop) so nothing can pin the watermark; `FlushAll` replies
 /// immediately — nothing buffers. Keeps the placed/acked protocol
 /// identical to the CH tail, so reorder/decode stages run unchanged.
-pub fn spawn_null(emitter_ack: Arc<AtomicU64>) -> (mpsc::Sender<BatcherMsg>, AckHandle, TailParts) {
+pub fn spawn_null(
+    emitter_ack: Arc<Monotone<EmitterAck>>,
+) -> (mpsc::Sender<BatcherMsg>, AckHandle, TailParts) {
     let (ack, collector) = ack::spawn(emitter_ack);
     let (msg_tx, mut msg_rx) = mpsc::channel::<BatcherMsg>(256);
     let swallow_ack = ack.clone();
@@ -144,7 +149,7 @@ pub async fn spawn_with_config(
     emitter: &EmitterConfig,
     inserter_pool_size: usize,
     stats: Arc<EmitterStats>,
-    emitter_ack: Arc<AtomicU64>,
+    emitter_ack: Arc<Monotone<EmitterAck>>,
     fatal: Fatal,
     config_rx: Option<watch::Receiver<Arc<ResolvedConfig>>>,
 ) -> Result<(mpsc::Sender<BatcherMsg>, AckHandle, TailParts), EmitterError> {

--- a/src/filter/catalog_tracker.rs
+++ b/src/filter/catalog_tracker.rs
@@ -95,9 +95,7 @@ pub struct CatalogTracker {
     /// non-mapped catalog (pg_depend, pg_namespace, …).
     pg_class_writes_oid_in_prefix: u64,
     seeded_from_source: u64,
-    /// Non-`None` verdicts returned by `observe`; catalog's
-    /// `generation_bumps` may lag as it collapses bumps between lookups
-    /// into one `invalidate`.
+    /// Coarse invalidations, including writes without decoded OID
     invalidation_signals_sent: u64,
 }
 
@@ -198,10 +196,7 @@ impl CatalogTracker {
         self.nodes.contains(&(db_node, rel_node)) || self.nodes.contains(&(0, rel_node))
     }
 
-    /// Filters internally on rmgr + info; safe to call unconditionally.
-    /// Returned verdict rides the record to the decoder worker, which
-    /// bumps invalidation epochs at its own stream position (see module
-    /// doc).
+    /// Observe catalog database and decoded user relation OID when present
     pub fn observe(&mut self, record: &XLogRecord) -> Observation {
         let rm = record.header.resource_manager_id;
         let info_high = record.header.info & 0xF0;
@@ -236,11 +231,7 @@ impl CatalogTracker {
         Observation::default()
     }
 
-    /// Coarse-fire (no row decode) when a record hits the current
-    /// pg_class filenode, for ops the harvest path skips (DELETE). The
-    /// `InvalidateSweep` verdict arms the DROP sweep at the worker
-    /// ([`PendingSweeps`], keyed by the record's xid). Returns the written
-    /// pg_class's database
+    /// Invalidate pg_class writes skipped by row decoder, such as DELETE
     fn signal_pg_class_touch(&mut self, record: &XLogRecord) -> Option<u32> {
         let (db, _rel) = self.pg_class_block(record)?;
         self.invalidation_signals_sent += 1;

--- a/src/filter/engine.rs
+++ b/src/filter/engine.rs
@@ -272,14 +272,7 @@ impl Filter {
         )
     }
 
-    /// Route plus the tracker's [`CatalogSignal`] verdict, stamped on the
-    /// outgoing [`Record`](crate::record::Record) so the decoder worker
-    /// bumps invalidation epochs at its own stream position (a
-    /// pump-position bump would be consumable before pre-DDL records finish
-    /// decoding; see `catalog_tracker` module doc), plus the
-    /// catalog-boundary verdict driving the pump's publication hold and
-    /// descriptor capture. `Err` = malformed commit payload: capture input
-    /// would be silently incomplete, poison the stream.
+    /// Classify route and catalog boundary, reject incomplete commit metadata
     pub fn decide_record(
         &mut self,
         record: &XLogRecord,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod fs;
 pub mod mapping;
 pub mod ops;
 pub mod pg;
+pub mod pos;
 pub mod record;
 pub mod runtime_config;
 pub mod schema;

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use crate::catalog::type_bridge;
 use crate::schema::{RelDescriptor, RelName, SchemaDiff, replident_key_attnums};
 use ahash::HashMap;
+use tokio::sync::RwLock;
 
 #[derive(Debug, Clone)]
 pub struct TableMapping {
@@ -104,12 +105,44 @@ pub struct ToastConfig {
 /// concurrent republish can't split a transaction across mapping versions
 pub type MappingSnapshot = Arc<HashMap<RelName, TableMapping>>;
 
-/// Shared copy-on-write routing map: writers swap or `Arc::make_mut` the
-/// inner snapshot, held snapshots stay frozen
-pub type MappingHandle = Arc<tokio::sync::RwLock<MappingSnapshot>>;
+pub type MappingHandle = Arc<MappingCell>;
+
+/// Copy-on-write routing map. Writers `Arc::make_mut` or swap the inner
+/// snapshot, so a snapshot taken for one unit of work stays frozen
+#[derive(Debug)]
+pub struct MappingCell {
+    inner: RwLock<MappingSnapshot>,
+}
+
+impl MappingCell {
+    pub async fn with<R>(&self, f: impl FnOnce(&MappingSnapshot) -> R) -> R {
+        f(&*self.inner.read().await)
+    }
+
+    pub async fn snapshot(&self) -> MappingSnapshot {
+        self.inner.read().await.clone()
+    }
+
+    /// `false` once a fold or republish displaced `at`. Holding `at` keeps
+    /// its allocation alive and forces `Arc::make_mut` to clone, so pointer
+    /// identity answers "has the map moved since I looked?"
+    pub async fn unmoved(&self, at: &MappingSnapshot) -> bool {
+        Arc::ptr_eq(&*self.inner.read().await, at)
+    }
+
+    pub async fn mutate<R>(&self, f: impl FnOnce(&mut MappingSnapshot) -> R) -> R {
+        f(&mut *self.inner.write().await)
+    }
+
+    pub async fn publish(&self, tables: MappingSnapshot) {
+        *self.inner.write().await = tables;
+    }
+}
 
 pub fn mapping_handle(tables: HashMap<RelName, TableMapping>) -> MappingHandle {
-    Arc::new(tokio::sync::RwLock::new(Arc::new(tables)))
+    Arc::new(MappingCell {
+        inner: RwLock::new(Arc::new(tables)),
+    })
 }
 
 pub fn derive_columns_for_mapping(desc: &RelDescriptor) -> Vec<ColumnMapping> {
@@ -182,15 +215,18 @@ mod tests {
         let (rel, map) = one_table();
         let handle = mapping_handle(map);
         // Applicator shape: make_mut clones out from under held snapshots
-        let planned: MappingSnapshot = handle.read().await.clone();
-        Arc::make_mut(&mut *handle.write().await).remove(&rel);
+        let planned: MappingSnapshot = handle.snapshot().await;
+        handle.mutate(|m| Arc::make_mut(m).remove(&rel)).await;
         assert!(planned.contains_key(&rel), "snapshot keeps its version");
-        assert!(!handle.read().await.contains_key(&rel), "handle moved on");
+        assert!(
+            !handle.with(|m| m.contains_key(&rel)).await,
+            "handle moved on"
+        );
         // Republish shape: full inner-Arc swap
-        let planned = handle.read().await.clone();
+        let planned = handle.snapshot().await;
         let (rel2, map2) = one_table();
-        *handle.write().await = Arc::new(map2);
+        handle.publish(Arc::new(map2)).await;
         assert!(!planned.contains_key(&rel2), "snapshot predates the swap");
-        assert!(handle.read().await.contains_key(&rel2));
+        assert!(handle.with(|m| m.contains_key(&rel2)).await);
     }
 }

--- a/src/ops/control.rs
+++ b/src/ops/control.rs
@@ -446,11 +446,12 @@ async fn stream_status(ctx: &SharedCtx) -> Result<String> {
         ("pause_received_lsn", snap.pause_received_lsn),
         ("target_replay_lsn", snap.promotion_target_replay_lsn),
         ("target_receive_lsn", snap.promotion_target_receive_lsn),
-        ("floor", snap.floor_lsn),
-        ("source_received", snap.source_received_lsn),
-        ("drain", snap.decoder_commit_lsn),
-        ("emitter_ack", snap.emitter_ack_lsn),
-        ("shadow_replay", snap.shadow_replay_lsn),
+        ("floor", snap.floor_lsn.get()),
+        ("source_received", snap.source_received_lsn.get()),
+        ("drain", snap.decoder_commit_lsn.get()),
+        // Live ack, not the manifest's floored `emitter_ack`
+        ("emitter_ack", snap.emitter_ack_lsn.get()),
+        ("shadow_replay", snap.shadow_replay_lsn.get()),
     ] {
         out.insert(key.into(), format_pg_lsn(lsn).to_string().into());
     }

--- a/src/ops/metrics.rs
+++ b/src/ops/metrics.rs
@@ -20,6 +20,7 @@ use tokio::net::TcpListener;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 
+use crate::pos::{Drain, EmitterAck, FilterDispatched, Floor, Pos, ShadowReplay, SourceReceived};
 use crate::source::transition::SWITCH_FAILURE_REASONS;
 
 #[derive(Debug, Error)]
@@ -35,19 +36,19 @@ pub enum MetricsError {
 #[derive(Debug, Default, Clone)]
 pub struct MetricsSnapshot {
     /// Source PG's most recent `server_wal_end` (write LSN as PG sees it)
-    pub source_received_lsn: u64,
+    pub source_received_lsn: Pos<SourceReceived>,
     /// Last segment-boundary LSN dispatched downstream; becomes durable once
     /// segment fsync lands
-    pub filter_lsn: u64,
+    pub filter_lsn: Pos<FilterDispatched>,
     /// Shadow PG's `pg_last_wal_replay_lsn()`, `0` until first poll
-    pub shadow_replay_lsn: u64,
+    pub shadow_replay_lsn: Pos<ShadowReplay>,
     /// Highest commit LSN drained out of the xact buffer, so above every
     /// commit whose rows could have reached ClickHouse
-    pub decoder_commit_lsn: u64,
-    /// Contiguous-done watermark from the insert pipeline
-    pub emitter_ack_lsn: u64,
+    pub decoder_commit_lsn: Pos<Drain>,
+    /// Live insert watermark, unlike manifest's resume-safe `emitter_ack`
+    pub emitter_ack_lsn: Pos<EmitterAck>,
     /// Durable resume floor: restart resumes here and every pruner cuts to it
-    pub floor_lsn: u64,
+    pub floor_lsn: Pos<Floor>,
     /// `route` is `"to_shadow"` / `"to_decoder"`
     pub records_by_rm_route: BTreeMap<(String, &'static str), u64>,
     pub xact_active: u64,
@@ -396,32 +397,32 @@ pub fn render(snap: &MetricsSnapshot) -> String {
         (
             "walshadow_source_received_lsn",
             "Source PG's most recent server_wal_end seen on the replication socket.",
-            snap.source_received_lsn,
+            snap.source_received_lsn.get(),
         ),
         (
             "walshadow_filter_lsn",
             "LSN of the last filtered WAL byte the daemon has dispatched.",
-            snap.filter_lsn,
+            snap.filter_lsn.get(),
         ),
         (
             "walshadow_shadow_replay_lsn",
             "Shadow PG's pg_last_wal_replay_lsn(), polled at status cadence.",
-            snap.shadow_replay_lsn,
+            snap.shadow_replay_lsn.get(),
         ),
         (
             "walshadow_decoder_commit_lsn",
             "Highest commit LSN drained out of the xact buffer.",
-            snap.decoder_commit_lsn,
+            snap.decoder_commit_lsn.get(),
         ),
         (
             "walshadow_emitter_ack_lsn",
             "Contiguous-done watermark from the insert pipeline.",
-            snap.emitter_ack_lsn,
+            snap.emitter_ack_lsn.get(),
         ),
         (
             "walshadow_floor_lsn",
             "Durable resume floor: restart resumes here and pruners cut to it.",
-            snap.floor_lsn,
+            snap.floor_lsn.get(),
         ),
         (
             "walshadow_source_timeline",
@@ -1401,8 +1402,8 @@ mod tests {
     #[test]
     fn render_includes_help_type_lines() {
         let mut snap = MetricsSnapshot {
-            source_received_lsn: 0xCAFE_BABE,
-            filter_lsn: 0xC0FFEE,
+            source_received_lsn: 0xCAFE_BABE.into(),
+            filter_lsn: 0xC0FFEE.into(),
             xact_active: 3,
             uptime_secs: 42,
             ..MetricsSnapshot::default()
@@ -1515,7 +1516,7 @@ mod tests {
     async fn registry_set_and_snapshot_round_trip() {
         let reg = MetricsRegistry::new();
         let snap = MetricsSnapshot {
-            filter_lsn: 7,
+            filter_lsn: 7.into(),
             xacts_committed_total: 11,
             ..MetricsSnapshot::default()
         };
@@ -1608,7 +1609,7 @@ mod tests {
     async fn http_serve_returns_text_format_body() {
         let reg = MetricsRegistry::new();
         let snap = MetricsSnapshot {
-            filter_lsn: 0xDEAD,
+            filter_lsn: 0xDEAD.into(),
             ..MetricsSnapshot::default()
         };
         reg.set(snap).await;

--- a/src/ops/retention.rs
+++ b/src/ops/retention.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 use thiserror::Error;
 use walrus::pg::wal::segment::{SEGMENT_NAME_LEN, SegmentName};
 
+use crate::pos::{FilterDurable, Pos, ShadowReplay};
 use crate::record::WAL_SEG_SIZE;
 
 /// 256 MiB = ~16 segments at 16 MiB. Enough to replay through a typical
@@ -48,7 +49,11 @@ pub struct TrimReport {
 /// Trim segments whose *end* LSN (`start_lsn + WAL_SEG_SIZE`) is below
 /// `cutoff_lsn`. End-LSN boundary preserves the segment containing the
 /// cutoff: shadow may still be reading it.
-pub async fn trim_below_lsn(dir: &Path, cutoff_lsn: u64) -> Result<TrimReport, RetentionError> {
+pub async fn trim_below_lsn(
+    dir: &Path,
+    cutoff_lsn: impl Into<Pos<ShadowReplay>>,
+) -> Result<TrimReport, RetentionError> {
+    let cutoff_lsn = cutoff_lsn.into();
     let mut report = TrimReport::default();
     if !dir.exists() {
         return Ok(report);
@@ -65,7 +70,7 @@ pub async fn trim_below_lsn(dir: &Path, cutoff_lsn: u64) -> Result<TrimReport, R
             continue;
         };
         let end_lsn = seg.start_lsn(WAL_SEG_SIZE).saturating_add(WAL_SEG_SIZE);
-        if end_lsn > cutoff_lsn {
+        if end_lsn > cutoff_lsn.get() {
             continue;
         }
         let size = entry.metadata().await.map(|m| m.len()).unwrap_or(0);
@@ -80,7 +85,7 @@ pub async fn trim_below_lsn(dir: &Path, cutoff_lsn: u64) -> Result<TrimReport, R
             target: "walshadow::retention",
             file = %name,
             end_lsn,
-            cutoff_lsn,
+            cutoff_lsn = cutoff_lsn.get(),
             "trimmed",
         );
     }
@@ -91,7 +96,7 @@ pub async fn trim_below_lsn(dir: &Path, cutoff_lsn: u64) -> Result<TrimReport, R
 /// Return `None` when no sealed segment exists
 /// Ignore `.partial` files because `restore_command` serves only sealed
 /// segments
-pub async fn max_segment_end(dir: &Path) -> Result<Option<u64>, RetentionError> {
+pub async fn max_segment_end(dir: &Path) -> Result<Option<Pos<FilterDurable>>, RetentionError> {
     let mut max_end = None;
     if !dir.exists() {
         return Ok(max_end);
@@ -108,8 +113,8 @@ pub async fn max_segment_end(dir: &Path) -> Result<Option<u64>, RetentionError> 
         let Some(seg) = seg_str.and_then(|s| SegmentName::parse(s).ok()) else {
             continue;
         };
-        let end = seg.start_lsn(WAL_SEG_SIZE).saturating_add(WAL_SEG_SIZE);
-        max_end = Some(max_end.map_or(end, |m: u64| m.max(end)));
+        let end = Pos::new(seg.start_lsn(WAL_SEG_SIZE).saturating_add(WAL_SEG_SIZE));
+        max_end = Some(max_end.map_or(end, |m: Pos<FilterDurable>| m.max(end)));
     }
     Ok(max_end)
 }
@@ -270,7 +275,7 @@ mod tests {
         }
         .start_lsn(WAL_SEG_SIZE)
             + WAL_SEG_SIZE;
-        assert_eq!(max_segment_end(dir).await.unwrap(), Some(want));
+        assert_eq!(max_segment_end(dir).await.unwrap(), Some(want.into()));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/pos.rs
+++ b/src/pos.rs
@@ -1,0 +1,375 @@
+//! Typed stream positions and the monotone cells that publish them
+//!
+//! Kinds name roles, not an order: shadow and decoder consume one stream
+//! independently, so `drain` routinely runs ahead of `shadow_replay`
+
+use std::cmp::Ordering as CmpOrdering;
+use std::fmt;
+use std::marker::PhantomData;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use tokio::sync::watch;
+use walrus::pg::backup::{format_pg_lsn, parse_pg_lsn};
+
+/// Position role, named for diagnostics
+pub trait PosKind: 'static {
+    const NAME: &'static str;
+}
+
+/// WAL byte position. Seq-space counts stay off this trait, so rendering or
+/// persisting a count as an LSN is a compile error
+pub trait LsnKind: PosKind {}
+
+macro_rules! kinds {
+    ($($(#[$m:meta])* $name:ident => $label:literal;)+) => {
+        $(
+            $(#[$m])*
+            #[derive(Debug)]
+            pub enum $name {}
+            impl PosKind for $name {
+                const NAME: &'static str = $label;
+            }
+        )+
+    };
+}
+
+macro_rules! lsn_kinds {
+    ($($(#[$m:meta])* $name:ident => $label:literal;)+) => {
+        kinds! { $($(#[$m])* $name => $label;)+ }
+        $(impl LsnKind for $name {})+
+    };
+}
+
+lsn_kinds! {
+    /// Highest `server_wal_end` seen on replication socket
+    SourceReceived => "source_received";
+    /// Highest sealed segment boundary fsynced by segment sink
+    FilterDurable => "filter_durable";
+    /// Shadow PG `pg_last_wal_replay_lsn()`
+    ShadowReplay => "shadow_replay";
+    /// Minimum `flush_lsn` across active shadow streams
+    ShadowFlush => "shadow_flush";
+    /// Highest byte position dispatched onto one shadow stream
+    ShadowDispatched => "shadow_dispatched";
+    /// Highest commit LSN drained from transaction buffer
+    Drain => "drain";
+    /// Highest commit LSN durably acked by pipeline
+    EmitterAck => "emitter_ack";
+    /// Emitter ack floored at oldest undurable transaction
+    ResumeSafe => "resume_safe";
+    XactFirst => "xact_first";
+    /// Last segment boundary handed downstream, durable after fsync
+    FilterDispatched => "filter_dispatched";
+    Commit => "commit";
+    Snapshot => "snapshot";
+    /// Segment-aligned, archive-clamped resume and GC floor
+    Floor => "floor";
+    /// Timeline start or ancestor switchpoint
+    Switchpoint => "switchpoint";
+}
+
+kinds! {
+    /// Contiguous done prefix in ack collector seq space
+    AckFrontier => "ack_frontier";
+    /// Prefix of seqs fully routed by decode pool
+    PlacedFrontier => "placed_frontier";
+    /// Enqueues onto shadow send queues
+    QueuedWake => "queued_wake";
+    /// Standby status reports plus connection attaches
+    AppliedWake => "applied_wake";
+}
+
+pub struct Pos<K>(u64, PhantomData<fn() -> K>);
+
+impl<K> Pos<K> {
+    pub const ZERO: Self = Self(0, PhantomData);
+
+    pub const fn new(raw: u64) -> Self {
+        Self(raw, PhantomData)
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    pub const fn is_zero(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Cross role boundary, callers must document why roles align
+    pub const fn retag<J>(self) -> Pos<J> {
+        Pos::new(self.0)
+    }
+}
+
+impl<K> Clone for Pos<K> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<K> Copy for Pos<K> {}
+
+impl<K> Default for Pos<K> {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl<K> From<u64> for Pos<K> {
+    fn from(raw: u64) -> Self {
+        Self::new(raw)
+    }
+}
+
+impl<K> PartialEq<u64> for Pos<K> {
+    fn eq(&self, other: &u64) -> bool {
+        self.0 == *other
+    }
+}
+
+impl<K> PartialOrd<u64> for Pos<K> {
+    fn partial_cmp(&self, other: &u64) -> Option<CmpOrdering> {
+        Some(self.0.cmp(other))
+    }
+}
+
+impl<K> PartialEq for Pos<K> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<K> Eq for Pos<K> {}
+
+impl<K> PartialOrd for Pos<K> {
+    fn partial_cmp(&self, other: &Self) -> Option<CmpOrdering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<K> Ord for Pos<K> {
+    fn cmp(&self, other: &Self) -> CmpOrdering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl<K: LsnKind> fmt::Display for Pos<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&format_pg_lsn(self.0), f)
+    }
+}
+
+impl<K: PosKind> fmt::Debug for Pos<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}={}", K::NAME, self.0)
+    }
+}
+
+impl<K: LsnKind> Serialize for Pos<K> {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(&format_pg_lsn(self.0))
+    }
+}
+
+impl<'de, K: LsnKind> Deserialize<'de> for Pos<K> {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        parse_pg_lsn(&s)
+            .map(Pos::new)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Shared position that only moves forward, with level-triggered waiters
+///
+/// `join` is the routine mutator: a watermark that can be assigned is one that
+/// can regress, and a regressed durability watermark recycles WAL the
+/// destination never received. Dropping the cell closes every [`Gate`] on it
+pub struct Monotone<K> {
+    tx: watch::Sender<u64>,
+    _kind: PhantomData<fn() -> K>,
+}
+
+impl<K> Monotone<K> {
+    pub fn new(init: impl Into<Pos<K>>) -> Self {
+        Self {
+            tx: watch::Sender::new(init.into().get()),
+            _kind: PhantomData,
+        }
+    }
+
+    pub fn join(&self, v: impl Into<Pos<K>>) -> Pos<K> {
+        let v = v.into().get();
+        let mut prev = 0;
+        self.tx.send_if_modified(|cur| {
+            prev = std::mem::replace(cur, (*cur).max(v));
+            prev < v
+        });
+        Pos::new(prev.max(v))
+    }
+
+    /// Re-anchor after position space changes, such as timeline fork
+    pub fn rebase(&self, v: impl Into<Pos<K>>) -> Pos<K> {
+        let v = v.into();
+        self.tx.send_replace(v.get());
+        v
+    }
+
+    /// Advance a cell that counts events rather than bytes
+    pub fn bump(&self) {
+        self.tx.send_modify(|cur| *cur += 1);
+    }
+
+    pub fn get(&self) -> Pos<K> {
+        Pos::new(*self.tx.borrow())
+    }
+
+    pub fn watch(&self) -> Gate<K> {
+        Gate {
+            rx: self.tx.subscribe(),
+            _kind: PhantomData,
+        }
+    }
+}
+
+impl<K> Default for Monotone<K> {
+    fn default() -> Self {
+        Self::new(0u64)
+    }
+}
+
+impl<K: PosKind> fmt::Debug for Monotone<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.get().fmt(f)
+    }
+}
+
+/// Level-triggered view of a [`Monotone`]
+pub struct Gate<K> {
+    rx: watch::Receiver<u64>,
+    _kind: PhantomData<fn() -> K>,
+}
+
+impl<K> Clone for Gate<K> {
+    fn clone(&self) -> Self {
+        Self {
+            rx: self.rx.clone(),
+            _kind: PhantomData,
+        }
+    }
+}
+
+impl<K: PosKind> fmt::Debug for Gate<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.current().fmt(f)
+    }
+}
+
+/// Cell dropped before the target was covered, so nothing can reach it
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GateClosed;
+
+impl fmt::Display for GateClosed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("gate closed before target was covered")
+    }
+}
+
+impl std::error::Error for GateClosed {}
+
+impl<K> Gate<K> {
+    pub fn current(&self) -> Pos<K> {
+        Pos::new(*self.rx.borrow())
+    }
+
+    /// Resolve once the cell covers `target`
+    ///
+    /// Probe before parking, so a move that landed first is not waited out
+    pub async fn wait(&self, target: impl Into<Pos<K>>) -> Result<Pos<K>, GateClosed> {
+        let target = target.into().get();
+        let mut rx = self.rx.clone();
+        loop {
+            let cur = *rx.borrow_and_update();
+            if cur >= target {
+                return Ok(Pos::new(cur));
+            }
+            rx.changed().await.map_err(|_| GateClosed)?;
+        }
+    }
+
+    /// Resolve on the first move past `seen`, for consumers that redo their
+    /// work from current state rather than aiming at a target
+    pub async fn advance(&self, seen: Pos<K>) -> Result<Pos<K>, GateClosed> {
+        self.wait(seen.get().saturating_add(1)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_rebase_lowers_a_cell() {
+        let m: Monotone<Floor> = Monotone::default();
+        assert_eq!(m.join(500u64), 500);
+        assert_eq!(m.join(100u64), 500);
+        assert_eq!(m.rebase(100u64), 100, "fork re-anchors the floor");
+        assert_eq!(m.get(), 100);
+    }
+
+    #[test]
+    fn counts_never_render_as_pg_lsn() {
+        assert_eq!(Pos::<Drain>::new(0x4100588).to_string(), "0/4100588");
+        assert_eq!(
+            format!(
+                "{} {:?}",
+                Pos::<EmitterAck>::new(16),
+                Pos::<AckFrontier>::new(16)
+            ),
+            "0/10 ack_frontier=16"
+        );
+    }
+
+    #[test]
+    fn lsn_kinds_round_trip_through_pg_text() {
+        let p = Pos::<Floor>::new(0x6A000000);
+        let s = serde_json::to_string(&p).expect("serialize");
+        assert_eq!(s, "\"0/6A000000\"");
+        assert_eq!(serde_json::from_str::<Pos<Floor>>(&s).expect("parse"), p);
+    }
+
+    #[tokio::test]
+    async fn gate_opens_on_a_target_already_covered() {
+        let m = Monotone::<Drain>::default();
+        m.join(900u64);
+        assert_eq!(m.watch().wait(500u64).await.expect("covered"), 900);
+    }
+
+    /// Consumers that redo work from current state wake on any move, and on
+    /// a move that landed before they asked
+    #[tokio::test]
+    async fn advance_resolves_on_a_move_already_made() {
+        let m = Monotone::<QueuedWake>::default();
+        let gate = m.watch();
+        m.bump();
+        assert_eq!(gate.advance(Pos::ZERO).await.expect("moved"), 1);
+        let waiting = tokio::spawn({
+            let gate = gate.clone();
+            async move { gate.advance(Pos::new(1)).await }
+        });
+        tokio::task::yield_now().await;
+        m.bump();
+        assert_eq!(waiting.await.expect("join").expect("moved"), 2);
+    }
+
+    #[tokio::test]
+    async fn dropping_the_cell_wakes_an_uncovered_waiter() {
+        let m = Monotone::<Drain>::default();
+        let gate = m.watch();
+        m.join(10u64);
+        drop(m);
+        assert_eq!(gate.wait(10u64).await.expect("covered"), 10);
+        assert_eq!(gate.wait(11u64).await, Err(GateClosed));
+    }
+}

--- a/src/source/boundary_hold.rs
+++ b/src/source/boundary_hold.rs
@@ -31,6 +31,7 @@ use std::time::{Duration, Instant};
 
 use tokio::sync::Mutex;
 
+use crate::pos::{Pos, ShadowReplay};
 use crate::record::{BoundaryKind, Record, RecordSink, SinkError};
 use crate::source::catalog_capture::CatalogCapture;
 use crate::source::queueing_record_sink::QueueingRecordSink;
@@ -101,49 +102,50 @@ impl CatalogBoundaryGate {
     pub async fn hold(
         &self,
         commit_lsn: u64,
-        next_lsn: u64,
+        next_lsn: impl Into<Pos<ShadowReplay>>,
         worker_alive: impl Fn() -> bool,
     ) -> Result<(), SinkError> {
+        let next_lsn = next_lsn.into();
+        let applied = self.state.lock().await.applied();
         let start = Instant::now();
-        // Subscribed before the first read, so a status landing mid-check
-        // wakes the wait rather than being missed
-        let mut applied = self.state.lock().await.applied_rx();
-        loop {
+        let held = loop {
+            // Read the wake count before the probe, so a status landing
+            // between them is not parked through
+            let seen = applied.current();
             let agg = self.state.lock().await.aggregate();
             if agg.min_apply_lsn.is_some_and(|apply| apply >= next_lsn) {
-                self.stats.holds.fetch_add(1, Ordering::Relaxed);
-                self.stats
-                    .hold_nanos
-                    .fetch_add(start.elapsed().as_nanos() as u64, Ordering::Relaxed);
-                // Info: fires at DDL rate, operators read it as the
-                // hold-latency signal
-                tracing::info!(
-                    target: "walshadow::boundary_hold",
-                    commit_lsn = format_args!("{commit_lsn:#X}"),
-                    next_lsn = format_args!("{next_lsn:#X}"),
-                    held = ?start.elapsed(),
-                    "catalog boundary released",
-                );
-                return Ok(());
+                break start.elapsed();
             }
             if !worker_alive() {
                 return self.fail(format!(
                     "decoder worker terminated during catalog boundary hold at {commit_lsn:#X}"
                 ));
             }
-            if start.elapsed() >= self.config.hold_timeout {
+            let waited = start.elapsed();
+            if waited >= self.config.hold_timeout {
                 return self.fail(format!(
-                    "catalog boundary hold at {commit_lsn:#X} timed out after {:?}: \
-                     shadow apply {:?} < {next_lsn:#X} ({} walreceiver connection(s))",
-                    self.config.hold_timeout, agg.min_apply_lsn, agg.active_connections,
+                    "catalog boundary hold at {commit_lsn:#X} timed out after {waited:?}: \
+                     shadow apply {:?} < {next_lsn} ({} walreceiver connection(s))",
+                    agg.min_apply_lsn, agg.active_connections,
                 ));
             }
+            // Poll cadence also covers aggregate moves with no per-connection
+            // progress, such as a walreceiver attaching or dropping
             self.state.lock().await.request_status();
-            // Shadow's reply wakes this; `poll_interval` is the backstop so a
-            // lost wake — or a walreceiver that never answers — polls instead
-            // of hanging, and paces the `worker_alive` / deadline checks above
-            let _ = tokio::time::timeout(self.config.poll_interval, applied.changed()).await;
-        }
+            let _ = tokio::time::timeout(self.config.poll_interval, applied.advance(seen)).await;
+        };
+        self.stats.holds.fetch_add(1, Ordering::Relaxed);
+        self.stats
+            .hold_nanos
+            .fetch_add(held.as_nanos() as u64, Ordering::Relaxed);
+        tracing::info!(
+            target: "walshadow::boundary_hold",
+            commit_lsn = format_args!("{commit_lsn:#X}"),
+            next_lsn = %next_lsn,
+            held = ?held,
+            "catalog boundary released",
+        );
+        Ok(())
     }
 
     fn fail(&self, msg: String) -> Result<(), SinkError> {
@@ -239,7 +241,9 @@ impl RecordSink for BoundaryHoldSink {
             let parked = Instant::now();
             if let Err(hold_err) = self
                 .gate
-                .hold(record.source_lsn, record.next_lsn, || inner.worker_alive())
+                .hold(record.source_lsn, Pos::new(record.next_lsn), || {
+                    inner.worker_alive()
+                })
                 .await
             {
                 // Prefer the worker's parked root cause over the generic

--- a/src/source/manifest.rs
+++ b/src/source/manifest.rs
@@ -40,8 +40,8 @@
 //! * `shadow_replay`: shadow PG's `pg_last_wal_replay_lsn()`
 //! * `drain`: highest commit-record LSN drained out of the xact buffer.
 //!   Strictly higher than `emitter_ack`.
-//! * `emitter_ack`: highest commit-record LSN durably acked by the
-//!   pipeline's contiguous-done watermark. Slot-advance ceiling.
+//! * `emitter_ack`: [`ResumeSafe`], not the live ack behind
+//!   `walshadow_emitter_ack_lsn`. Slot-advance ceiling.
 //! * `shadow_flush`: min `flush_lsn` from inbound `'r'` standby status
 //!   across active shadow streaming connections. On restart, resume
 //!   position walsender hands shadow via `START_REPLICATION PHYSICAL
@@ -55,10 +55,13 @@
 use std::io;
 use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use walrus::pg::backup::{format_pg_lsn, parse_pg_lsn};
 
+use crate::pos::{
+    Drain, FilterDurable, Floor, Pos, ResumeSafe, ShadowFlush, ShadowReplay, SourceReceived,
+    Switchpoint,
+};
 use crate::record::WAL_SEG_SIZE;
 use crate::source::wal_stream::WalStream;
 
@@ -69,23 +72,6 @@ pub const MANIFEST_FILENAME: &str = "manifest.toml";
 // cannot be resumed against (decode would read uncovered intervals); the
 // version gate turns that into a deterministic upgrade failure.
 pub const MANIFEST_VERSION: u32 = 2;
-
-/// LSN persisted in postgres `pg_lsn` text form (`1A/2B3C4D5E`).
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub struct Lsn(pub u64);
-
-impl Serialize for Lsn {
-    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        s.collect_str(&format_pg_lsn(self.0))
-    }
-}
-
-impl<'de> Deserialize<'de> for Lsn {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(d)?;
-        parse_pg_lsn(&s).map(Lsn).map_err(serde::de::Error::custom)
-    }
-}
 
 /// Artifact ownership plus the branch the floor sits on. The system identifier
 /// gates every nonvolatile spill-dir artifact: reusing a spill dir against a
@@ -110,7 +96,7 @@ pub struct SourceIdentity {
     /// a live identity off `IDENTIFY_SYSTEM` has parsed no history to place
     /// itself with, and an on-disk manifest may carry no switchpoint at all.
     #[serde(default)]
-    pub timeline_begin: Lsn,
+    pub timeline_begin: Pos<Switchpoint>,
 }
 
 /// Branch the pump is reading, which runs ahead of
@@ -123,12 +109,13 @@ pub struct WalBranch {
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LsnSet {
-    pub source_received: Lsn,
-    pub filter_durable: Lsn,
-    pub shadow_replay: Lsn,
-    pub drain: Lsn,
-    pub emitter_ack: Lsn,
-    pub shadow_flush: Lsn,
+    pub source_received: Pos<SourceReceived>,
+    pub filter_durable: Pos<FilterDurable>,
+    pub shadow_replay: Pos<ShadowReplay>,
+    pub drain: Pos<Drain>,
+    /// Resume-safe ack, TOML key retained for compatibility
+    pub emitter_ack: Pos<ResumeSafe>,
+    pub shadow_flush: Pos<ShadowFlush>,
 }
 
 /// Scalars precede tables (TOML emit constraint): `version`/`floor`
@@ -138,7 +125,7 @@ pub struct Manifest {
     pub version: u32,
     /// Resume LSN = decode floor = GC cut. Segment-aligned,
     /// archive-clamped at write time via [`resolved_floor`].
-    pub floor: Lsn,
+    pub floor: Pos<Floor>,
     pub source: SourceIdentity,
     /// Absent in manifests written before timeline crossing landed; those runs
     /// never left the floor's branch, so the floor timeline is also the stream's
@@ -179,8 +166,14 @@ pub fn manifest_path(spill_dir: &Path) -> PathBuf {
 /// crash-durable lower bound on the sealed archive end — so the archive
 /// clamp folds in at write time. Restart resumes at this floor and every
 /// pruner cuts against it: cut ≤ resume by construction, never by test.
-pub fn resolved_floor(emitter_ack: u64, filter_durable: u64) -> u64 {
-    WalStream::align_down(emitter_ack, WAL_SEG_SIZE).min(filter_durable)
+pub fn resolved_floor(
+    emitter_ack: impl Into<Pos<ResumeSafe>>,
+    filter_durable: impl Into<Pos<FilterDurable>>,
+) -> Pos<Floor> {
+    Pos::new(
+        WalStream::align_down(emitter_ack.into().get(), WAL_SEG_SIZE)
+            .min(filter_durable.into().get()),
+    )
 }
 
 /// Stream-start selection.
@@ -195,22 +188,23 @@ pub fn resolved_floor(emitter_ack: u64, filter_durable: u64) -> u64 {
 /// live ack by up to one status interval); slot errors surface at
 /// START_REPLICATION, same exposure as the boot-scan clamp had.
 pub fn resolve_start(
-    raw_start: u64,
-    floor: Option<u64>,
+    raw_start: impl Into<Pos<Floor>>,
+    floor: Option<Pos<Floor>>,
     pinned: bool,
-    archive_end: Option<u64>,
-) -> u64 {
-    let aligned = WalStream::align_down(raw_start, WAL_SEG_SIZE);
+    archive_end: Option<Pos<FilterDurable>>,
+) -> Pos<Floor> {
+    let aligned = Pos::new(WalStream::align_down(raw_start.into().get(), WAL_SEG_SIZE));
     if pinned {
         return aligned;
     }
-    if let Some(f) = floor.filter(|f| *f != 0) {
+    if let Some(f) = floor.filter(|f| !f.is_zero()) {
         return f;
     }
-    match archive_end {
-        Some(end) if end < aligned => end,
-        _ => aligned,
-    }
+    // Archive clamp becomes restart floor
+    archive_end
+        .map(Pos::retag)
+        .filter(|end| *end < aligned)
+        .unwrap_or(aligned)
 }
 
 /// Resolve WAL resume LSN, precedence order:
@@ -221,34 +215,37 @@ pub fn resolve_start(
 ///   3. manifest's last `emitter_ack`: durable CH resume point
 ///   4. greenfield: source's current write head
 ///
-/// Pipeline ack atomic MUST seed from this SAME value, not 0: status
-/// loop persists atomic into the manifest's `emitter_ack` every interval
-/// with no monotonic guard, first write fires at boot before any
-/// re-read acks. Seeding 0 clobbers a resumed manifest's ack to 0; a
-/// crash before re-read of `[aligned, resume]` then falls through to
-/// case 4 next boot (zero ack skipped), silently dropping `[resume,
-/// head]` WAL that never reached CH.
+/// Seed the live pipeline ack from this value, not zero, so the first status
+/// write cannot discard persisted resume state before WAL re-read catches up
 pub fn resolve_resume_lsn(
-    start_lsn: Option<u64>,
-    bootstrap_end_lsn: Option<u64>,
-    manifest_ack_lsn: Option<u64>,
-    greenfield_head: u64,
-) -> u64 {
+    start_lsn: Option<Pos<Floor>>,
+    bootstrap_end_lsn: Option<Pos<Floor>>,
+    manifest_ack_lsn: Option<Pos<ResumeSafe>>,
+    greenfield_head: impl Into<Pos<SourceReceived>>,
+) -> Pos<Floor> {
     match (start_lsn, bootstrap_end_lsn, manifest_ack_lsn) {
         (Some(s), _, _) => s,
         (None, Some(l), _) => l,
-        (None, None, Some(c)) if c != 0 => c,
-        (None, None, _) => greenfield_head,
+        (None, None, Some(c)) if !c.is_zero() => c.retag(),
+        (None, None, _) => greenfield_head.into().retag(),
     }
 }
 
 /// Out-dir trim cut — shadow-recovery domain, distinct from the manifest
 /// floor. Keep `retention_bytes` behind replay, never past the last
 /// restartpoint REDO (shadow resumes recovery there).
-pub fn retention_cutoff(shadow_replay: u64, retention_bytes: u64, redo: Option<u64>) -> u64 {
-    shadow_replay
-        .saturating_sub(retention_bytes)
-        .min(redo.unwrap_or(u64::MAX))
+pub fn retention_cutoff(
+    shadow_replay: impl Into<Pos<ShadowReplay>>,
+    retention_bytes: u64,
+    redo: Option<Pos<ShadowReplay>>,
+) -> Pos<ShadowReplay> {
+    Pos::new(
+        shadow_replay
+            .into()
+            .get()
+            .saturating_sub(retention_bytes)
+            .min(redo.map_or(u64::MAX, Pos::get)),
+    )
 }
 
 /// `Ok(None)` for greenfield (no manifest). `Err(ForeignSource)` when the
@@ -299,23 +296,23 @@ mod tests {
         SourceIdentity {
             system_id: 7_334_001_234_567_890_123,
             timeline: 1,
-            timeline_begin: Lsn(0),
+            timeline_begin: Pos::ZERO,
         }
     }
 
     fn sample() -> Manifest {
         Manifest {
             version: MANIFEST_VERSION,
-            floor: Lsn(0x0123_4564_0000_0000 & !(SEG - 1)),
+            floor: (0x0123_4564_0000_0000 & !(SEG - 1)).into(),
             source: ident(),
             wal: WalBranch { stream_timeline: 2 },
             lsn: LsnSet {
-                source_received: Lsn(0x0123_4567_89AB_CDEF),
-                filter_durable: Lsn(0x0123_4567_0000_0000),
-                shadow_replay: Lsn(0x0123_4566_0000_0000),
-                drain: Lsn(0x0123_4565_0000_0000),
-                emitter_ack: Lsn(0x0123_4564_0000_0000),
-                shadow_flush: Lsn(0x0123_4563_0000_0000),
+                source_received: 0x0123_4567_89AB_CDEF.into(),
+                filter_durable: 0x0123_4567_0000_0000.into(),
+                shadow_replay: 0x0123_4566_0000_0000.into(),
+                drain: 0x0123_4565_0000_0000.into(),
+                emitter_ack: 0x0123_4564_0000_0000.into(),
+                shadow_flush: 0x0123_4563_0000_0000.into(),
             },
         }
     }
@@ -331,6 +328,34 @@ mod tests {
         );
         let got: Manifest = toml::from_str(&text).unwrap();
         assert_eq!(got, m);
+    }
+
+    /// Preserve manifest compatibility across typed-position migration
+    #[test]
+    fn on_disk_toml_is_exact() {
+        const EXPECTED: &str = "\
+version = 2
+floor = \"1234564/0\"
+
+[source]
+system_id = 7334001234567890123
+timeline = 1
+timeline_begin = \"0/0\"
+
+[wal]
+stream_timeline = 2
+
+[lsn]
+source_received = \"1234567/89ABCDEF\"
+filter_durable = \"1234567/0\"
+shadow_replay = \"1234566/0\"
+drain = \"1234565/0\"
+emitter_ack = \"1234564/0\"
+shadow_flush = \"1234563/0\"
+";
+        let text = toml::to_string(&sample()).unwrap();
+        assert_eq!(text, EXPECTED);
+        assert_eq!(toml::from_str::<Manifest>(EXPECTED).unwrap(), sample());
     }
 
     #[test]
@@ -390,7 +415,7 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
         let got: Manifest = toml::from_str(&without).expect("parse without timeline_begin");
-        assert_eq!(got.source.timeline_begin, Lsn(0));
+        assert_eq!(got.source.timeline_begin, Pos::ZERO);
     }
 
     /// Manifests predating the crossing carry no `[wal]`; the floor timeline
@@ -445,13 +470,13 @@ mod tests {
 
     #[test]
     fn floor_zero_before_first_seal() {
-        assert_eq!(resolved_floor(2 * SEG + 1, 0), 0);
+        assert!(resolved_floor(2 * SEG + 1, Pos::ZERO).is_zero());
     }
 
     #[test]
     fn start_pinned_aligns_only() {
         assert_eq!(
-            resolve_start(3 * SEG + 9, Some(SEG), true, Some(SEG)),
+            resolve_start(3 * SEG + 9, Some(SEG.into()), true, Some(SEG.into())),
             3 * SEG,
         );
     }
@@ -459,7 +484,7 @@ mod tests {
     #[test]
     fn start_floor_wins_when_nonzero() {
         assert_eq!(
-            resolve_start(3 * SEG + 9, Some(2 * SEG), false, None),
+            resolve_start(3 * SEG + 9, Some((2 * SEG).into()), false, None),
             2 * SEG
         );
     }
@@ -467,7 +492,7 @@ mod tests {
     #[test]
     fn start_zero_floor_falls_through_to_archive_clamp() {
         assert_eq!(
-            resolve_start(3 * SEG + 9, Some(0), false, Some(2 * SEG)),
+            resolve_start(3 * SEG + 9, Some(Pos::ZERO), false, Some((2 * SEG).into())),
             2 * SEG,
         );
     }
@@ -476,30 +501,44 @@ mod tests {
     fn start_greenfield_aligns_and_clamps() {
         assert_eq!(resolve_start(3 * SEG + 9, None, false, None), 3 * SEG);
         assert_eq!(
-            resolve_start(3 * SEG + 9, None, false, Some(4 * SEG)),
+            resolve_start(3 * SEG + 9, None, false, Some((4 * SEG).into())),
             3 * SEG
         );
-        assert_eq!(resolve_start(3 * SEG + 9, None, false, Some(SEG)), SEG);
+        assert_eq!(
+            resolve_start(3 * SEG + 9, None, false, Some(SEG.into())),
+            SEG
+        );
     }
 
     #[test]
     fn retention_cutoff_keeps_window_and_redo() {
         assert_eq!(retention_cutoff(10 * SEG, 2 * SEG, None), 8 * SEG);
-        assert_eq!(retention_cutoff(10 * SEG, 2 * SEG, Some(5 * SEG)), 5 * SEG);
-        assert_eq!(retention_cutoff(SEG, 2 * SEG, None), 0);
+        assert_eq!(
+            retention_cutoff(10 * SEG, 2 * SEG, Some((5 * SEG).into())),
+            5 * SEG
+        );
+        assert!(retention_cutoff(SEG, 2 * SEG, None).is_zero());
     }
 
     #[test]
     fn resume_lsn_start_override_wins() {
         assert_eq!(
-            resolve_resume_lsn(Some(0x10), Some(0x99), Some(0x88), 0xFF),
+            resolve_resume_lsn(
+                Some(0x10.into()),
+                Some(0x99.into()),
+                Some(0x88.into()),
+                0xFF
+            ),
             0x10,
         );
     }
 
     #[test]
     fn resume_lsn_bootstrap_end_outranks_manifest() {
-        assert_eq!(resolve_resume_lsn(None, Some(0x99), Some(0x88), 0xFF), 0x99);
+        assert_eq!(
+            resolve_resume_lsn(None, Some(0x99.into()), Some(0x88.into()), 0xFF),
+            0x99
+        );
     }
 
     #[test]
@@ -509,16 +548,16 @@ mod tests {
         // silently skip [ack, head] WAL)
         let ack = 0xAABB_0000u64;
         let head = 0xFFFF_0000u64;
-        let resume = resolve_resume_lsn(None, None, Some(ack), head);
+        let resume = resolve_resume_lsn(None, None, Some(ack.into()), head);
         assert_eq!(resume, ack, "must resume from durable ack");
-        assert_ne!(resume, 0, "ack seed must not regress to 0");
-        assert_ne!(resume, head, "must not skip ahead to source head");
+        assert!(!resume.is_zero(), "ack seed must not regress to 0");
+        assert_ne!(resume.get(), head, "must not skip ahead to source head");
     }
 
     #[test]
     fn resume_lsn_zero_ack_falls_through_to_greenfield() {
         // ack == 0 is greenfield-equivalent: nothing below head to ship
-        assert_eq!(resolve_resume_lsn(None, None, Some(0), 0xFF), 0xFF);
+        assert_eq!(resolve_resume_lsn(None, None, Some(Pos::ZERO), 0xFF), 0xFF);
     }
 
     #[test]
@@ -531,7 +570,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         let mut m = sample();
         write(tmp.path(), &m).await.unwrap();
-        m.lsn.emitter_ack = Lsn(0x0DEA_DBEE_F00D_0000);
+        m.lsn.emitter_ack = 0x0DEA_DBEE_F00D_0000.into();
         write(tmp.path(), &m).await.unwrap();
         let got = load(tmp.path(), &ident()).await.unwrap().unwrap();
         assert_eq!(got, m);

--- a/src/source/shadow_stream.rs
+++ b/src/source/shadow_stream.rs
@@ -25,14 +25,75 @@ use std::time::Duration;
 use smallvec::SmallVec;
 use thiserror::Error;
 use tokio::net::{TcpListener, TcpStream, UnixListener, UnixStream};
-use tokio::sync::{Mutex, watch};
+use tokio::sync::Mutex;
 use walrus::pg::replication::server::{
     self, ServerError, TimelineSwitch, WalSenderConn, decode_standby_status,
 };
 use walrus::pg::replication::stream::{encode_keepalive_frame_into, encode_wal_data_frame_into};
 
+use crate::pos::{
+    AppliedWake, Gate, Monotone, Pos, QueuedWake, ShadowDispatched, ShadowFlush, ShadowReplay,
+    SourceReceived,
+};
 use crate::record::{RecordBytesSink, SinkError};
 use ahash::{HashMap, HashMapExt};
+
+#[derive(Debug, Clone, Copy)]
+enum Phase {
+    /// Switchpoint the branch stops at, PG's `sendTimeLineValidUpto`. `None`
+    /// on the current timeline
+    Streaming(Option<TimelineSwitch>),
+    /// Client must receive next-timeline result
+    Ended(TimelineSwitch),
+    /// Teardown with optional pending timeline result
+    Closing(Option<TimelineSwitch>),
+}
+
+impl Phase {
+    fn is_streaming(self) -> bool {
+        matches!(self, Self::Streaming(_))
+    }
+
+    fn is_closing(self) -> bool {
+        matches!(self, Self::Closing(_))
+    }
+
+    /// Switchpoint this connection is pinned to, whether or not it is served
+    fn cut(self) -> Option<TimelineSwitch> {
+        match self {
+            Self::Streaming(c) | Self::Closing(c) => c,
+            Self::Ended(s) => Some(s),
+        }
+    }
+
+    fn ended(self) -> Option<TimelineSwitch> {
+        if let Self::Ended(s) | Self::Closing(Some(s)) = self {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
+    fn end(&mut self, switch: TimelineSwitch) -> bool {
+        if self.ended().is_some() {
+            return false;
+        }
+        *self = if self.is_closing() {
+            Self::Closing(Some(switch))
+        } else {
+            Self::Ended(switch)
+        };
+        true
+    }
+
+    fn close(&mut self) -> bool {
+        if self.is_closing() {
+            return false;
+        }
+        *self = Self::Closing(self.ended());
+        true
+    }
+}
 
 /// Per-connection state for one WAL-consuming client (typically
 /// shadow PG).
@@ -40,32 +101,21 @@ use ahash::{HashMap, HashMapExt};
 struct ConnState {
     /// High water of bytes pushed onto the send buffer; source's
     /// `write_lsn` equivalent.
-    dispatched_lsn: u64,
+    dispatched_lsn: Pos<ShadowDispatched>,
     /// Last `flush_lsn` from the client's `'r'` standby status.
-    flush_lsn: u64,
+    flush_lsn: Pos<ShadowFlush>,
     /// Last `apply_lsn` from the client's `'r'` standby status.
-    apply_lsn: u64,
-    /// Set when the client asked for a branch that has ended: the switchpoint
-    /// its stream stops at, PG's `sendTimeLineValidUpto`. `None` on the current
-    /// timeline.
-    ends_at: Option<TimelineSwitch>,
-    /// Marked on a write error/overflow; listener drops the slot on
-    /// the next status sweep.
-    closing: bool,
-    /// Served through `ends_at`, so the stream owes the client a next-timeline
-    /// result rather than a closed socket.
-    timeline_ended: bool,
+    apply_lsn: Pos<ShadowReplay>,
+    phase: Phase,
 }
 
 impl ConnState {
     fn fresh(start_lsn: u64, ends_at: Option<TimelineSwitch>) -> Self {
         Self {
-            dispatched_lsn: start_lsn,
-            flush_lsn: start_lsn,
-            apply_lsn: start_lsn,
-            ends_at,
-            closing: false,
-            timeline_ended: false,
+            dispatched_lsn: Pos::new(start_lsn),
+            flush_lsn: Pos::new(start_lsn),
+            apply_lsn: Pos::new(start_lsn),
+            phase: Phase::Streaming(ends_at),
         }
     }
 }
@@ -75,8 +125,8 @@ impl ConnState {
 /// disk-driven polling).
 #[derive(Debug, Default, Clone, Copy)]
 pub struct AggregateLsn {
-    pub min_flush_lsn: Option<u64>,
-    pub min_apply_lsn: Option<u64>,
+    pub min_flush_lsn: Option<Pos<ShadowFlush>>,
+    pub min_apply_lsn: Option<Pos<ShadowReplay>>,
     /// Connections past `START_REPLICATION`, the only ones carrying LSNs.
     pub active_connections: usize,
     /// Monotonic count of sockets that entered the handshake. Above
@@ -126,7 +176,7 @@ pub struct ShadowStreamState {
     /// Slow-connection byte cutoff; past it the listener kills the socket.
     pub slow_threshold: usize,
     /// Populates `'w'`/`'k'` frame headers.
-    pub server_wal_end: u64,
+    pub server_wal_end: Pos<SourceReceived>,
     /// Surfaced via [`AggregateLsn::dropped_total`] for the
     /// `walshadow_shadow_stream_dropped_connections_total` gauge.
     dropped_total: u64,
@@ -139,10 +189,10 @@ pub struct ShadowStreamState {
     /// Wakes the listener to write now rather than on its batching tick;
     /// bumped by `request_status`, the one caller whose bytes a hold is
     /// waiting behind
-    queued: watch::Sender<u64>,
+    queued: Monotone<QueuedWake>,
     /// Bumped when a client's apply LSN advances: wakes a publication hold
     /// on the standby status that releases it
-    applied: watch::Sender<u64>,
+    applied: Monotone<AppliedWake>,
 }
 
 impl ShadowStreamState {
@@ -163,46 +213,46 @@ impl ShadowStreamState {
             next_conn_id: 1,
             send_queues: HashMap::new(),
             slow_threshold,
-            server_wal_end: current_lsn,
+            server_wal_end: Pos::new(current_lsn),
             dropped_total: 0,
             accepted_total: 0,
             wire_buf: Vec::new(),
             wire_buf_start: current_lsn,
-            queued: watch::Sender::new(0),
-            applied: watch::Sender::new(0),
+            queued: Monotone::default(),
+            applied: Monotone::default(),
         }
     }
 
     /// Wakes the listener out of its batching tick, for the paths that
-    /// cannot wait one out ([`request_status`](Self::request_status)).
-    /// `watch` latches, so a wake landing while the listener is mid-write
-    /// still arms its next wait — and a drain takes the whole queue, so one
-    /// wake covers every byte enqueued before it
-    pub fn queued_rx(&self) -> watch::Receiver<u64> {
-        self.queued.subscribe()
+    /// cannot wait one out ([`request_status`](Self::request_status))
+    pub fn queued(&self) -> Gate<QueuedWake> {
+        self.queued.watch()
     }
 
     /// Wakes when any client's apply LSN advances; the waiter re-reads
     /// [`aggregate`](Self::aggregate), which stays the release authority
-    pub fn applied_rx(&self) -> watch::Receiver<u64> {
-        self.applied.subscribe()
+    pub fn applied(&self) -> Gate<AppliedWake> {
+        self.applied.watch()
     }
 
     fn wake_listener(&self) {
-        self.queued.send_modify(|n| *n += 1);
+        self.queued.bump();
     }
 
     pub fn aggregate(&self) -> AggregateLsn {
         let served = self.timeline;
-        let (active, min_flush, min_apply, branch) =
-            self.connections.values().filter(|c| !c.closing).fold(
-                (0usize, u64::MAX, u64::MAX, u32::MAX),
+        let (active, min_flush, min_apply, branch) = self
+            .connections
+            .values()
+            .filter(|c| !c.phase.is_closing())
+            .fold(
+                (0usize, Pos::new(u64::MAX), Pos::new(u64::MAX), u32::MAX),
                 |(n, flush, apply, tli), c| {
                     (
                         n + 1,
                         flush.min(c.flush_lsn),
                         apply.min(c.apply_lsn),
-                        tli.min(c.ends_at.map_or(served, |s| s.timeline)),
+                        tli.min(c.phase.cut().map_or(served, |s| s.timeline)),
                     )
                 },
             );
@@ -249,10 +299,12 @@ impl ShadowStreamState {
         // Reconnecting at or past the switchpoint: nothing left on this branch,
         // so end it now rather than idling until the next dispatch
         if let Some(switch) = ends_at
-            && self.connections[&id].dispatched_lsn >= switch.ends_at
+            && self.connections[&id].dispatched_lsn.get() >= switch.ends_at
         {
             self.end_timeline_for(id, switch);
         }
+        // New connection can lower aggregate without status progress
+        self.applied.bump();
         Some(id)
     }
 
@@ -295,13 +347,14 @@ impl ShadowStreamState {
         self.timeline = next_tli;
         let mut caught_up = SmallVec::<[u64; 4]>::new();
         for (id, c) in self.connections.iter_mut() {
-            if c.ends_at.is_none() {
-                c.ends_at = Some(switch);
-                // Already served everything below the fork: nothing more will be
-                // dispatched to notice, and an idle source would leave it waiting
-                if c.dispatched_lsn >= switch.ends_at {
-                    caught_up.push(*id);
-                }
+            let Phase::Streaming(cut @ None) = &mut c.phase else {
+                continue;
+            };
+            *cut = Some(switch);
+            // Already served everything below the fork: nothing more will be
+            // dispatched to notice, and an idle source would leave it waiting
+            if c.dispatched_lsn.get() >= switch.ends_at {
+                caught_up.push(*id);
             }
         }
         for id in caught_up {
@@ -341,17 +394,17 @@ impl ShadowStreamState {
             return;
         }
         let end_lsn = start_lsn + bytes.len() as u64;
-        self.server_wal_end = self.server_wal_end.max(end_lsn);
+        self.server_wal_end = self.server_wal_end.max(end_lsn.into());
         self.retain_wire(start_lsn, bytes);
-        let server_wal_end = self.server_wal_end;
+        let server_wal_end = self.server_wal_end.get();
         // Snapshot: enqueue below takes `&mut self`, so the map can't stay borrowed
         let targets: SmallVec<[(u64, u64, Option<TimelineSwitch>); 4]> = self
             .connections
             .iter()
             // A connection already at its switchpoint is done: descendant bytes
             // must never go down a stream the client reads as ancestor
-            .filter(|(_, c)| !c.closing && !c.timeline_ended && c.dispatched_lsn < end_lsn)
-            .map(|(id, c)| (*id, c.dispatched_lsn, c.ends_at))
+            .filter(|(_, c)| c.phase.is_streaming() && c.dispatched_lsn.get() < end_lsn)
+            .map(|(id, c)| (*id, c.dispatched_lsn.get(), c.phase.cut()))
             .collect();
         for (id, conn_offset, ends_at) in targets {
             let cut = ends_at.map(|s| s.ends_at).filter(|v| *v < end_lsn);
@@ -376,9 +429,8 @@ impl ShadowStreamState {
     /// picks this up and ends the timeline on the wire.
     fn end_timeline_for(&mut self, id: u64, switch: TimelineSwitch) {
         if let Some(c) = self.connections.get_mut(&id)
-            && !c.timeline_ended
+            && c.phase.end(switch)
         {
-            c.timeline_ended = true;
             tracing::info!(
                 target: "walshadow::shadow_stream",
                 conn_id = id,
@@ -394,8 +446,7 @@ impl ShadowStreamState {
     /// `Some` once a connection has been served through its switchpoint: the
     /// stream owes the client the next-timeline result.
     fn timeline_ended_for(&self, id: u64) -> Option<TimelineSwitch> {
-        let conn = self.connections.get(&id)?;
-        conn.timeline_ended.then_some(conn.ends_at).flatten()
+        self.connections.get(&id)?.phase.ended()
     }
 
     /// Replay `[start_lsn, server_wal_end]` so a reconnect behind the live head
@@ -406,9 +457,10 @@ impl ShadowStreamState {
         let ends_at = self
             .connections
             .get(&id)
-            .and_then(|c| c.ends_at)
+            .and_then(|c| c.phase.cut())
             .map(|s| s.ends_at);
-        let server_wal_end = ends_at.map_or(self.server_wal_end, |v| v.min(self.server_wal_end));
+        let head = self.server_wal_end.get();
+        let server_wal_end = ends_at.map_or(head, |v| v.min(head));
         if start_lsn >= server_wal_end || start_lsn < self.wire_buf_start {
             return;
         }
@@ -437,17 +489,25 @@ impl ShadowStreamState {
     pub fn drop_connection(&mut self, id: u64) {
         self.connections.remove(&id);
         self.send_queues.remove(&id);
+        // Removing laggard can raise aggregate and release hold
+        self.applied.bump();
     }
 
     /// Record an inbound `'r'` standby status.
-    pub fn observe_status(&mut self, id: u64, write_lsn: u64, flush_lsn: u64, apply_lsn: u64) {
-        let _ = write_lsn;
+    pub fn observe_status(
+        &mut self,
+        id: u64,
+        _write_lsn: u64,
+        flush_lsn: impl Into<Pos<ShadowFlush>>,
+        apply_lsn: impl Into<Pos<ShadowReplay>>,
+    ) {
         if let Some(c) = self.connections.get_mut(&id) {
+            let (flush_lsn, apply_lsn) = (flush_lsn.into(), apply_lsn.into());
             c.flush_lsn = c.flush_lsn.max(flush_lsn);
             let advanced = apply_lsn > c.apply_lsn;
             c.apply_lsn = c.apply_lsn.max(apply_lsn);
             if advanced {
-                self.applied.send_modify(|n| *n += 1);
+                self.applied.bump();
             }
         }
     }
@@ -468,9 +528,8 @@ impl ShadowStreamState {
         let q = self.send_queues.entry(id).or_default();
         if q.len() + framed.len() > self.slow_threshold {
             if let Some(c) = self.connections.get_mut(&id)
-                && !c.closing
+                && c.phase.close()
             {
-                c.closing = true;
                 self.dropped_total += 1;
             }
             self.send_queues.remove(&id);
@@ -503,9 +562,8 @@ impl ShadowStreamState {
         {
             q.truncate(envelope_start);
             if let Some(c) = self.connections.get_mut(&id)
-                && !c.closing
+                && c.phase.close()
             {
-                c.closing = true;
                 self.dropped_total += 1;
             }
             self.send_queues.remove(&id);
@@ -521,7 +579,8 @@ impl ShadowStreamState {
         self.frame_copy_data(id, Some(self.slow_threshold), build_body)
     }
 
-    pub fn advance_dispatched(&mut self, id: u64, new_lsn: u64) {
+    pub fn advance_dispatched(&mut self, id: u64, new_lsn: impl Into<Pos<ShadowDispatched>>) {
+        let new_lsn = new_lsn.into();
         if let Some(c) = self.connections.get_mut(&id) {
             c.dispatched_lsn = c.dispatched_lsn.max(new_lsn);
         }
@@ -540,11 +599,11 @@ impl ShadowStreamState {
     /// bulk streaming, not for this. Bulk traffic keeps that batching —
     /// only the prod jumps the queue
     pub fn request_status(&mut self) {
-        let server_wal_end = self.server_wal_end;
+        let server_wal_end = self.server_wal_end.get();
         let ids: Vec<u64> = self
             .connections
             .iter()
-            .filter(|(_, c)| !c.closing)
+            .filter(|(_, c)| !c.phase.is_closing())
             .map(|(id, _)| *id)
             .collect();
         for id in ids {
@@ -800,13 +859,14 @@ where
     // and the backstop for a wake the queue raced. Batching survives: a
     // wake drains everything queued, and bytes enqueued during a write
     // land in the next drain
-    let mut queued = state.lock().await.queued_rx();
-    // Registration backfilled this connection before the subscribe, so the
-    // first wait must not swallow bytes already queued
-    queued.mark_changed();
+    // Zero start: registration backfilled this connection before the
+    // subscribe, and those bytes must not be swallowed
+    let queued = state.lock().await.queued();
+    let mut woke_at = Pos::ZERO;
     loop {
         tokio::select! {
-            _ = queued.changed() => {
+            Ok(seen) = queued.advance(woke_at) => {
+                woke_at = seen;
                 let pending = state.lock().await.drain_send_queue(id);
                 if let Some(bytes) = pending
                     && !bytes.is_empty()
@@ -819,7 +879,7 @@ where
                 let pending = {
                     let mut s = state.lock().await;
                     if last_write.elapsed() >= KEEPALIVE_IDLE {
-                        let server_wal_end = s.server_wal_end;
+                        let server_wal_end = s.server_wal_end.get();
                         let _ = s.enqueue_copy_data_with(id, |out| {
                             encode_keepalive_frame_into(out, server_wal_end, false);
                         });
@@ -839,7 +899,12 @@ where
                     Some(payload) => {
                         if let Some(status) = decode_standby_status(&payload) {
                             let mut s = state.lock().await;
-                            s.observe_status(id, status.write_lsn, status.flush_lsn, status.apply_lsn);
+                            s.observe_status(
+                                id,
+                                status.write_lsn,
+                                status.flush_lsn,
+                                status.apply_lsn,
+                            );
                         }
                     }
                     None => return Ok(StreamOutcome::Closed),
@@ -853,7 +918,7 @@ where
             // enqueued after a drain this loop already did would otherwise land
             // behind the result set, or never
             let tail = ended.and_then(|_| s.drain_send_queue(id));
-            let closing = s.connections.get(&id).is_none_or(|c| c.closing);
+            let closing = s.connections.get(&id).is_none_or(|c| c.phase.is_closing());
             (ended, closing, tail)
         };
         if let Some(switch) = ended {
@@ -882,17 +947,19 @@ mod tests {
         let id = s
             .register_connection(0x1000, 1, None)
             .expect("current timeline");
-        let rx = s.queued_rx();
+        let queued = s.queued();
+        let quiet = queued.current();
         s.enqueue(id, vec![b'd', 0, 0, 0, 4]);
-        assert!(
-            !rx.has_changed().expect("sender alive"),
+        assert_eq!(
+            queued.current(),
+            quiet,
             "bulk WAL keeps the listener's batching tick",
         );
         s.request_status();
-        assert!(rx.has_changed().expect("sender alive"));
-        let queued = s.drain_send_queue(id).expect("queue");
+        assert!(queued.current() > quiet);
+        let bytes = s.drain_send_queue(id).expect("queue");
         assert!(
-            queued.len() > 5,
+            bytes.len() > 5,
             "the wake carries the queued WAL out with the keepalive",
         );
     }
@@ -903,20 +970,19 @@ mod tests {
         let id = s
             .register_connection(0x1000, 1, None)
             .expect("current timeline");
-        let mut rx = s.applied_rx();
+        let applied = s.applied();
+        let quiet = applied.current();
         s.observe_status(id, 0x2000, 0x2000, 0x1000);
-        assert!(
-            !rx.has_changed().expect("sender alive"),
+        assert_eq!(
+            applied.current(),
+            quiet,
             "flush progress alone releases nothing",
         );
         s.observe_status(id, 0x2000, 0x2000, 0x1800);
-        assert!(rx.has_changed().expect("sender alive"));
-        rx.mark_unchanged();
+        let woke = applied.current();
+        assert!(woke > quiet);
         s.observe_status(id, 0x2000, 0x2000, 0x1800);
-        assert!(
-            !rx.has_changed().expect("sender alive"),
-            "a repeated status is not progress",
-        );
+        assert_eq!(applied.current(), woke, "a repeated status is not progress");
     }
 
     #[test]
@@ -1087,8 +1153,8 @@ mod tests {
         s.observe_status(b, 0x2200, 0x2100, 0x1900);
         let agg = s.aggregate();
         assert_eq!(agg.active_connections, 2);
-        assert_eq!(agg.min_flush_lsn, Some(0x2000));
-        assert_eq!(agg.min_apply_lsn, Some(0x1800));
+        assert_eq!(agg.min_flush_lsn, Some(0x2000.into()));
+        assert_eq!(agg.min_apply_lsn, Some(0x1800.into()));
     }
 
     /// A client held on a historic branch reads as that branch, not as the one
@@ -1125,9 +1191,26 @@ mod tests {
         assert!(s.enqueue(id, vec![0u8; 32]));
         assert!(s.enqueue(id, vec![0u8; 16]));
         assert!(!s.enqueue(id, vec![0u8; 64]));
-        assert!(s.connections.get(&id).unwrap().closing);
+        assert!(s.connections[&id].phase.is_closing());
         assert!(!s.send_queues.contains_key(&id));
         assert_eq!(s.aggregate().dropped_total, 1);
+    }
+
+    #[test]
+    fn an_overflow_after_the_switchpoint_still_owes_the_timeline_end() {
+        let mut s = ShadowStreamState::new(1, "x".into(), 0, 64);
+        let switch = TimelineSwitch {
+            timeline: 1,
+            ends_at: 0,
+            next_timeline: 2,
+        };
+        let id = s
+            .register_connection(0, 1, Some(switch))
+            .expect("timeline 1 is known");
+        assert_eq!(s.timeline_ended_for(id), Some(switch));
+        assert!(!s.enqueue(id, vec![0u8; 128]));
+        assert!(s.connections[&id].phase.is_closing());
+        assert_eq!(s.timeline_ended_for(id), Some(switch));
     }
 
     #[test]

--- a/src/source/source_feed.rs
+++ b/src/source/source_feed.rs
@@ -21,6 +21,8 @@ use walrus::pg::replication::conn::{
 use walrus::pg::replication::stream::{Frame, build_status_update, decode_frame};
 use walrus::pg::replication::tls::{SocketStream, SslMode, maybe_upgrade};
 
+use crate::pos::{Floor, Pos, ResumeSafe, SourceReceived};
+
 /// Matches wal-rus / wal-g defaults; servers tolerate up to
 /// `wal_sender_timeout` of silence (default 60s).
 pub const DEFAULT_STATUS_INTERVAL: Duration = Duration::from_secs(10);
@@ -128,23 +130,23 @@ pub enum SourceEvent<'a> {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct StandbyStatus {
     /// `write_lsn` PG sees: WAL pump read + committed to store locally.
-    pub write_lsn: u64,
+    pub write_lsn: Pos<SourceReceived>,
     /// `flush_lsn` PG sees: drives a physical slot's restart_lsn, so the
     /// caller caps it at its persisted resume floor — source must retain
     /// WAL a crash-now restart re-requests.
-    pub flush_lsn: u64,
+    pub flush_lsn: Pos<Floor>,
     /// `apply_lsn` PG sees: bounded by shadow replay LSN and CH emitter
     /// ack LSN, so source's slot won't recycle un-consumed WAL.
-    pub apply_lsn: u64,
+    pub apply_lsn: Pos<ResumeSafe>,
 }
 
 impl StandbyStatus {
     /// All three slots at the same value.
     pub fn collapsed(lsn: u64) -> Self {
         Self {
-            write_lsn: lsn,
-            flush_lsn: lsn,
-            apply_lsn: lsn,
+            write_lsn: lsn.into(),
+            flush_lsn: lsn.into(),
+            apply_lsn: lsn.into(),
         }
     }
 }
@@ -155,20 +157,24 @@ impl StandbyStatus {
 /// WAL).
 #[derive(Debug, Clone, Copy, Default)]
 struct StatusFloors {
-    write: u64,
-    flush: u64,
-    apply: u64,
+    write: Pos<SourceReceived>,
+    flush: Pos<Floor>,
+    apply: Pos<ResumeSafe>,
 }
 
 /// PG assigns a physical slot's restart_lsn from flush unconditionally
 /// (`PhysicalConfirmReceivedLocation`), so a stale lower value walks the
 /// slot backwards, below recycled WAL it can read as invalidatable under
 /// max_slot_wal_keep_size. Hold each field at its own high-water.
-fn clamp_status(status: StandbyStatus, floors: &mut StatusFloors) -> (u64, u64, u64) {
+fn clamp_status(status: StandbyStatus, floors: &mut StatusFloors) -> StandbyStatus {
     floors.write = status.write_lsn.max(floors.write);
     floors.flush = status.flush_lsn.max(floors.flush);
     floors.apply = status.apply_lsn.max(floors.apply);
-    (floors.write, floors.flush, floors.apply)
+    StandbyStatus {
+        write_lsn: floors.write,
+        flush_lsn: floors.flush,
+        apply_lsn: floors.apply,
+    }
 }
 
 /// Build the `START_REPLICATION` command string for a physical replication
@@ -407,8 +413,12 @@ impl SourceFeed {
     }
 
     async fn send_status(&mut self, status: StandbyStatus) -> Result<()> {
-        let (write, flush, apply) = clamp_status(status, &mut self.floors);
-        let payload = build_status_update(write, flush, apply);
+        let held = clamp_status(status, &mut self.floors);
+        let payload = build_status_update(
+            held.write_lsn.get(),
+            held.flush_lsn.get(),
+            held.apply_lsn.get(),
+        );
         self.conn.send_copy_data(&payload).await?;
         self.last_status = Instant::now();
         Ok(())
@@ -438,8 +448,8 @@ impl SourceFeed {
     pub async fn prove_physical_slot(
         &mut self,
         slot: &str,
-        resume_lsn: u64,
-        floor: u64,
+        resume_lsn: Pos<Floor>,
+        floor: Pos<Floor>,
     ) -> Result<Option<u64>, SlotError> {
         let client = self.sql_client().await.map_err(SlotError::Query)?;
         let row = client
@@ -472,19 +482,19 @@ impl SourceFeed {
             );
             return Ok(None);
         };
-        if restart_lsn > resume_lsn {
+        if restart_lsn > resume_lsn.get() {
             return Err(SlotError::TooNew {
                 slot: slot.to_string(),
                 restart_lsn,
-                resume_lsn,
+                resume_lsn: resume_lsn.get(),
             });
         }
-        if restart_lsn > floor {
+        if restart_lsn > floor.get() {
             tracing::warn!(
                 target: "walshadow",
                 slot,
                 restart_lsn = %format_pg_lsn(restart_lsn),
-                floor = %format_pg_lsn(floor),
+                floor = %floor,
                 "slot pins no write-ahead log back to the resume floor; a restart \
                  before it advances would ask for segments nothing retains",
             );
@@ -565,29 +575,33 @@ pub(crate) async fn open_sql_client(cfg: &PgConfig) -> Result<Client> {
 mod tests {
     use super::*;
 
+    fn triple(s: StandbyStatus) -> (u64, u64, u64) {
+        (s.write_lsn.get(), s.flush_lsn.get(), s.apply_lsn.get())
+    }
+
     #[test]
     fn clamp_keeps_each_field_independent() {
         let mut floors = StatusFloors::default();
         // leading write must not lift flush/apply
-        let (w, f, a) = clamp_status(
+        let held = clamp_status(
             StandbyStatus {
-                write_lsn: 3000,
-                flush_lsn: 1000,
-                apply_lsn: 800,
+                write_lsn: 3000.into(),
+                flush_lsn: 1000.into(),
+                apply_lsn: 800.into(),
             },
             &mut floors,
         );
-        assert_eq!((w, f, a), (3000, 1000, 800));
+        assert_eq!(triple(held), (3000, 1000, 800));
         // higher flush/apply, same write: each rises from its own floor
-        let (w, f, a) = clamp_status(
+        let held = clamp_status(
             StandbyStatus {
-                write_lsn: 3000,
-                flush_lsn: 1500,
-                apply_lsn: 1200,
+                write_lsn: 3000.into(),
+                flush_lsn: 1500.into(),
+                apply_lsn: 1200.into(),
             },
             &mut floors,
         );
-        assert_eq!((w, f, a), (3000, 1500, 1200));
+        assert_eq!(triple(held), (3000, 1500, 1200));
     }
 
     #[test]
@@ -595,22 +609,22 @@ mod tests {
         let mut floors = StatusFloors::default();
         clamp_status(
             StandbyStatus {
-                write_lsn: 5000,
-                flush_lsn: 4000,
-                apply_lsn: 4000,
+                write_lsn: 5000.into(),
+                flush_lsn: 4000.into(),
+                apply_lsn: 4000.into(),
             },
             &mut floors,
         );
         // stale lower values hold at prior floor
-        let (w, f, a) = clamp_status(
+        let held = clamp_status(
             StandbyStatus {
-                write_lsn: 4500,
-                flush_lsn: 3000,
-                apply_lsn: 3500,
+                write_lsn: 4500.into(),
+                flush_lsn: 3000.into(),
+                apply_lsn: 3500.into(),
             },
             &mut floors,
         );
-        assert_eq!((w, f, a), (5000, 4000, 4000));
+        assert_eq!(triple(held), (5000, 4000, 4000));
     }
 
     /// Both halves of the start LSN must be rendered in hexadecimal, matching

--- a/src/source/transition.rs
+++ b/src/source/transition.rs
@@ -39,6 +39,7 @@ use thiserror::Error;
 use tokio::sync::Mutex;
 use walrus::pg::backup::format_pg_lsn;
 
+use crate::pos::{Drain, FilterDurable, Floor, Pos, ResumeSafe, ShadowReplay, Switchpoint};
 use crate::record::{RecordSink, SegmentSink};
 use crate::source::shadow_stream::ShadowStreamState;
 use crate::source::source_feed::{SlotError, SourceEvent, SourceFeed, StandbyStatus};
@@ -84,8 +85,11 @@ pub enum TransitionError {
         #[source]
         source: HistoryError,
     },
-    #[error("consumed frontier {next_lsn:#X} sits past the fork {switch_lsn:#X}")]
-    ResumePastFork { next_lsn: u64, switch_lsn: u64 },
+    #[error("consumed frontier {next_lsn} sits past the fork {switch_lsn:#X}")]
+    ResumePastFork {
+        next_lsn: Pos<Floor>,
+        switch_lsn: u64,
+    },
     #[error("drained through {drain_lsn:#X}, past the fork {switch_lsn:#X}")]
     PublishedPastFork { drain_lsn: u64, switch_lsn: u64 },
     #[error(
@@ -179,7 +183,7 @@ pub struct ForkGuards {
     /// rows could have reached ClickHouse. `emitter_ack` cannot carry this
     /// proof: the pipeline completes out of order, so a stalled early sequence
     /// pins it below rows already inserted from a later one.
-    pub drain_lsn: u64,
+    pub drain_lsn: Pos<Drain>,
     /// Ordinary transactions still unresolved once the ancestor ends. A clean
     /// switchover leaves none: fast shutdown rolls live sessions back and each
     /// xid-assigned transaction writes its abort before the shutdown
@@ -201,13 +205,13 @@ pub struct ForkBarrier {
     ///
     /// [`XactBuffer::resume_safe_lsn`]:
     ///     crate::xact::xact_buffer::XactBuffer::resume_safe_lsn
-    pub resume_safe_lsn: u64,
+    pub resume_safe_lsn: Pos<ResumeSafe>,
     /// Shadow's aggregate apply LSN; `None` with no walreceiver attached.
-    pub shadow_apply_lsn: Option<u64>,
+    pub shadow_apply_lsn: Option<Pos<ShadowReplay>>,
     /// Highest fsynced sealed-segment boundary.
-    pub filter_durable: u64,
+    pub filter_durable: Pos<FilterDurable>,
     /// Floor already persisted, which may already cover the fork segment.
-    pub floor: u64,
+    pub floor: Pos<Floor>,
 }
 
 /// What the barrier is still waiting on. Reported rather than bounded: the
@@ -217,15 +221,24 @@ pub struct ForkBarrier {
 pub enum ForkWait {
     /// A transaction below the fork segment's start is not durable in
     /// ClickHouse, so resuming from that boundary would skip it.
-    EmitterAck { acked: u64, fork_segment: u64 },
+    EmitterAck {
+        acked: Pos<ResumeSafe>,
+        fork_segment: Pos<Floor>,
+    },
     /// Shadow has not replayed the ancestor's last record. It gets there
     /// without being told about the fork — replay only needs bytes it has.
-    ShadowApply { applied: Option<u64>, fork: u64 },
+    ShadowApply {
+        applied: Option<Pos<ShadowReplay>>,
+        fork: Pos<Switchpoint>,
+    },
     /// Segments below the fork are not fsynced, so the fork segment's start is
     /// not yet a durable position. A clean end seals them on its own; an
     /// unclean one needs the truncation from
     /// plans/future/failover.md §Unplanned promotion first.
-    ArchiveSeal { durable: u64, fork_segment: u64 },
+    ArchiveSeal {
+        durable: Pos<FilterDurable>,
+        fork_segment: Pos<Floor>,
+    },
 }
 
 impl std::fmt::Display for ForkWait {
@@ -234,15 +247,25 @@ impl std::fmt::Display for ForkWait {
             Self::EmitterAck {
                 acked,
                 fork_segment,
-            } => write!(f, "emitter acked {acked:#X}, need {fork_segment:#X}"),
+            } => write!(
+                f,
+                "emitter acked {:#X}, need {:#X}",
+                acked.get(),
+                fork_segment.get()
+            ),
             Self::ShadowApply { applied, fork } => match applied {
-                Some(a) => write!(f, "shadow applied {a:#X}, fork at {fork:#X}"),
-                None => write!(f, "no walreceiver attached, fork at {fork:#X}"),
+                Some(a) => write!(f, "shadow applied {a}, fork at {:#X}", fork.get()),
+                None => write!(f, "no walreceiver attached, fork at {:#X}", fork.get()),
             },
             Self::ArchiveSeal {
                 durable,
                 fork_segment,
-            } => write!(f, "archive fsynced {durable:#X}, need {fork_segment:#X}"),
+            } => write!(
+                f,
+                "archive fsynced {:#X}, need {:#X}",
+                durable.get(),
+                fork_segment.get()
+            ),
         }
     }
 }
@@ -261,21 +284,27 @@ impl ForkWait {
 impl ForkBarrier {
     /// `None` once every consumer has reached the fork; otherwise what is still
     /// behind.
-    pub fn pending(&self, switch_lsn: u64, seg_size: u64) -> Option<ForkWait> {
-        let fork_segment = WalStream::align_down(switch_lsn, seg_size);
-        if self.resume_safe_lsn < fork_segment {
+    pub fn pending(
+        &self,
+        switch_lsn: impl Into<Pos<Switchpoint>>,
+        seg_size: u64,
+    ) -> Option<ForkWait> {
+        let switch_lsn = switch_lsn.into();
+        // One barrier, three roles: each comparison unwraps the far side once
+        let fork_segment: Pos<Floor> = Pos::new(WalStream::align_down(switch_lsn.get(), seg_size));
+        if self.resume_safe_lsn < fork_segment.get() {
             return Some(ForkWait::EmitterAck {
                 acked: self.resume_safe_lsn,
                 fork_segment,
             });
         }
-        if !self.shadow_apply_lsn.is_some_and(|a| a >= switch_lsn) {
+        if !self.shadow_apply_lsn.is_some_and(|a| a >= switch_lsn.get()) {
             return Some(ForkWait::ShadowApply {
                 applied: self.shadow_apply_lsn,
                 fork: switch_lsn,
             });
         }
-        if fork_segment > self.filter_durable.max(self.floor) {
+        if fork_segment > self.filter_durable.get().max(self.floor.get()) {
             return Some(ForkWait::ArchiveSeal {
                 durable: self.filter_durable,
                 fork_segment,
@@ -310,8 +339,8 @@ impl ForkPoint {
 #[derive(Debug, Clone, Copy)]
 pub struct ForkResume {
     pub timeline: u32,
-    pub floor: u64,
-    pub switch_lsn: u64,
+    pub floor: Pos<Floor>,
+    pub switch_lsn: Pos<Switchpoint>,
 }
 
 /// One crossing's outcome. The history comes back with it: the floor timeline
@@ -525,9 +554,9 @@ impl Switchover<'_> {
             switch_lsn,
             ..
         } = fork;
-        if guards.drain_lsn > switch_lsn {
+        if guards.drain_lsn.get() > switch_lsn {
             return Err(TransitionError::PublishedPastFork {
-                drain_lsn: guards.drain_lsn,
+                drain_lsn: guards.drain_lsn.get(),
                 switch_lsn,
             });
         }
@@ -562,7 +591,9 @@ impl Switchover<'_> {
         // leaving a slot that pins nothing below it to be found at the next
         // restart (plans/failover.md §Slot)
         if let Some(name) = slot {
-            let restart_lsn = feed.prove_physical_slot(name, seg_start, seg_start).await?;
+            let restart_lsn = feed
+                .prove_physical_slot(name, Pos::new(seg_start), Pos::new(seg_start))
+                .await?;
             tracing::info!(
                 target: "walshadow",
                 slot = name,
@@ -582,8 +613,8 @@ impl Switchover<'_> {
         // is the fork segment's start on the descendant
         commit(ForkResume {
             timeline: next_tli,
-            floor: seg_start,
-            switch_lsn,
+            floor: Pos::new(seg_start),
+            switch_lsn: Pos::new(switch_lsn),
         })
         .await
         .map_err(TransitionError::Commit)?;
@@ -883,7 +914,7 @@ mod tests {
                 },
             },
             TransitionError::ResumePastFork {
-                next_lsn: 2,
+                next_lsn: 2.into(),
                 switch_lsn: 1,
             },
             TransitionError::PublishedPastFork {
@@ -940,10 +971,10 @@ mod tests {
     /// Everything caught up to a fork one segment in, at offset 0x1000
     fn caught_up() -> ForkBarrier {
         ForkBarrier {
-            resume_safe_lsn: SEG + 0x800,
-            shadow_apply_lsn: Some(SEG + 0x1000),
-            filter_durable: SEG,
-            floor: 0,
+            resume_safe_lsn: (SEG + 0x800).into(),
+            shadow_apply_lsn: Some((SEG + 0x1000).into()),
+            filter_durable: SEG.into(),
+            floor: Pos::ZERO,
         }
     }
 
@@ -959,7 +990,7 @@ mod tests {
     fn barrier_holds_only_for_an_ack_below_the_fork_segment() {
         assert_eq!(
             ForkBarrier {
-                resume_safe_lsn: SEG,
+                resume_safe_lsn: SEG.into(),
                 ..caught_up()
             }
             .pending(SEG + 0x1000, SEG),
@@ -968,21 +999,21 @@ mod tests {
         );
         assert_eq!(
             ForkBarrier {
-                resume_safe_lsn: SEG - 1,
+                resume_safe_lsn: (SEG - 1).into(),
                 ..caught_up()
             }
             .pending(SEG + 0x1000, SEG),
             Some(ForkWait::EmitterAck {
-                acked: SEG - 1,
-                fork_segment: SEG,
+                acked: (SEG - 1).into(),
+                fork_segment: SEG.into(),
             }),
         );
     }
 
     #[test]
     fn barrier_holds_until_shadow_replays_the_ancestors_last_record() {
-        let fork = SEG + 0x1000;
-        for applied in [None, Some(fork - 1)] {
+        let fork: Pos<Switchpoint> = (SEG + 0x1000).into();
+        for applied in [None, Some((fork.get() - 1).into())] {
             let b = ForkBarrier {
                 shadow_apply_lsn: applied,
                 ..caught_up()
@@ -1001,18 +1032,22 @@ mod tests {
     #[test]
     fn barrier_holds_for_an_unsealed_archive_unless_the_floor_covers_it() {
         let b = ForkBarrier {
-            filter_durable: 0,
+            filter_durable: Pos::ZERO,
             ..caught_up()
         };
         assert_eq!(
             b.pending(SEG + 0x1000, SEG),
             Some(ForkWait::ArchiveSeal {
-                durable: 0,
-                fork_segment: SEG,
+                durable: Pos::ZERO,
+                fork_segment: SEG.into(),
             }),
         );
         assert_eq!(
-            ForkBarrier { floor: SEG, ..b }.pending(SEG + 0x1000, SEG),
+            ForkBarrier {
+                floor: SEG.into(),
+                ..b
+            }
+            .pending(SEG + 0x1000, SEG),
             None,
             "a floor already at the fork segment needs no seal",
         );

--- a/src/source/wal_stream.rs
+++ b/src/source/wal_stream.rs
@@ -39,6 +39,7 @@ use walrus::pg::walparser::{
 use crate::filter::manifest::{Entry, FILTER_VERSION, Kind, Manifest};
 use crate::filter::rewrite::{RewriteError, noop_replace};
 use crate::filter::{Filter, FilterSnapshot};
+use crate::pos::{Floor, Pos};
 #[cfg(test)]
 use crate::record::{
     CollectingRecordSink, CollectingSegmentSink, CompositeRecordSink, MetricsRecordSink,
@@ -140,7 +141,12 @@ pub struct ForkPrefix {
 }
 
 impl WalStream {
-    pub fn new(timeline: u32, seg_size: u64, start_lsn: u64) -> Result<Self, WalStreamError> {
+    pub fn new(
+        timeline: u32,
+        seg_size: u64,
+        start_lsn: impl Into<Pos<Floor>>,
+    ) -> Result<Self, WalStreamError> {
+        let start_lsn = start_lsn.into().get();
         if !start_lsn.is_multiple_of(seg_size) {
             return Err(WalStreamError::UnalignedBase(start_lsn));
         }
@@ -182,11 +188,13 @@ impl WalStream {
         lsn - (lsn % seg_size)
     }
 
-    pub fn next_lsn(&self) -> u64 {
-        self.next_lsn
+    /// Read cursor: where a restart of this stream resumes
+    pub fn next_lsn(&self) -> Pos<Floor> {
+        Pos::new(self.next_lsn)
     }
 
-    /// LSN one past the end of the last `on_segment` call.
+    /// LSN one past the end of the last `on_segment` call. Raw: read as the
+    /// filter frontier, as a shadow-replay target, and as a wire offset
     pub fn dispatched_lsn(&self) -> u64 {
         self.current_lsn
     }

--- a/src/toast/toast_retire.rs
+++ b/src/toast/toast_retire.rs
@@ -35,7 +35,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::source::manifest::Lsn;
+use crate::pos::{Commit, Floor, Pos};
 
 pub const RETIRE_LEDGER_FILENAME: &str = "toast_retires.toml";
 
@@ -68,7 +68,7 @@ struct RetireFile {
 #[derive(Serialize, Deserialize)]
 struct RetireEntry {
     toast_relid: u32,
-    commit_lsn: Lsn,
+    commit_lsn: Pos<Commit>,
 }
 
 /// Pending `(toast_relid, dropping commit_lsn)` retires, persisted on
@@ -76,7 +76,7 @@ struct RetireEntry {
 #[derive(Debug)]
 pub struct RetireLedger {
     dir: PathBuf,
-    entries: Vec<(u32, u64)>,
+    entries: Vec<(u32, Pos<Commit>)>,
 }
 
 impl RetireLedger {
@@ -96,7 +96,7 @@ impl RetireLedger {
                 ledger.entries = file
                     .retire
                     .into_iter()
-                    .map(|e| (e.toast_relid, e.commit_lsn.0))
+                    .map(|e| (e.toast_relid, e.commit_lsn))
                     .collect();
             }
             Err(e) if e.kind() == io::ErrorKind::NotFound => {}
@@ -109,13 +109,14 @@ impl RetireLedger {
         self.entries.is_empty()
     }
 
-    pub fn entries(&self) -> &[(u32, u64)] {
+    pub fn entries(&self) -> &[(u32, Pos<Commit>)] {
         &self.entries
     }
 
     /// Entries whose dropping commit precedes `cut` (persisted resolved
     /// floor); snapshot so the caller can await between removals.
-    pub fn due(&self, cut: u64) -> Vec<(u32, u64)> {
+    pub fn due(&self, cut: impl Into<Pos<Floor>>) -> Vec<(u32, Pos<Commit>)> {
+        let cut = cut.into().get();
         self.entries
             .iter()
             .copied()
@@ -128,8 +129,9 @@ impl RetireLedger {
     pub async fn push(
         &mut self,
         toast_relid: u32,
-        commit_lsn: u64,
+        commit_lsn: impl Into<Pos<Commit>>,
     ) -> Result<(), RetireLedgerError> {
+        let commit_lsn = commit_lsn.into();
         if self.entries.contains(&(toast_relid, commit_lsn)) {
             return Ok(());
         }
@@ -141,8 +143,9 @@ impl RetireLedger {
     pub async fn remove(
         &mut self,
         toast_relid: u32,
-        commit_lsn: u64,
+        commit_lsn: impl Into<Pos<Commit>>,
     ) -> Result<(), RetireLedgerError> {
+        let commit_lsn = commit_lsn.into();
         let before = self.entries.len();
         self.entries.retain(|&e| e != (toast_relid, commit_lsn));
         if self.entries.len() == before {
@@ -159,7 +162,7 @@ impl RetireLedger {
                 .iter()
                 .map(|&(toast_relid, commit_lsn)| RetireEntry {
                     toast_relid,
-                    commit_lsn: Lsn(commit_lsn),
+                    commit_lsn,
                 })
                 .collect(),
         };
@@ -194,7 +197,10 @@ mod tests {
             "rename must clean up the .tmp sidecar",
         );
         let reloaded = RetireLedger::load(tmp.path()).await.unwrap();
-        assert_eq!(reloaded.entries(), &[(16500, 0x1000), (16600, 0x2000)]);
+        assert_eq!(
+            reloaded.entries(),
+            &[(16500, 0x1000.into()), (16600, 0x2000.into())]
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -203,9 +209,9 @@ mod tests {
         let mut ledger = RetireLedger::load(tmp.path()).await.unwrap();
         ledger.push(16500, 0x1000).await.unwrap();
         ledger.push(16500, 0x1000).await.unwrap();
-        assert_eq!(ledger.entries(), &[(16500, 0x1000)]);
+        assert_eq!(ledger.entries(), &[(16500, 0x1000.into())]);
         let reloaded = RetireLedger::load(tmp.path()).await.unwrap();
-        assert_eq!(reloaded.entries(), &[(16500, 0x1000)]);
+        assert_eq!(reloaded.entries(), &[(16500, 0x1000.into())]);
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -216,7 +222,7 @@ mod tests {
         ledger.push(16600, 0x2000).await.unwrap();
         ledger.remove(16500, 0x1000).await.unwrap();
         let reloaded = RetireLedger::load(tmp.path()).await.unwrap();
-        assert_eq!(reloaded.entries(), &[(16600, 0x2000)]);
+        assert_eq!(reloaded.entries(), &[(16600, 0x2000.into())]);
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -226,9 +232,9 @@ mod tests {
         ledger.push(1, 0x1000).await.unwrap();
         ledger.push(2, 0x2000).await.unwrap();
         ledger.push(3, 0x3000).await.unwrap();
-        assert_eq!(ledger.due(0x2000), [(1, 0x1000)]);
+        assert_eq!(ledger.due(0x2000), [(1, 0x1000.into())]);
         assert_eq!(ledger.due(u64::MAX).len(), 3);
-        assert!(ledger.due(0).is_empty());
+        assert!(ledger.due(Pos::ZERO).is_empty());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -278,7 +284,7 @@ mod tests {
         );
         assert_eq!(
             ledger.due(resolved_floor(n + 2 * SEG + 5, n + 2 * SEG)),
-            vec![(16500, n + SEG + 42)],
+            vec![(16500, (n + SEG + 42).into())],
         );
     }
 }

--- a/src/xact/xact_buffer.rs
+++ b/src/xact/xact_buffer.rs
@@ -59,6 +59,7 @@ use crate::decode::wal_xact::{
 };
 use crate::emit::ch_emitter::EmitterStats;
 use crate::ops::trace::{InflightSnapshotEntry, TxnSpanRegistry, new_txn_span};
+use crate::pos::{Commit, Drain, EmitterAck, Pos, ResumeSafe, XactFirst};
 use crate::record::{Record, RecordSink, Route, SinkError};
 use crate::runtime_config::{ConfigEvent, ConfigTableKind};
 use crate::schema::{RelDescriptor, SchemaEvent};
@@ -350,7 +351,7 @@ pub struct XactBufferStats {
     /// Highest commit-record LSN handed to a drain. Snapshot for the
     /// manifest `drain` role, monotonic. The durable-ack sibling lives in
     /// the pipeline ack collector, not here
-    pub drain_lsn: u64,
+    pub drain_lsn: Pos<Drain>,
     /// Cumulative raw-stash payload bytes by first landing; eviction moving
     /// a memory-resident entry to spill does not re-count
     pub raw_stash_bytes_mem: u64,
@@ -406,7 +407,7 @@ pub enum DrainEntry {
 struct XactState {
     /// Sticky across spill rotations; distinguishes two xids that collide
     /// after a slot rebuild
-    first_lsn: u64,
+    first_lsn: Pos<XactFirst>,
     /// WAL-order by arrival
     in_mem: Vec<SpillEntry>,
     in_mem_bytes: usize,
@@ -436,7 +437,7 @@ impl XactState {
             first_lsn = first_lsn,
         );
         Self {
-            first_lsn,
+            first_lsn: first_lsn.into(),
             in_mem: Vec::new(),
             in_mem_bytes: 0,
             spill: None,
@@ -509,8 +510,8 @@ fn value_size(v: &ColumnValue) -> usize {
 
 #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
 struct PendingDurableXact {
-    first_lsn: u64,
-    commit_lsn: u64,
+    first_lsn: Pos<XactFirst>,
+    commit_lsn: Pos<Commit>,
 }
 
 #[derive(Debug, Default)]
@@ -519,24 +520,24 @@ struct PendingDurable {
 }
 
 impl PendingDurable {
-    fn push(&mut self, first_lsn: u64, commit_lsn: u64) {
+    fn push(&mut self, first_lsn: Pos<XactFirst>, commit_lsn: Pos<Commit>) {
         self.by_first_lsn.push(Reverse(PendingDurableXact {
             first_lsn,
             commit_lsn,
         }));
     }
 
-    fn prune(&mut self, durable_ack: u64) {
+    fn prune(&mut self, durable_ack: Pos<EmitterAck>) {
         while self
             .by_first_lsn
             .peek()
-            .is_some_and(|Reverse(xact)| xact.commit_lsn <= durable_ack)
+            .is_some_and(|Reverse(xact)| xact.commit_lsn <= durable_ack.get())
         {
             self.by_first_lsn.pop();
         }
     }
 
-    fn min_first_lsn(&self) -> Option<u64> {
+    fn min_first_lsn(&self) -> Option<Pos<XactFirst>> {
         self.by_first_lsn.peek().map(|Reverse(xact)| xact.first_lsn)
     }
 }
@@ -855,7 +856,7 @@ impl XactBuffer {
             .inflight
             .iter()
             .map(|(xid, st)| {
-                let mut last_lsn = st.first_lsn;
+                let mut last_lsn = st.first_lsn.get();
                 let mut rels: std::collections::BTreeSet<(u32, u32)> =
                     std::collections::BTreeSet::new();
                 let mut heap_count = 0u64;
@@ -896,7 +897,7 @@ impl XactBuffer {
                     .join(",");
                 InflightSnapshotEntry {
                     xid: *xid,
-                    first_lsn: st.first_lsn,
+                    first_lsn: st.first_lsn.get(),
                     last_lsn,
                     heap_count,
                     chunk_count,
@@ -1157,7 +1158,7 @@ impl XactBuffer {
         let st = self.inflight.get_mut(&xid).expect("xid present");
         let first_spill = st.spill.is_none();
         if first_spill {
-            st.spill = Some(self.store.writer(xid, st.first_lsn).await?);
+            st.spill = Some(self.store.writer(xid, st.first_lsn.get()).await?);
         }
         let writer = st.spill.as_mut().unwrap();
         let drained: Vec<SpillEntry> = std::mem::take(&mut st.in_mem);
@@ -1281,7 +1282,7 @@ impl XactBuffer {
                 states.push(st);
             }
         }
-        self.stats.drain_lsn = self.stats.drain_lsn.max(commit_lsn);
+        self.stats.drain_lsn = self.stats.drain_lsn.max(commit_lsn.into());
         if states.is_empty() {
             // Read-only / filter-dropped: reorder coordinator still
             // registers a seq so the contiguous watermark passes commit_lsn
@@ -1296,7 +1297,7 @@ impl XactBuffer {
         }
         // Preserve floor while decoded slices remain undurable
         if let Some(first) = states.iter().map(|st| st.first_lsn).min() {
-            self.pending_durable.push(first, commit_lsn);
+            self.pending_durable.push(first, commit_lsn.into());
         }
         for st in &states {
             self.stats.xacts_active = self.stats.xacts_active.saturating_sub(1);
@@ -1337,21 +1338,24 @@ impl XactBuffer {
     /// post-COMMIT WAL (page padding, RUNNING_XACTS, CHECKPOINT) counts as
     /// drained when quiescent. The durable ack side lives in the ack
     /// collector (`AckHandle::trailing`).
-    pub fn advance_idle(&mut self, lsn: u64) {
+    pub fn advance_idle(&mut self, lsn: impl Into<Pos<Drain>>) {
         if self.stats.xacts_active != 0 {
             return;
         }
-        self.stats.drain_lsn = self.stats.drain_lsn.max(lsn);
+        self.stats.drain_lsn = self.stats.drain_lsn.max(lsn.into());
     }
 
     /// Floor durable acknowledgment at first record of each undurable transaction
-    pub fn resume_safe_lsn(&mut self, durable_ack: u64) -> u64 {
+    pub fn resume_safe_lsn(&mut self, durable_ack: impl Into<Pos<EmitterAck>>) -> Pos<ResumeSafe> {
+        let durable_ack = durable_ack.into();
         self.pending_durable.prune(durable_ack);
-        self.inflight
-            .values()
-            .map(|st| st.first_lsn)
-            .chain(self.pending_durable.min_first_lsn())
-            .fold(durable_ack, u64::min)
+        Pos::new(
+            self.inflight
+                .values()
+                .map(|st| st.first_lsn)
+                .chain(self.pending_durable.min_first_lsn())
+                .fold(durable_ack.get(), |acc, first| acc.min(first.get())),
+        )
     }
 
     /// Discard xact `xid` + spill file. No-op if unknown. `abort_lsn` is
@@ -1361,10 +1365,10 @@ impl XactBuffer {
     pub async fn abort(
         &mut self,
         xid: u32,
-        abort_lsn: u64,
+        abort_lsn: impl Into<Pos<Drain>>,
         subxids: &[u32],
     ) -> std::result::Result<(), XactBufferError> {
-        self.stats.drain_lsn = self.stats.drain_lsn.max(abort_lsn);
+        self.stats.drain_lsn = self.stats.drain_lsn.max(abort_lsn.into());
         // `xid` is header xact_id: top abort or subxact standalone
         // rollback. Drop `xid` + every sub. For mid-xact subxact rollback
         // (PG `RecordSubTransactionAbort` writes a separate

--- a/tests/bootstrap_pipeline_ch.rs
+++ b/tests/bootstrap_pipeline_ch.rs
@@ -20,7 +20,7 @@
 mod fx;
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use walrus::pg::walparser::RelFileNode;
@@ -31,6 +31,7 @@ use walshadow::heap_decoder::ColumnValue;
 use walshadow::mapping::{ColumnMapping, TableMapping, TableTarget};
 use walshadow::pipeline::batcher::BatcherMsg;
 use walshadow::pipeline::{Fatal, bootstrap, tail};
+use walshadow::pos::{EmitterAck, Monotone};
 use walshadow::schema::{RelAttr, RelDescriptor, RelName, ReplIdent};
 use walshadow::toast::ToastResolver;
 
@@ -144,7 +145,7 @@ async fn bootstrap_tail_fans_out_n2() {
     let mapping = walshadow::mapping::mapping_handle(cfg.tables.clone());
 
     let stats = Arc::new(EmitterStats::default());
-    let emitter_ack = Arc::new(AtomicU64::new(0));
+    let emitter_ack = Arc::new(Monotone::<EmitterAck>::new(0));
     let fatal = Fatal::new();
     let (msg_tx, ack, tail) = tail::spawn(
         &cfg,
@@ -199,11 +200,12 @@ async fn bootstrap_tail_fans_out_n2() {
     reply_rx.await.expect("flush ack");
     tokio::time::timeout(Duration::from_secs(30), ack.wait_through(outcome.next_seq))
         .await
-        .expect("wait_through(K) completed — per-seq acks reconciled across N=2");
+        .expect("wait_through(K) completed — per-seq acks reconciled across N=2")
+        .expect("ack collector alive");
 
     // Watermark saturates at start_lsn (every bootstrap commit_lsn is equal).
     assert_eq!(
-        emitter_ack.load(Ordering::Acquire),
+        emitter_ack.get(),
         START_LSN,
         "contiguous-done watermark at start_lsn",
     );

--- a/tests/common/inproc_harness.rs
+++ b/tests/common/inproc_harness.rs
@@ -32,7 +32,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
-use std::sync::atomic::AtomicU64;
 use tokio::sync::Mutex;
 use walrus::pg::replication::conn::PgConfig;
 use walrus::pg::replication::tls::{SslMode, TlsParams};
@@ -44,6 +43,7 @@ use walshadow::mapping::{ColumnMapping, NamespaceMapping, TableMapping, TableTar
 use walshadow::pg::socket_conninfo;
 use walshadow::pipeline::reorder::ReorderSink;
 use walshadow::pipeline::{PipelineConfig, PipelineHandle, TailKind};
+use walshadow::pos::{EmitterAck, Floor, Monotone};
 use walshadow::record::{MetricsRecordSink, Record, RecordSink, SinkError, WAL_SEG_SIZE};
 use walshadow::schema::RelName;
 use walshadow::segment_sink::DirSegmentSink;
@@ -607,12 +607,12 @@ pub struct Pipeline {
     pub xact_buffer: Arc<Mutex<XactBuffer>>,
     pub chunk_buf: Vec<u8>,
     pub handle: PipelineHandle,
-    pub ack: Arc<AtomicU64>,
+    pub ack: Arc<Monotone<EmitterAck>>,
     /// Persisted-resolved-floor stand-in gating deferred toast-mirror
     /// retires; the daemon's status loop advances it after each manifest
-    /// persist, tests store into it directly. Seeds at the boot head, so
+    /// persist, tests advance it explicitly. Seeds at the boot head, so
     /// retires queued by this run defer until a test advances it.
-    pub resume_floor: Arc<AtomicU64>,
+    pub resume_floor: Arc<Monotone<Floor>>,
     /// Same `EmitterStats` Arc the daemon exports to Prometheus; lets tests
     /// assert the parallel path keeps the emitter counters live.
     pub stats: Arc<EmitterStats>,
@@ -854,13 +854,13 @@ async fn build_pipeline_inner(
         .expect("ddl applicator init")
         .with_resolver(config_resolver.clone());
     let stats = Arc::new(EmitterStats::default());
-    let emitter_ack = Arc::new(AtomicU64::new(0));
+    let emitter_ack = Arc::new(Monotone::<EmitterAck>::new(0));
     // Aligned boot head stands in for the daemon's resolved floor (a
     // rebuilt harness re-reads from the segment start, like a daemon
     // restart): retires queued by this run defer until a test advances
     // the floor; ledger entries below a prior run's segment are due and
     // retire in the boot flush below.
-    let resume_floor = Arc::new(AtomicU64::new(WalStream::align_down(
+    let resume_floor = Arc::new(Monotone::<Floor>::new(WalStream::align_down(
         ident.xlogpos,
         WAL_SEG_SIZE,
     )));

--- a/tests/emitter_budget_flush.rs
+++ b/tests/emitter_budget_flush.rs
@@ -19,7 +19,7 @@
 mod fx;
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 
 use walrus::pg::walparser::RelFileNode;
 use walshadow::ch::CompressionChoice;
@@ -28,6 +28,7 @@ use walshadow::heap_decoder::{ColumnValue, CommittedTuple, DecodedHeap, DecodedT
 use walshadow::mapping::{ColumnMapping, TableMapping, TableTarget};
 use walshadow::pipeline::batcher::{BatcherMsg, RoutedRow};
 use walshadow::pipeline::{Fatal, tail};
+use walshadow::pos::{EmitterAck, Monotone};
 use walshadow::schema::{RelAttr, RelDescriptor, RelName, ReplIdent};
 
 const RFN: RelFileNode = RelFileNode {
@@ -153,7 +154,7 @@ async fn budget_trips_seal_complete_inserts() {
     };
 
     let stats = Arc::new(EmitterStats::default());
-    let emitter_ack = Arc::new(AtomicU64::new(0));
+    let emitter_ack = Arc::new(Monotone::<EmitterAck>::new(0));
     let fatal = Fatal::new();
     let (msg_tx, ack, tail_parts) =
         tail::spawn(&cfg, 1, stats.clone(), emitter_ack.clone(), fatal.clone())
@@ -184,7 +185,7 @@ async fn budget_trips_seal_complete_inserts() {
         .await
         .expect("send flush");
     reply_rx.await.expect("flush ack");
-    ack.wait_through(1).await;
+    ack.wait_through(1).await.expect("ack collector alive");
     drop(msg_tx);
     drop(ack);
     tail_parts.join().await;
@@ -192,7 +193,7 @@ async fn budget_trips_seal_complete_inserts() {
 
     // The contiguous-done watermark reaches the seq's commit lsn.
     assert_eq!(
-        emitter_ack.load(Ordering::Acquire),
+        emitter_ack.get(),
         commit_lsn,
         "durable horizon must reach the commit lsn",
     );

--- a/tests/emitter_native_types.rs
+++ b/tests/emitter_native_types.rs
@@ -16,7 +16,6 @@
 mod fx;
 
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
 
 use walrus::pg::walparser::RelFileNode;
 use walshadow::ch::CompressionChoice;
@@ -26,6 +25,7 @@ use walshadow::heap_decoder::{ColumnValue, CommittedTuple, DecodedHeap, DecodedT
 use walshadow::mapping::{ColumnMapping, TableMapping, TableTarget};
 use walshadow::pipeline::batcher::{BatcherMsg, RoutedRow};
 use walshadow::pipeline::{Fatal, tail};
+use walshadow::pos::{EmitterAck, Monotone};
 use walshadow::schema::{RelDescriptor, RelName, ReplIdent};
 
 const RFN: RelFileNode = RelFileNode {
@@ -122,7 +122,7 @@ async fn native_numeric_time_timetz_round_trip() {
     });
 
     let stats = Arc::new(EmitterStats::default());
-    let emitter_ack = Arc::new(AtomicU64::new(0));
+    let emitter_ack = Arc::new(Monotone::<EmitterAck>::new(0));
     let fatal = Fatal::new();
     let (msg_tx, ack, tail_parts) = tail::spawn(&cfg, 1, stats, emitter_ack, fatal.clone())
         .await
@@ -176,7 +176,7 @@ async fn native_numeric_time_timetz_round_trip() {
         .await
         .expect("send flush");
     reply_rx.await.expect("flush ack");
-    ack.wait_through(1).await;
+    ack.wait_through(1).await.expect("ack collector alive");
     drop(msg_tx);
     drop(ack);
     tail_parts.join().await;

--- a/tests/emitter_tls.rs
+++ b/tests/emitter_tls.rs
@@ -27,7 +27,6 @@ use std::os::unix::process::CommandExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
 use std::time::{Duration, Instant};
 
 use clickhouse_c::tls::{self, rustls};
@@ -38,6 +37,7 @@ use walshadow::heap_decoder::{ColumnValue, CommittedTuple, DecodedHeap, DecodedT
 use walshadow::mapping::{ColumnMapping, TableMapping, TableTarget};
 use walshadow::pipeline::batcher::{BatcherMsg, RoutedRow};
 use walshadow::pipeline::{Fatal, tail};
+use walshadow::pos::{EmitterAck, Monotone};
 use walshadow::schema::{RelDescriptor, RelName, ReplIdent};
 
 const RFN: RelFileNode = RelFileNode {
@@ -351,7 +351,7 @@ async fn emitter_tls_round_trip() {
     // `AsyncClient::connect_tls`, so spawning the tail exercises the secure
     // path the same way the WAL/bootstrap producers do.
     let stats = Arc::new(EmitterStats::default());
-    let emitter_ack = Arc::new(AtomicU64::new(0));
+    let emitter_ack = Arc::new(Monotone::<EmitterAck>::new(0));
     let fatal = Fatal::new();
     let (msg_tx, ack, tail_parts) = tail::spawn(&cfg, 1, stats, emitter_ack, fatal.clone())
         .await
@@ -393,7 +393,7 @@ async fn emitter_tls_round_trip() {
         .await
         .expect("send flush");
     reply_rx.await.expect("flush ack");
-    ack.wait_through(1).await;
+    ack.wait_through(1).await.expect("ack collector alive");
     drop(msg_tx);
     drop(ack);
     tail_parts.join().await;

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -9,30 +9,31 @@
 //! resumes as greenfield.
 
 use walshadow::manifest::{
-    self, Lsn, LsnSet, MANIFEST_FILENAME, MANIFEST_VERSION, Manifest, SourceIdentity, WalBranch,
+    self, LsnSet, MANIFEST_FILENAME, MANIFEST_VERSION, Manifest, SourceIdentity, WalBranch,
 };
+use walshadow::pos::Pos;
 
 fn ident() -> SourceIdentity {
     SourceIdentity {
         system_id: 7_000_000_000_000_000_001,
         timeline: 3,
-        timeline_begin: Lsn(0x0400_0000),
+        timeline_begin: Pos::new(0x0400_0000),
     }
 }
 
 fn sample() -> Manifest {
     Manifest {
         version: MANIFEST_VERSION,
-        floor: Lsn(0x05),
+        floor: Pos::new(0x05),
         source: ident(),
         wal: WalBranch { stream_timeline: 3 },
         lsn: LsnSet {
-            source_received: Lsn(0x10),
-            filter_durable: Lsn(0x09),
-            shadow_replay: Lsn(0x08),
-            drain: Lsn(0x07),
-            emitter_ack: Lsn(0x06),
-            shadow_flush: Lsn(0x05),
+            source_received: Pos::new(0x10),
+            filter_durable: Pos::new(0x09),
+            shadow_replay: Pos::new(0x08),
+            drain: Pos::new(0x07),
+            emitter_ack: Pos::new(0x06),
+            shadow_flush: Pos::new(0x05),
         },
     }
 }
@@ -58,7 +59,7 @@ async fn write_survives_simulated_crash_during_tmp_phase() {
     // The next clean write recovers — and overwrites the bogus .tmp on
     // its way.
     let mut better = good.clone();
-    better.lsn.emitter_ack = Lsn(0x100);
+    better.lsn.emitter_ack = Pos::new(0x100);
     manifest::write(dir, &better).await.unwrap();
     assert!(
         !tmp_path.exists(),

--- a/tests/pipeline_parallel_ddl_e2e.rs
+++ b/tests/pipeline_parallel_ddl_e2e.rs
@@ -18,7 +18,7 @@
 //!   TRUNCATE carries no `_lsn`, so only correct ordering against the
 //!   surrounding inserts yields the right surviving set.
 //!
-//! Both assert the durable watermark (ack-collector atomic) advanced, so
+//! Both assert ack collector's watermark advanced, so
 //! the barrier fence reached durable rather than hanging.
 
 #![cfg(target_os = "linux")]
@@ -194,7 +194,7 @@ async fn parallel_pipeline_schema_evolution_orders_after_data() {
     );
 
     assert!(
-        ack.load(Ordering::Acquire) > 0,
+        ack.get() > 0,
         "durable watermark advanced through the barrier",
     );
 }
@@ -353,7 +353,7 @@ async fn parallel_pipeline_truncate_orders_after_data() {
     );
 
     assert!(
-        ack.load(Ordering::Acquire) > 0,
+        ack.get() > 0,
         "durable watermark advanced through the barrier",
     );
 }

--- a/tests/pipeline_parallel_e2e.rs
+++ b/tests/pipeline_parallel_e2e.rs
@@ -147,9 +147,7 @@ async fn parallel_pipeline_replicates_dml() {
         .expect("shadow replay catches up");
     assert!(observed >= target);
 
-    // The pipeline's durable watermark lives in the ack-collector atomic;
-    // capture it (and the emitter counters) before `shutdown` consumes the
-    // pipeline.
+    // Capture shared diagnostics before `shutdown` consumes pipeline
     let ack = pipeline.ack.clone();
     let stats = pipeline.stats.clone();
 
@@ -213,10 +211,7 @@ async fn parallel_pipeline_replicates_dml() {
 
     // Every dispatched seq drained, so the contiguous-done watermark
     // advanced past its initial 0.
-    assert!(
-        ack.load(std::sync::atomic::Ordering::Acquire) > 0,
-        "durable watermark advanced",
-    );
+    assert!(ack.get() > 0, "durable watermark advanced",);
 
     // Emitter Prometheus counters stay live on the parallel path (reorder
     // bumps xacts per commit; inserters bump rows/blocks post-EndOfStream).
@@ -433,7 +428,7 @@ async fn parallel_pipeline_slices_multi_batch_commit() {
         "cross-slice detoast rehydrated the unchanged-toast UPDATE",
     );
     assert!(
-        ack.load(std::sync::atomic::Ordering::Acquire) > 0,
+        ack.get() > 0,
         "final-slice publication advanced the durable watermark",
     );
 }

--- a/tests/pipeline_tail.rs
+++ b/tests/pipeline_tail.rs
@@ -4,13 +4,13 @@
 mod fx;
 
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
 use std::time::Duration;
 
 use walshadow::ch::CompressionChoice;
 use walshadow::ch_emitter::{EmitterConfig, EmitterStats};
 use walshadow::pipeline::Fatal;
 use walshadow::pipeline::tail;
+use walshadow::pos::{EmitterAck, Monotone};
 
 fn emitter(port: u16) -> EmitterConfig {
     EmitterConfig {
@@ -36,7 +36,7 @@ async fn tail_finish_flushes_and_drains_clean() {
 
     let fatal = Fatal::new();
     let stats = Arc::new(EmitterStats::default());
-    let emitter_ack = Arc::new(AtomicU64::new(0));
+    let emitter_ack = Arc::new(Monotone::<EmitterAck>::new(0));
     let (msg_tx, ack, parts) = tail::spawn(&emitter(ch_tcp), 2, stats, emitter_ack, fatal.clone())
         .await
         .expect("spawn tail");
@@ -61,7 +61,7 @@ async fn tail_finish_returns_fatal_message() {
 
     let fatal = Fatal::new();
     let stats = Arc::new(EmitterStats::default());
-    let emitter_ack = Arc::new(AtomicU64::new(0));
+    let emitter_ack = Arc::new(Monotone::<EmitterAck>::new(0));
     let (msg_tx, ack, parts) = tail::spawn(&emitter(ch_tcp), 2, stats, emitter_ack, fatal.clone())
         .await
         .expect("spawn tail");
@@ -88,7 +88,7 @@ async fn tail_finish_fatal_during_drain() {
 
     let fatal = Fatal::new();
     let stats = Arc::new(EmitterStats::default());
-    let emitter_ack = Arc::new(AtomicU64::new(0));
+    let emitter_ack = Arc::new(Monotone::<EmitterAck>::new(0));
     let (msg_tx, ack, parts) = tail::spawn(&emitter(ch_tcp), 2, stats, emitter_ack, fatal.clone())
         .await
         .expect("spawn tail");

--- a/tests/toast_rewrite_e2e.rs
+++ b/tests/toast_rewrite_e2e.rs
@@ -594,7 +594,9 @@ async fn alter_rewrite_link_swap_retires_old_mirror() {
         "retire must defer while the resume floor hasn't passed the drop",
     );
     assert_eq!(stats.toast_mirror_retires.load(Ordering::Relaxed), 0);
-    pipeline.resume_floor.store(u64::MAX, Ordering::Release);
+    pipeline
+        .resume_floor
+        .join(walshadow::pos::Pos::new(u64::MAX));
     let driver = fx::spawn_workload(
         &source,
         vec![

--- a/tests/toast_tombstone_e2e.rs
+++ b/tests/toast_tombstone_e2e.rs
@@ -417,7 +417,9 @@ async fn tombstones_supersede_then_truncate_wipes_then_drop_retires() {
 
     // Cursor persisted past the dropping commit (daemon status-loop
     // stand-in); the next commit executes the queued retire.
-    pipeline.resume_floor.store(u64::MAX, Ordering::Release);
+    pipeline
+        .resume_floor
+        .join(walshadow::pos::Pos::new(u64::MAX));
     let driver = fx::spawn_workload(
         &source,
         vec![

--- a/tests/toast_truncate_drop_e2e.rs
+++ b/tests/toast_truncate_drop_e2e.rs
@@ -197,7 +197,9 @@ async fn cold_restart_drop_retires_mirror() {
         "1",
         "retire must defer while the resume floor hasn't passed the drop",
     );
-    pipeline.resume_floor.store(u64::MAX, Ordering::Release);
+    pipeline
+        .resume_floor
+        .join(walshadow::pos::Pos::new(u64::MAX));
     let driver = fx::spawn_workload(
         &source,
         vec![

--- a/tests/vacuum_catalog_churn.rs
+++ b/tests/vacuum_catalog_churn.rs
@@ -216,7 +216,11 @@ impl RecordSink for HoldingCensus {
             if record.catalog_boundary {
                 let parked = Instant::now();
                 self.gate
-                    .hold(record.source_lsn, record.next_lsn, || true)
+                    .hold(
+                        record.source_lsn,
+                        walshadow::pos::Pos::new(record.next_lsn),
+                        || true,
+                    )
                     .await?;
                 self.holds += 1;
                 self.held += parked.elapsed();

--- a/tests/wal_stream_e2e.rs
+++ b/tests/wal_stream_e2e.rs
@@ -754,7 +754,7 @@ async fn shutdown_writes_partial_segment_and_resume_from_start_lsn_continues() {
     assert!(
         next_at_close > dispatched_at_close,
         "current_buf must hold ≥1 byte for close() to produce a .partial \
-         (dispatched={dispatched_at_close:#X}, next={next_at_close:#X})",
+         (dispatched={dispatched_at_close:#X}, next={next_at_close})",
     );
 
     // Drive the shutdown path. Equivalent to the daemon's ctrl_c branch

--- a/tests/xact_buffer.rs
+++ b/tests/xact_buffer.rs
@@ -30,6 +30,7 @@ use walshadow::heap_decoder::{
     ColumnValue, CommittedTuple, DecodedHeap, DecodedTuple, DescribedHeap, HeapOp, ToastPointer,
 };
 use walshadow::pg::socket_conninfo;
+use walshadow::pos::Pos;
 use walshadow::shadow::{BridgeConf, Shadow, ShadowConfig};
 use walshadow::shadow_catalog::{ShadowCatalog, ShadowCatalogConfig};
 use walshadow::spill::ToastChunk;
@@ -709,7 +710,7 @@ async fn abort_drops_xact_and_unlinks_spill_against_real_shadow() {
         .unwrap();
     }
     assert!(b.stats().spill_xacts_active >= 1);
-    b.abort(11, 200, &[]).await.unwrap();
+    b.abort(11, Pos::new(200), &[]).await.unwrap();
     let leftover: Vec<_> = std::fs::read_dir(&spill_dir)
         .unwrap()
         .filter_map(|e| e.ok())


### PR DESCRIPTION
Add typed WAL positions so sequence counters cannot be stored or displayed as LSNs. Replace duplicated progress state with one monotonic value that callers can wait on. Keep routing maps and staleness checks together.

Fixes:
1. Fail barriers when durability tracking stops, instead of treating closed tracking channels as success

2. Single routing snapshot during ALTER handling avoids races, panics, and stale lookups during mapping updates

3. Predict transaction routes from frozen mapping and config snapshots, preventing one transaction from using multiple routing versions

4. Check fatal pipeline errors before ready success paths, preventing more work from being dispatched after failure

5. Reject invalid acknowledgements instead of silently corrupting progress tracking

6. Signal apply progress when walreceivers attach or detach, releasing catalog waits immediately