### PR TITLE
Optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,6 +2698,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "libc",
  "pin-project-lite",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ smallvec = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "net", "fs", "sync", "signal", "io-util"] }
 tokio-postgres = "0.7"
-tokio-util = { version = "0.7", features = ["io"] }
+tokio-util = { version = "0.7", features = ["io", "rt"] }
 toml = { version = "1", default-features = false, features = ["parse", "display", "serde"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "ansi"] }
@@ -76,6 +76,17 @@ opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.32", default-features = false, features = ["grpc-tonic", "trace"] }
 tracing-opentelemetry = { version = "0.33", default-features = false }
 mimalloc = "0.1.52"
+
+# `harness = false` throughout: these take shape flags rather than libtest
+# filters. Bootstrap pump + drain needs no PG and no CH; oracle batch needs
+# a shadow PG for its roundtrip stage only
+[[bench]]
+name = "bootstrap_pump"
+harness = false
+
+[[bench]]
+name = "oracle_batch"
+harness = false
 
 [dev-dependencies]
 tempfile = "3"

--- a/benches/bootstrap_pump.rs
+++ b/benches/bootstrap_pump.rs
@@ -1,0 +1,477 @@
+//! Bootstrap pump + drain throughput, no Postgres and no ClickHouse.
+//!
+//! Two stages the greenfield initial load is made of, measured apart:
+//!
+//! - `pump`: in-memory BASE_BACKUP tars → `MultiplexSink(DiskLanderSink,
+//!   PageWalkSink)` → tuple channel → null drain. Covers tar parse, page
+//!   framing, heap decode and the tuple-channel hop, under `--parallelism`
+//!   concurrent tar parts so shared-sink contention shows up.
+//! - `drain`: synthetic `BackfillTuple`s → `pipeline::bootstrap::drain` →
+//!   metrics-only tail. Covers routing plus the `BatcherMsg` hop.
+//!
+//! ```text
+//! cargo bench --bench bootstrap_pump -- \
+//!     --stage pump --parts 8 --segments-per-part 4 --pages 1024 --parallelism 4
+//! ```
+//!
+//! Must run on mimalloc, the allocator `walshadow-stream` sets: the walk
+//! produces decoded values on one thread and the drain frees them on
+//! another, and glibc's shared arena serializes on that pattern hard
+//! enough to invert the conclusion — there the parallel pump measures
+//! slower than the serial one it replaced.
+//!
+//! `harness = false`, so nextest lists it by answering `--list`.
+
+// Matches `walshadow-stream`: the walk allocates decoded values on one
+// thread and the drain frees them on another, and glibc's shared arena
+// serializes on that pattern. A bench on a different allocator measures a
+// different program
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use walrus::pg::replication::base_backup::Tablespace;
+use walrus::pg::walparser::RelFileNode;
+
+use walshadow::backfill::backup_source::{
+    BackupSink, BackupSource, EndInfo, PumpStats, PumpTarget, StartInfo, pump_tar_to_sink,
+};
+use walshadow::backfill_bootstrap::{BootstrapConfig, spawn_greenfield_bootstrap};
+use walshadow::backup_page_walk::{BackfillTuple, CatalogMap, PAGE_BYTES};
+use walshadow::heap_decoder::ColumnValue;
+use walshadow::mapping::{ColumnMapping, TableMapping, TableTarget};
+use walshadow::pipeline::bootstrap;
+use walshadow::pos::{EmitterAck, Monotone};
+use walshadow::schema::{INT4OID, RelAttr, RelDescriptor, RelName, ReplIdent};
+use walshadow::toast::ToastResolver;
+
+const DB_NODE: u32 = 5;
+const FIRST_FILENODE: u32 = 16400;
+const START_LSN: u64 = 0x5000_0000;
+/// `HeapTupleHeaderData` + pad to the 8-byte-aligned user-data offset
+const TUPLE_HEADER: usize = 24;
+const SIZE_OF_PAGE_HEADER: usize = 24;
+const SIZE_OF_ITEM_ID: usize = 4;
+const LP_NORMAL: u32 = 1;
+
+#[derive(Clone, Copy)]
+struct Shape {
+    /// Concurrent tar parts, as an object-store backup is partitioned
+    parts: usize,
+    /// Relation segments per part, one tar entry each
+    segments_per_part: usize,
+    pages_per_segment: usize,
+    tuples_per_page: usize,
+    /// int4 columns per tuple
+    columns: usize,
+    parallelism: usize,
+}
+
+impl Default for Shape {
+    fn default() -> Self {
+        Self {
+            parts: 8,
+            segments_per_part: 4,
+            pages_per_segment: 256,
+            tuples_per_page: 100,
+            columns: 8,
+            parallelism: 4,
+        }
+    }
+}
+
+impl Shape {
+    fn segments(self) -> usize {
+        self.parts * self.segments_per_part
+    }
+
+    fn tuples(self) -> u64 {
+        (self.segments() * self.pages_per_segment * self.tuples_per_page) as u64
+    }
+
+    fn bytes(self) -> u64 {
+        (self.segments() * self.pages_per_segment * PAGE_BYTES) as u64
+    }
+}
+
+fn descriptor(filenode: u32, columns: usize) -> Arc<RelDescriptor> {
+    RelDescriptor {
+        rfn: RelFileNode {
+            spc_node: 1663,
+            db_node: DB_NODE,
+            rel_node: filenode,
+        },
+        oid: filenode,
+        toast_oid: 0,
+        namespace_oid: 2200,
+        rel_name: RelName::new("public", &format!("t{filenode}")),
+        kind: 'r',
+        persistence: 'p',
+        replident: ReplIdent::Default { pk_attnums: None },
+        attributes: (0..columns)
+            .map(|i| RelAttr {
+                attnum: i as i16 + 1,
+                name: format!("c{i}"),
+                type_oid: INT4OID,
+                typmod: -1,
+                not_null: false,
+                dropped: false,
+                type_name: "int4".into(),
+                type_byval: true,
+                type_len: 4,
+                type_align: 'i',
+                type_storage: 'p',
+                missing_default: None,
+            })
+            .collect(),
+    }
+    .into()
+}
+
+fn mapping(filenode: u32, columns: usize) -> TableMapping {
+    TableMapping {
+        target: TableTarget::new("bench", &format!("t{filenode}")),
+        columns: (0..columns)
+            .map(|i| ColumnMapping {
+                src_attnum: i as i16 + 1,
+                target_name: format!("c{i}"),
+                target_type: "Int32".into(),
+            })
+            .collect(),
+    }
+}
+
+/// One 8 KiB heap page carrying `tuples` live int4-only tuples, laid out
+/// as PG writes them: line pointers up from the header, tuple bodies down
+/// from the page end.
+fn heap_page(tuples: usize, columns: usize, seed: i32) -> Vec<u8> {
+    let body = TUPLE_HEADER + 4 * columns;
+    let mut page = vec![0u8; PAGE_BYTES];
+    let mut written = 0usize;
+    for i in 0..tuples {
+        let off = PAGE_BYTES - (i + 1) * body;
+        if off < SIZE_OF_PAGE_HEADER + (i + 1) * SIZE_OF_ITEM_ID {
+            break;
+        }
+        let xmin = 100u32 + i as u32;
+        page[off..off + 4].copy_from_slice(&xmin.to_le_bytes());
+        page[off + 18..off + 20].copy_from_slice(&(columns as u16).to_le_bytes());
+        page[off + 20..off + 22].copy_from_slice(&0u16.to_le_bytes());
+        page[off + 22] = TUPLE_HEADER as u8;
+        for c in 0..columns {
+            let at = off + TUPLE_HEADER + c * 4;
+            let v = seed + (i as i32) * 31 + c as i32;
+            page[at..at + 4].copy_from_slice(&v.to_le_bytes());
+        }
+        let slot = SIZE_OF_PAGE_HEADER + i * SIZE_OF_ITEM_ID;
+        let raw = ((off as u32) & 0x7FFF) | (LP_NORMAL << 15) | (((body as u32) & 0x7FFF) << 17);
+        page[slot..slot + SIZE_OF_ITEM_ID].copy_from_slice(&raw.to_le_bytes());
+        written = i + 1;
+    }
+    let pd_lower = SIZE_OF_PAGE_HEADER + written * SIZE_OF_ITEM_ID;
+    let pd_upper = PAGE_BYTES - written * body;
+    page[12..14].copy_from_slice(&(pd_lower as u16).to_le_bytes());
+    page[14..16].copy_from_slice(&(pd_upper as u16).to_le_bytes());
+    page
+}
+
+/// One tar part holding `segments_per_part` `base/<db>/<filenode>` entries.
+async fn build_part(shape: Shape, part: usize) -> Vec<u8> {
+    use tokio::io::AsyncWriteExt;
+
+    let mut builder = tokio_tar::Builder::new(Vec::new());
+    for s in 0..shape.segments_per_part {
+        let filenode = FIRST_FILENODE + (part * shape.segments_per_part + s) as u32;
+        let mut body = Vec::with_capacity(shape.pages_per_segment * PAGE_BYTES);
+        for p in 0..shape.pages_per_segment {
+            body.extend_from_slice(&heap_page(
+                shape.tuples_per_page,
+                shape.columns,
+                (p * 1_000) as i32,
+            ));
+        }
+        let mut header = tokio_tar::Header::new_gnu();
+        header
+            .set_path(format!("base/{DB_NODE}/{filenode}"))
+            .unwrap();
+        header.set_size(body.len() as u64);
+        header.set_mode(0o600);
+        header.set_entry_type(tokio_tar::EntryType::Regular);
+        header.set_cksum();
+        builder
+            .append(&header, std::io::Cursor::new(body))
+            .await
+            .unwrap();
+    }
+    builder.finish().await.unwrap();
+    let mut out = builder.into_inner().await.unwrap();
+    out.flush().await.unwrap();
+    out
+}
+
+/// Object-store-shaped source over pre-built tars: one `pump_tar_to_sink`
+/// per part, `parallelism` in flight, so the shared sink sees the same
+/// interleaving a real fan-out gives it.
+struct MemSource {
+    parts: Vec<Vec<u8>>,
+    parallelism: usize,
+}
+
+#[async_trait::async_trait]
+impl BackupSource for MemSource {
+    async fn run(
+        self: Box<Self>,
+        data_dir: std::path::PathBuf,
+        sink: Arc<dyn BackupSink>,
+        stats: Arc<PumpStats>,
+    ) -> anyhow::Result<(StartInfo, EndInfo)> {
+        use futures::{StreamExt, TryStreamExt};
+
+        let start = StartInfo {
+            start_lsn: START_LSN,
+            timeline: 1,
+            tablespaces: Vec::<Tablespace>::new(),
+        };
+        let end = EndInfo {
+            end_lsn: START_LSN + 0x1000,
+            timeline: 1,
+        };
+        sink.start(&start).await?;
+        let target = Arc::new(PumpTarget::new(data_dir, sink.clone(), stats));
+        let MemSource { parts, parallelism } = *self;
+        futures::stream::iter(parts)
+            .map(|blob| {
+                let target = target.clone();
+                async move {
+                    let mut archive = tokio_tar::Archive::new(std::io::Cursor::new(blob));
+                    pump_tar_to_sink(&mut archive, &target).await
+                }
+            })
+            .buffer_unordered(parallelism)
+            .try_collect::<Vec<_>>()
+            .await?;
+        sink.finish(&end).await?;
+        Ok((start, end))
+    }
+}
+
+struct Report {
+    label: String,
+    elapsed_secs: f64,
+    tuples: u64,
+    bytes: u64,
+    detail: Vec<(&'static str, f64)>,
+}
+
+impl Report {
+    fn print(&self) {
+        println!(
+            "{:<10} {:>8.3}s  {:>10.1} MiB/s  {:>12.0} tuples/s  ({} tuples, {:.1} MiB)",
+            self.label,
+            self.elapsed_secs,
+            self.bytes as f64 / self.elapsed_secs / (1 << 20) as f64,
+            self.tuples as f64 / self.elapsed_secs,
+            self.tuples,
+            self.bytes as f64 / (1 << 20) as f64,
+        );
+        for (name, v) in &self.detail {
+            println!("    {name:<26} {v:>10.3}");
+        }
+    }
+}
+
+async fn bench_pump(shape: Shape) -> Report {
+    let mut parts = Vec::with_capacity(shape.parts);
+    for p in 0..shape.parts {
+        parts.push(build_part(shape, p).await);
+    }
+
+    let mut catalog = CatalogMap::new();
+    for i in 0..shape.segments() {
+        catalog.insert(descriptor(FIRST_FILENODE + i as u32, shape.columns));
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = BootstrapConfig::new(tmp.path().join("data"));
+    let progress = cfg.progress.clone();
+    let source = Box::new(MemSource {
+        parts,
+        parallelism: shape.parallelism,
+    });
+
+    let started = Instant::now();
+    let (mut rx, pump) = spawn_greenfield_bootstrap(cfg, source, catalog, false);
+    let drained = tokio::spawn(async move {
+        let mut n = 0u64;
+        while let Some(slab) = rx.recv().await {
+            // Touch the payload so the decode can't be optimised away
+            n += slab.iter().map(|t| t.columns.len() as u64).sum::<u64>();
+        }
+        n
+    });
+    pump.await.unwrap().unwrap();
+    let touched = drained.await.unwrap();
+    let elapsed = started.elapsed().as_secs_f64();
+
+    let ld = |a: &AtomicU64| a.load(Ordering::Relaxed) as f64;
+    Report {
+        label: "pump".into(),
+        elapsed_secs: elapsed,
+        tuples: touched / shape.columns as u64,
+        bytes: ld(&progress.pump.bytes_tapped) as u64,
+        detail: vec![
+            ("pages_walked", ld(&progress.page_walk.pages_walked)),
+            ("decode_secs", ld(&progress.page_walk.decode_nanos) / 1e9),
+            ("tap_secs", ld(&progress.pump.sink_chunk_nanos) / 1e9),
+            (
+                "channel_block_secs",
+                ld(&progress.page_walk.channel_block_nanos) / 1e9,
+            ),
+        ],
+    }
+}
+
+async fn bench_drain(shape: Shape) -> Report {
+    let rels: Vec<Arc<RelDescriptor>> = (0..shape.segments())
+        .map(|i| descriptor(FIRST_FILENODE + i as u32, shape.columns))
+        .collect();
+    let mut catalog = CatalogMap::new();
+    let mut tables = std::collections::HashMap::new();
+    for r in &rels {
+        catalog.insert(r.clone());
+        tables.insert(r.rel_name.clone(), mapping(r.oid, shape.columns));
+    }
+    let routes = Arc::new(tables.into_iter().collect());
+
+    let (msg_tx, ack, tail) =
+        walshadow::pipeline::tail::spawn_null(Arc::new(Monotone::<EmitterAck>::new(0)));
+    let (tup_tx, tup_rx) = tokio::sync::mpsc::channel::<Vec<BackfillTuple>>(16);
+
+    let per_rel = shape.pages_per_segment as u64 * shape.tuples_per_page as u64;
+    let columns = shape.columns;
+    let feeder = tokio::spawn(async move {
+        for r in rels {
+            // Slab at the walk's grain so the drain sees production shape
+            for slab_start in (0..per_rel).step_by(shape.tuples_per_page * 16) {
+                let end = (slab_start + (shape.tuples_per_page * 16) as u64).min(per_rel);
+                let slab: Vec<BackfillTuple> = (slab_start..end)
+                    .map(|i| BackfillTuple {
+                        rfn: r.rfn,
+                        xid: 100 + i as u32,
+                        xmax: 0,
+                        infomask: 0,
+                        source_lsn: START_LSN,
+                        blkno: (i / 100) as u32,
+                        offnum: (i % 100) as u16 + 1,
+                        columns: (0..columns)
+                            .map(|c| Some(ColumnValue::Int4(i as i32 + c as i32)))
+                            .collect(),
+                    })
+                    .collect();
+                if tup_tx.send(slab).await.is_err() {
+                    return;
+                }
+            }
+        }
+    });
+
+    let stats = Arc::new(walshadow::ch_emitter::EmitterStats::default());
+    let started = Instant::now();
+    let outcome = bootstrap::drain(
+        tup_rx,
+        catalog,
+        routes,
+        msg_tx.clone(),
+        ack.clone(),
+        stats.clone(),
+        ToastResolver::disabled(),
+        None,
+        Default::default(),
+        None,
+        ahash::HashSet::default(),
+    )
+    .await
+    .unwrap();
+    let elapsed = started.elapsed().as_secs_f64();
+    feeder.await.unwrap();
+    drop(msg_tx);
+    drop(ack);
+    tail.join().await;
+
+    Report {
+        label: "drain".into(),
+        elapsed_secs: elapsed,
+        tuples: outcome.rows_routed,
+        // Int4 payload only; the interesting rate here is rows, not bytes
+        bytes: outcome.rows_routed * 4 * shape.columns as u64,
+        detail: vec![("seqs", outcome.next_seq as f64)],
+    }
+}
+
+fn usage() -> ! {
+    eprintln!(
+        "usage: bootstrap_pump [--list] [--stage pump|drain|all] [--parts N] \
+         [--segments-per-part N] [--pages N] [--tuples-per-page N] [--columns N] \
+         [--parallelism N]"
+    );
+    std::process::exit(2)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    // nextest --all-targets lists benches by running them with --list
+    if args.iter().any(|a| a == "--list") {
+        println!("bootstrap_pump: benchmark");
+        return;
+    }
+    let mut shape = Shape::default();
+    let mut stage = "all".to_string();
+    let mut i = 0;
+    while i < args.len() {
+        let val = |s: &Option<&String>| -> usize {
+            s.and_then(|v| v.parse().ok()).unwrap_or_else(|| usage())
+        };
+        let next = args.get(i + 1);
+        match args[i].as_str() {
+            "--stage" => stage = next.cloned().unwrap_or_else(|| usage()),
+            "--parts" => shape.parts = val(&next).max(1),
+            "--segments-per-part" => shape.segments_per_part = val(&next).max(1),
+            "--pages" => shape.pages_per_segment = val(&next).max(1),
+            "--tuples-per-page" => shape.tuples_per_page = val(&next).max(1),
+            "--columns" => shape.columns = val(&next).max(1),
+            "--parallelism" => shape.parallelism = val(&next).max(1),
+            // cargo bench passes --bench through
+            "--bench" => {
+                i += 1;
+                continue;
+            }
+            _ => usage(),
+        }
+        i += 2;
+    }
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    println!(
+        "shape: {} segments x {} pages x {} tuples x {} int4 cols, {} parts, parallelism {}",
+        shape.segments(),
+        shape.pages_per_segment,
+        shape.tuples_per_page,
+        shape.columns,
+        shape.parts,
+        shape.parallelism,
+    );
+    println!(
+        "       {:.1} MiB of heap, {} tuples",
+        shape.bytes() as f64 / (1 << 20) as f64,
+        shape.tuples(),
+    );
+    if stage == "pump" || stage == "all" {
+        rt.block_on(bench_pump(shape)).print();
+    }
+    if stage == "drain" || stage == "all" {
+        rt.block_on(bench_drain(shape)).print();
+    }
+}

--- a/benches/oracle_batch.rs
+++ b/benches/oracle_batch.rs
@@ -1,0 +1,392 @@
+//! Oracle batch cost, by stage.
+//!
+//! - `frame`: the two payload-sized memory passes a request used to make, no
+//!   Postgres. One is the request copy into a second buffer the bridge
+//!   framed; the other is the zeroing pass a fresh response buffer pays
+//!   before `read_exact` overwrites it. Both scale with the batch, and
+//!   `ORACLE_BATCH_SEAL_BYTES` puts that at 32 MiB
+//! - `roundtrip`: a real shadow Postgres and a real `ENCODE_NATIVE`. Reports
+//!   what one batch costs end to end, alone and with the bridge pool
+//!   saturated, so the memory passes above have something to be a fraction
+//!   of. Also prices a column of `Literal` cells — bytes the daemon already
+//!   rendered — against building the same ClickHouse column locally
+//!
+//! ```text
+//! cargo bench --bench oracle_batch -- --stage frame --bytes 33554432
+//! cargo bench --bench oracle_batch -- --stage roundtrip --rows 100000 --workers 4
+//! ```
+//!
+//! `roundtrip` needs `initdb` on PATH and `pgext/walshadow.so` built against
+//! that major; it says so and skips otherwise.
+//!
+//! `harness = false`, so nextest lists it by answering `--list`.
+
+// Matches `walshadow-stream`, whose allocator is not glibc's. Request
+// buffers here are allocated and freed at 32 MiB, which is exactly where
+// allocators differ most
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use clickhouse_c::{Allocator, ColumnBuilder};
+use walshadow::bridge::Bridge;
+use walshadow::oracle::{Oracle, OracleCell, OracleColumnBuf, OracleRequestColumn};
+use walshadow::schema::NUMERICOID;
+use walshadow::shadow::{BridgeConf, Shadow, ShadowConfig};
+
+/// Port outside the integration suites' allocation
+const PG_PORT: u16 = 55450;
+/// Short-form numeric for 42: header 0x8000, one base-10000 digit
+fn numeric_42() -> Vec<u8> {
+    let mut out = 0x8000u16.to_le_bytes().to_vec();
+    out.extend_from_slice(&42i16.to_le_bytes());
+    out
+}
+
+/// WKT a PostGIS 2-D point renders to, ie a `Literal` cell
+const WKT: &[u8] = b"POINT(-73.987654 40.748817)";
+
+struct Args {
+    stage: String,
+    bytes: usize,
+    rows: usize,
+    workers: usize,
+    iters: usize,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            stage: "all".into(),
+            bytes: 32 << 20,
+            rows: 100_000,
+            workers: 4,
+            iters: 8,
+        }
+    }
+}
+
+fn usage() -> ! {
+    eprintln!(
+        "usage: --stage frame|roundtrip|all [--bytes N] [--rows N] [--workers N] [--iters N]"
+    );
+    std::process::exit(2);
+}
+
+/// Mean over `iters`, minus a warmup pass whose cost is first-touch
+fn timed(iters: usize, mut f: impl FnMut()) -> Duration {
+    f();
+    let started = Instant::now();
+    for _ in 0..iters {
+        f();
+    }
+    started.elapsed() / iters as u32
+}
+
+fn mib_per_s(bytes: usize, d: Duration) -> f64 {
+    bytes as f64 / (1 << 20) as f64 / d.as_secs_f64()
+}
+
+/// The two payload-sized passes a batch no longer makes
+fn bench_frame(args: &Args) {
+    let n = args.bytes;
+    let src = vec![0xa5u8; n];
+
+    // Request side, before: payload into its own buffer, then a second
+    // buffer of 4 + len the whole payload is copied into so one write_all
+    // ships it. After: cells go straight past a reserved prefix, so neither
+    // the allocation nor the copy happens
+    let copy = timed(args.iters, || {
+        let mut frame = Vec::with_capacity(5 + n);
+        frame.extend_from_slice(&[0u8; 5]);
+        frame.extend_from_slice(&src);
+        std::hint::black_box(frame.len());
+    });
+
+    // Response side: `vec![0u8; len]` zeroes bytes read_exact then
+    // overwrites. A recycled buffer read into its spare capacity pays
+    // neither the allocation nor the zeroing
+    let fresh = timed(args.iters, || {
+        let mut v = vec![0u8; n];
+        v.copy_from_slice(&src);
+        std::hint::black_box(v.len());
+    });
+    let mut scratch: Vec<u8> = Vec::with_capacity(n);
+    let recycled = timed(args.iters, || {
+        scratch.clear();
+        scratch.extend_from_slice(&src);
+        std::hint::black_box(scratch.len());
+    });
+
+    println!(
+        "frame stage, {:.0} MiB payload",
+        n as f64 / (1 << 20) as f64
+    );
+    println!(
+        "  request second buffer + copy   {:>8.3} ms  ({:.0} MiB/s)",
+        copy.as_secs_f64() * 1e3,
+        mib_per_s(n, copy),
+    );
+    println!(
+        "  response vec![0u8; len] + fill {:>8.3} ms  ({:.0} MiB/s)",
+        fresh.as_secs_f64() * 1e3,
+        mib_per_s(n, fresh),
+    );
+    println!(
+        "  response recycled + fill       {:>8.3} ms  ({:.0} MiB/s)",
+        recycled.as_secs_f64() * 1e3,
+        mib_per_s(n, recycled),
+    );
+    println!(
+        "  zeroing pass alone             {:>8.3} ms",
+        (fresh.as_secs_f64() - recycled.as_secs_f64()) * 1e3,
+    );
+}
+
+fn pg_available() -> bool {
+    Command::new("initdb")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn pgext_dir() -> Option<PathBuf> {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("pgext");
+    dir.join("walshadow.so").is_file().then_some(dir)
+}
+
+struct StopOnDrop {
+    sh: Shadow,
+}
+
+impl Drop for StopOnDrop {
+    fn drop(&mut self) {
+        let _ = self.sh.stop();
+    }
+}
+
+fn start_shadow(tmp: &tempfile::TempDir, lib_dir: PathBuf, workers: usize) -> StopOnDrop {
+    let mut cfg = ShadowConfig::new(tmp.path().join("data"), tmp.path().join("filtered"));
+    cfg.port = PG_PORT;
+    cfg.socket_dir = tmp.path().join("sock");
+    cfg.ctl_timeout = Duration::from_secs(60);
+    let mut bridge = BridgeConf::in_dir(&cfg.socket_dir);
+    bridge.library_dir = Some(lib_dir);
+    bridge.workers = workers;
+    cfg.bridge = Some(bridge);
+    std::fs::create_dir_all(&cfg.filter_out_dir).unwrap();
+    std::fs::create_dir_all(&cfg.socket_dir).unwrap();
+    let sh = Shadow::new(cfg);
+    sh.initdb().expect("initdb");
+    sh.write_base_conf().expect("write_base_conf");
+    sh.start().expect("start");
+    StopOnDrop { sh }
+}
+
+fn cells(oid: u32, body: &[u8], rows: usize, literal: bool) -> OracleColumnBuf {
+    let mut buf = OracleColumnBuf::new(oid, -1, "String");
+    for _ in 0..rows {
+        buf.push(if literal {
+            OracleCell::Literal(body.to_vec())
+        } else {
+            OracleCell::DiskRaw(body.to_vec())
+        });
+    }
+    buf
+}
+
+async fn one_batch(oracle: &Oracle, buf: &OracleColumnBuf, rows: usize) -> Duration {
+    let columns = [OracleRequestColumn {
+        ordinal: 0,
+        name: "c0",
+        target_type: "String",
+        buf,
+    }];
+    let started = Instant::now();
+    let block = oracle
+        .encode_batch(&columns, rows, Allocator::stdlib())
+        .await
+        .expect("oracle answers");
+    let elapsed = started.elapsed();
+    assert_eq!(
+        block
+            .column(0)
+            .and_then(|c| c.string())
+            .expect("string")
+            .0
+            .len(),
+        rows,
+    );
+    elapsed
+}
+
+/// Mean batch latency, `iters` batches in flight `concurrency` at a time
+async fn batches(
+    oracle: Arc<Oracle>,
+    buf: Arc<OracleColumnBuf>,
+    rows: usize,
+    iters: usize,
+    concurrency: usize,
+) -> (Duration, Duration) {
+    let started = Instant::now();
+    let mut sum = Duration::ZERO;
+    let mut left = iters;
+    while left > 0 {
+        let wave = concurrency.min(left);
+        let mut set = Vec::new();
+        for _ in 0..wave {
+            let oracle = oracle.clone();
+            let buf = buf.clone();
+            set.push(tokio::spawn(
+                async move { one_batch(&oracle, &buf, rows).await },
+            ));
+        }
+        for h in set {
+            sum += h.await.unwrap();
+        }
+        left -= wave;
+    }
+    (sum / iters as u32, started.elapsed() / iters as u32)
+}
+
+/// `ColumnBuilder::string` over the same cells, ie what a pure-`Literal`
+/// column would cost if it never left the daemon
+fn local_string_column(rows: usize, body: &[u8]) -> Duration {
+    let iters = 8;
+    timed(iters, || {
+        let mut offsets: Vec<u64> = Vec::with_capacity(rows);
+        let mut data: Vec<u8> = Vec::with_capacity(rows * body.len());
+        for _ in 0..rows {
+            data.extend_from_slice(body);
+            offsets.push(data.len() as u64);
+        }
+        let col = ColumnBuilder::string(&offsets, &data, rows).expect("string column");
+        std::hint::black_box(col.n_rows());
+    })
+}
+
+async fn bench_roundtrip(args: &Args) {
+    let Some(lib_dir) = pgext_dir() else {
+        println!("roundtrip stage: skip, pgext/walshadow.so missing (make -C pgext)");
+        return;
+    };
+    if !pg_available() {
+        println!("roundtrip stage: skip, no initdb on PATH");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let guard = start_shadow(&tmp, lib_dir, args.workers);
+    let socket = guard.sh.bridge_socket().expect("bridge configured");
+
+    let disk = Arc::new(cells(NUMERICOID, &numeric_42(), args.rows, false));
+    let literal = Arc::new(cells(NUMERICOID, WKT, args.rows, true));
+    let req_bytes = |b: &OracleColumnBuf| b.approx_size();
+
+    for workers in [1, args.workers] {
+        let bridge = Arc::new(
+            walshadow::bridge::connect_with_budget(socket, workers, Duration::from_secs(30))
+                .await
+                .expect("bridge connect"),
+        );
+        let oracle = Arc::new(Oracle::new(bridge.clone()));
+        let serial = batches(oracle.clone(), disk.clone(), args.rows, args.iters, 1).await;
+        let parallel = batches(
+            oracle.clone(),
+            disk.clone(),
+            args.rows,
+            args.iters,
+            workers.max(1),
+        )
+        .await;
+        println!(
+            "roundtrip stage, {} DiskRaw numeric cells ({:.1} MiB request), {} sockets",
+            args.rows,
+            req_bytes(&disk) as f64 / (1 << 20) as f64,
+            bridge.pool_size(),
+        );
+        println!(
+            "  one batch at a time   {:>8.2} ms/batch",
+            serial.1.as_secs_f64() * 1e3,
+        );
+        println!(
+            "  {:>2} in flight          {:>8.2} ms/batch wall, {:.2} ms latency",
+            workers,
+            parallel.1.as_secs_f64() * 1e3,
+            parallel.0.as_secs_f64() * 1e3,
+        );
+    }
+
+    // Cells the daemon already rendered, which the resolver now builds
+    // locally: this is what shipping them used to cost
+    let bridge = Arc::new(
+        walshadow::bridge::connect_with_budget(socket, 1, Duration::from_secs(30))
+            .await
+            .expect("bridge connect"),
+    );
+    let oracle = Arc::new(Oracle::new(bridge));
+    let shipped = batches(oracle, literal.clone(), args.rows, args.iters, 1).await;
+    let built = local_string_column(args.rows, WKT);
+    println!(
+        "literal column, {} cells ({:.1} MiB)",
+        args.rows,
+        req_bytes(&literal) as f64 / (1 << 20) as f64,
+    );
+    println!(
+        "  through the oracle    {:>8.2} ms/batch",
+        shipped.1.as_secs_f64() * 1e3,
+    );
+    println!(
+        "  built locally         {:>8.2} ms/batch",
+        built.as_secs_f64() * 1e3,
+    );
+}
+
+fn main() {
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    // nextest --all-targets lists benches by running them with --list
+    if argv.iter().any(|a| a == "--list") {
+        println!("oracle_batch: benchmark");
+        return;
+    }
+    let mut args = Args::default();
+    let mut i = 0;
+    while i < argv.len() {
+        let val = |s: &Option<&String>| -> usize {
+            s.and_then(|v| v.parse().ok()).unwrap_or_else(|| usage())
+        };
+        let next = argv.get(i + 1);
+        match argv[i].as_str() {
+            "--stage" => args.stage = next.cloned().unwrap_or_else(|| usage()),
+            "--bytes" => args.bytes = val(&next).max(1),
+            "--rows" => args.rows = val(&next).max(1),
+            "--workers" => args.workers = val(&next).clamp(1, 8),
+            "--iters" => args.iters = val(&next).max(1),
+            // cargo bench passes --bench through
+            "--bench" => {
+                i += 1;
+                continue;
+            }
+            _ => usage(),
+        }
+        i += 2;
+    }
+
+    if args.stage == "frame" || args.stage == "all" {
+        bench_frame(&args);
+    }
+    if args.stage == "roundtrip" || args.stage == "all" {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(bench_roundtrip(&args));
+    }
+}
+
+/// Silences the unused-import lint when only `frame` is compiled in
+#[allow(dead_code)]
+fn _bridge_type_is_used(_: &Bridge) {}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,7 @@ ENV RUSTFLAGS="-C target-feature=-crt-static"
 WORKDIR /src
 COPY Cargo.toml Cargo.lock ./
 COPY bench ./bench
+COPY benches ./benches
 COPY src ./src
 # Cache mounts persist cargo's registry/git and the target dir across builds,
 # so a source change recompiles only the changed crates, not all deps. The

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -55,11 +55,25 @@ request per insert batch
   record, using source or archived WAL; missing history stops replication
   instead of skipping it. Earlier records can still leave missing inserts or
   stale deletes
-- mapped external TOAST values or unresolved multixacts trigger whole-relation
-  `COPY` repair; inline values and unmapped external columns stay on page walk
+- mapped external TOAST values trigger streaming `COPY` reads of at most 256
+  physical row locations (CTIDs) per query, alongside backup page walk; inline
+  values and unmapped external columns stay on page walk. Tables with external
+  values in every row still require reading every such row from source
+- unresolved multixacts trigger CTID `COPY` repair after backup and window
+  replay; repair reads remain serial
+- repair output streams through bounded channels into configured inserter pool;
+  user table data never lands in shadow catalog. Unknown visibility can still
+  spill to bootstrap scratch files until transaction logs arrive
+- `--bootstrap-max-rate-kib` caps direct backup transfer and COPY repair output
+  separately, each at configured rate; concurrent rates can add together.
+  COPY cap counts binary field bytes, not source disk reads; WAL stays unthrottled
+- `--bootstrap-wind-down-secs` controls live window wait for transactions open
+  across handoff (default 5, zero skips waiting). Timeout resumes pump below
+  `end_lsn` at oldest buffered record; increasing wait reduces these rewinds
 - repair reads each physical relation with `ONLY` and rejects row-security
   filtering; source account must be able to read every row of repaired relations
-- dropping or rewriting a relation before repair fails bootstrap
+- repair locks each relation through descriptor validation and every COPY of
+  that batch, rejecting dropped, rewritten, or reshaped relations between batches
 - DDL during greenfield bootstrap is unsupported; affected relations may be
   skipped or fail repair
 - `copy` scans selected table through PostgreSQL SQL path
@@ -75,8 +89,10 @@ externally before replication window. Enable ClickHouse TOAST storage before
 initial load when complete large-value history matters
 
 Reused TOAST value IDs can leave ambiguous generations in backup chunk mirrors
-when hint bits do not prove older chunks dead. COPY repair fixes baseline rows,
-but later unchanged-pointer updates still depend on those mirrors
+when hint bits do not prove older chunks dead. CTID repair fixes baseline rows,
+but later unchanged-pointer updates still depend on those mirrors. Chunk lookup
+orders by `(ver, blkno, offnum)` for determinism, not generation correctness:
+a newer generation at a lower TID can lose when versions tie
 
 ## Not an HA system
 

--- a/pgext/faultshim.c
+++ b/pgext/faultshim.c
@@ -53,12 +53,13 @@ enum ws_op
 	WS_OP_CHMOD,
 	WS_OP_FCNTL,
 	WS_OP_CLOSE,
+	WS_OP_SETSOCKOPT,
 	WS_N_OPS
 };
 
 static const char *const ws_op_names[WS_N_OPS] = {
 	"socket", "bind", "listen", "connect", "accept",
-	"recv", "send", "chmod", "fcntl", "close"
+	"recv", "send", "chmod", "fcntl", "close", "setsockopt"
 };
 
 enum ws_action
@@ -110,6 +111,7 @@ static ssize_t (*ws_real_send) (int, const void *, size_t, int);
 static int	(*ws_real_chmod) (const char *, mode_t);
 static int	(*ws_real_fcntl) (int, int, ...);
 static int	(*ws_real_close) (int);
+static int	(*ws_real_setsockopt) (int, int, int, const void *, socklen_t);
 
 static void
 ws_die(const char *what)
@@ -148,6 +150,7 @@ ws_init(void)
 	ws_real_chmod = ws_next("chmod");
 	ws_real_fcntl = ws_next("fcntl");
 	ws_real_close = ws_next("close");
+	ws_real_setsockopt = ws_next("setsockopt");
 
 	path = getenv("WS_FAULT_STATE");
 	if (path == NULL)
@@ -445,6 +448,21 @@ chmod(const char *path, mode_t mode)
 		return -1;
 	}
 	return ws_real_chmod(path, mode);
+}
+
+int
+setsockopt(int fd, int level, int name, const void *val, socklen_t len)
+{
+	const struct ws_rule *rule;
+
+	if (!ws_hook(__builtin_return_address(0), WS_OP_SETSOCKOPT, &rule))
+		return ws_real_setsockopt(fd, level, name, val, len);
+	if (rule != NULL && rule->action == WS_ACT_FAIL)
+	{
+		errno = rule->arg;
+		return -1;
+	}
+	return ws_real_setsockopt(fd, level, name, val, len);
 }
 
 int

--- a/pgext/worker.c
+++ b/pgext/worker.c
@@ -43,9 +43,22 @@
 PG_MODULE_MAGIC;
 
 #define WS_MAX_CONNS		8
+/*
+ * Each worker serves one request at a time, so oracle throughput is one
+ * backend's conversion rate. `walshadow.bridge_workers` registers copies;
+ * worker 0 keeps the bare `socket_path` so a single-worker deployment and
+ * every catalog read are untouched, worker i listens on `socket_path.i`.
+ */
+#define WS_MAX_WORKERS		8
 #define WS_LISTEN_BACKLOG	16
 #define WS_IDLE_POLL_MS		1000
 #define WS_MAX_SCAN_OIDS	65536
+/*
+ * A 32 MiB request against default socket buffers costs hundreds of
+ * EAGAIN round trips; ask for a wide window and accept whatever the
+ * kernel grants (it halves the request and clamps to wmem_max).
+ */
+#define WS_SOCKBUF_BYTES	(4 * 1024 * 1024)
 
 /* wait-set positions, in the order ws_build_wait_set adds them */
 #define WS_POS_LATCH		0
@@ -53,10 +66,27 @@ PG_MODULE_MAGIC;
 #define WS_POS_LISTEN		2
 #define WS_POS_CONN0		3
 
+/* ... and in the per-connection io set */
+#define WS_IO_POS_LATCH		0
+#define WS_IO_POS_PM_DEATH	1
+#define WS_IO_POS_SOCKET	2
+
+/*
+ * One accepted connection. `io` is created once and its socket event mask
+ * flipped between readable and writeable, because building a fresh epoll
+ * set per EAGAIN is what a large transfer would otherwise pay for.
+ */
+typedef struct WsConn
+{
+	pgsocket	fd;
+	WaitEventSet *io;
+}			WsConn;
+
 PGDLLEXPORT void ws_worker_main(Datum main_arg);
 
 static char *ws_socket_path = NULL;
 static char *ws_database = NULL;
+static int	ws_bridge_workers = 1;
 static int	ws_io_timeout_ms = 30000;
 static int	ws_lock_timeout_ms = 1000;
 
@@ -186,20 +216,34 @@ ws_listen(const char *path)
 	return fd;
 }
 
+static WaitEventSet *
+ws_create_wait_set(int nevents)
+{
+#if PG_VERSION_NUM >= 170000
+	return CreateWaitEventSet(NULL, nevents);
+#else
+	return CreateWaitEventSet(TopMemoryContext, nevents);
+#endif
+}
+
 /*
- * Wait for `event` on one socket. `false` means the caller should abandon the
- * connection: shutdown was requested.
+ * Wait for `event` on one connection, reusing its own wait set. `false`
+ * means the caller should abandon the connection: shutdown was requested.
  */
 static bool
-ws_wait_socket(pgsocket fd, int event, long timeout_ms)
+ws_wait_conn(WsConn *conn, int event, long timeout_ms)
 {
-	int			rc;
+	WaitEvent	events[3];
+	int			nready;
+	int			i;
 
-	rc = WaitLatchOrSocket(MyLatch,
-						   WL_LATCH_SET | WL_EXIT_ON_PM_DEATH | WL_TIMEOUT | event,
-						   fd, timeout_ms, PG_WAIT_EXTENSION);
-	if (rc & WL_LATCH_SET)
+	ModifyWaitEvent(conn->io, WS_IO_POS_SOCKET, event, NULL);
+	nready = WaitEventSetWait(conn->io, timeout_ms, events,
+							  lengthof(events), PG_WAIT_EXTENSION);
+	for (i = 0; i < nready; i++)
 	{
+		if (events[i].pos != WS_IO_POS_LATCH)
+			continue;
 		ResetLatch(MyLatch);
 		CHECK_FOR_INTERRUPTS();
 		if (ConfigReloadPending)
@@ -214,10 +258,11 @@ ws_wait_socket(pgsocket fd, int event, long timeout_ms)
 }
 
 static bool
-ws_read_exact(pgsocket fd, char *buf, size_t len)
+ws_read_exact(WsConn *conn, char *buf, size_t len)
 {
 	size_t		got = 0;
 	TimestampTz deadline;
+	pgsocket	fd = conn->fd;
 
 	deadline = TimestampTzPlusMilliseconds(GetCurrentTimestamp(),
 										   ws_io_timeout_ms);
@@ -253,17 +298,18 @@ ws_read_exact(pgsocket fd, char *buf, size_t len)
 							ws_io_timeout_ms)));
 			return false;
 		}
-		if (!ws_wait_socket(fd, WL_SOCKET_READABLE, wait_ms))
+		if (!ws_wait_conn(conn, WL_SOCKET_READABLE, wait_ms))
 			return false;
 	}
 	return true;
 }
 
 static bool
-ws_write_all(pgsocket fd, const char *buf, size_t len)
+ws_write_all(WsConn *conn, const char *buf, size_t len)
 {
 	size_t		sent = 0;
 	TimestampTz deadline;
+	pgsocket	fd = conn->fd;
 
 	deadline = TimestampTzPlusMilliseconds(GetCurrentTimestamp(),
 										   ws_io_timeout_ms);
@@ -299,7 +345,7 @@ ws_write_all(pgsocket fd, const char *buf, size_t len)
 							ws_io_timeout_ms)));
 			return false;
 		}
-		if (!ws_wait_socket(fd, WL_SOCKET_WRITEABLE, wait_ms))
+		if (!ws_wait_conn(conn, WL_SOCKET_WRITEABLE, wait_ms))
 			return false;
 	}
 	return true;
@@ -467,7 +513,7 @@ ws_dispatch(StringInfo req, StringInfo resp)
  * `false` closes the connection.
  */
 static bool
-ws_serve_request(pgsocket fd)
+ws_serve_request(WsConn *conn)
 {
 	uint32		hdr;
 	uint32		len;
@@ -476,7 +522,7 @@ ws_serve_request(pgsocket fd)
 	MemoryContext oldctx;
 	bool		ok = false;
 
-	if (!ws_read_exact(fd, (char *) &hdr, sizeof(hdr)))
+	if (!ws_read_exact(conn, (char *) &hdr, sizeof(hdr)))
 		return false;
 	len = pg_ntoh32(hdr);
 
@@ -495,7 +541,7 @@ ws_serve_request(pgsocket fd)
 
 	initStringInfo(&req);
 	enlargeStringInfo(&req, (int) len);
-	if (ws_read_exact(fd, req.data, len))
+	if (ws_read_exact(conn, req.data, len))
 	{
 		req.len = (int) len;
 		req.data[len] = '\0';
@@ -506,8 +552,8 @@ ws_serve_request(pgsocket fd)
 		ws_dispatch(&req, &resp);
 
 		hdr = pg_hton32((uint32) resp.len);
-		ok = ws_write_all(fd, (char *) &hdr, sizeof(hdr)) &&
-			ws_write_all(fd, resp.data, (size_t) resp.len);
+		ok = ws_write_all(conn, (char *) &hdr, sizeof(hdr)) &&
+			ws_write_all(conn, resp.data, (size_t) resp.len);
 	}
 
 	MemoryContextSwitchTo(oldctx);
@@ -520,32 +566,54 @@ ws_serve_request(pgsocket fd)
  * ------------------------------------------------------------------------- */
 
 /*
- * Rebuilt per iteration: the wait-set API has no portable event removal, and
- * this loop is idle-dominated.
+ * The wait-set API has no portable event removal, so the set is rebuilt on
+ * a membership change and reused across every iteration in between. Under
+ * load that is one epoll set per connect/disconnect rather than per request.
  */
 static WaitEventSet *
-ws_build_wait_set(pgsocket listen_fd, const pgsocket *conns, int nconns)
+ws_build_wait_set(pgsocket listen_fd, const WsConn *conns, int nconns)
 {
-	WaitEventSet *set;
+	WaitEventSet *set = ws_create_wait_set(nconns + WS_POS_CONN0);
 	int			i;
 
-#if PG_VERSION_NUM >= 170000
-	set = CreateWaitEventSet(NULL, nconns + WS_POS_CONN0);
-#else
-	set = CreateWaitEventSet(CurrentMemoryContext, nconns + WS_POS_CONN0);
-#endif
 	AddWaitEventToSet(set, WL_LATCH_SET, PGINVALID_SOCKET, MyLatch, NULL);
 	AddWaitEventToSet(set, WL_EXIT_ON_PM_DEATH, PGINVALID_SOCKET, NULL, NULL);
 	AddWaitEventToSet(set, WL_SOCKET_READABLE, listen_fd, NULL, NULL);
 	for (i = 0; i < nconns; i++)
-		AddWaitEventToSet(set, WL_SOCKET_READABLE, conns[i], NULL, NULL);
+		AddWaitEventToSet(set, WL_SOCKET_READABLE, conns[i].fd, NULL, NULL);
 	return set;
 }
 
+/*
+ * Widen the socket buffers so a multi-megabyte frame crosses in a handful
+ * of syscalls. Advisory: a kernel that refuses leaves the default, which
+ * only costs more EAGAIN waits.
+ */
 static void
-ws_accept(pgsocket listen_fd, pgsocket *conns, int *nconns)
+ws_widen_sockbufs(pgsocket fd)
+{
+	int			want = WS_SOCKBUF_BYTES;
+
+	if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, (char *) &want, sizeof(want)) < 0 ||
+		setsockopt(fd, SOL_SOCKET, SO_SNDBUF, (char *) &want, sizeof(want)) < 0)
+		ereport(DEBUG1,
+				(errcode_for_socket_access(),
+				 errmsg("walshadow: could not widen socket buffers: %m")));
+}
+
+/*
+ * Membership generation, bumped on every accept and drop. The serve loop
+ * keys its cached wait set off this, not off nconns: an accept and a drop
+ * in the same iteration leave nconns unchanged over a different fd set,
+ * and a stale set would then poll a closed fd and miss the new one.
+ */
+static uint64 ws_conn_gen = 0;
+
+static bool
+ws_accept(pgsocket listen_fd, WsConn *conns, int *nconns)
 {
 	pgsocket	fd;
+	WsConn	   *conn;
 
 	fd = accept(listen_fd, NULL, NULL);
 	if (fd == PGINVALID_SOCKET)
@@ -554,7 +622,7 @@ ws_accept(pgsocket listen_fd, pgsocket *conns, int *nconns)
 			ereport(LOG,
 					(errcode_for_socket_access(),
 					 errmsg("walshadow: accept failed: %m")));
-		return;
+		return false;
 	}
 	if (*nconns >= WS_MAX_CONNS)
 	{
@@ -562,7 +630,7 @@ ws_accept(pgsocket listen_fd, pgsocket *conns, int *nconns)
 				(errmsg("walshadow: refusing connection, %d already open",
 						WS_MAX_CONNS)));
 		closesocket(fd);
-		return;
+		return false;
 	}
 	if (!pg_set_noblock(fd))
 	{
@@ -570,27 +638,39 @@ ws_accept(pgsocket listen_fd, pgsocket *conns, int *nconns)
 				(errcode_for_socket_access(),
 				 errmsg("walshadow: could not set client socket non-blocking: %m")));
 		closesocket(fd);
-		return;
+		return false;
 	}
-	conns[(*nconns)++] = fd;
+	ws_widen_sockbufs(fd);
+
+	conn = &conns[(*nconns)++];
+	ws_conn_gen++;
+	conn->fd = fd;
+	conn->io = ws_create_wait_set(3);
+	AddWaitEventToSet(conn->io, WL_LATCH_SET, PGINVALID_SOCKET, MyLatch, NULL);
+	AddWaitEventToSet(conn->io, WL_EXIT_ON_PM_DEATH, PGINVALID_SOCKET, NULL, NULL);
+	AddWaitEventToSet(conn->io, WL_SOCKET_READABLE, fd, NULL, NULL);
+	return true;
 }
 
 static void
-ws_drop_conn(pgsocket *conns, int *nconns, int idx)
+ws_drop_conn(WsConn *conns, int *nconns, int idx)
 {
-	closesocket(conns[idx]);
+	FreeWaitEventSet(conns[idx].io);
+	closesocket(conns[idx].fd);
 	conns[idx] = conns[--*nconns];
+	ws_conn_gen++;
 }
 
 static void
 ws_serve_loop(pgsocket listen_fd)
 {
-	pgsocket	conns[WS_MAX_CONNS];
+	WsConn		conns[WS_MAX_CONNS];
 	int			nconns = 0;
+	WaitEventSet *set = NULL;
+	uint64		set_gen = 0;
 
 	for (;;)
 	{
-		WaitEventSet *set;
 		WaitEvent	events[WS_MAX_CONNS + WS_POS_CONN0];
 		int			nready;
 		int			i;
@@ -605,10 +685,15 @@ ws_serve_loop(pgsocket listen_fd)
 		if (ShutdownRequestPending)
 			break;
 
-		set = ws_build_wait_set(listen_fd, conns, nconns);
+		if (set == NULL || set_gen != ws_conn_gen)
+		{
+			if (set != NULL)
+				FreeWaitEventSet(set);
+			set = ws_build_wait_set(listen_fd, conns, nconns);
+			set_gen = ws_conn_gen;
+		}
 		nready = WaitEventSetWait(set, WS_IDLE_POLL_MS, events,
 								  lengthof(events), PG_WAIT_EXTENSION);
-		FreeWaitEventSet(set);
 
 		for (i = 0; i < nready; i++)
 		{
@@ -631,12 +716,14 @@ ws_serve_loop(pgsocket listen_fd)
 		{
 			Assert(serve < nconns);
 			pgstat_report_activity(STATE_RUNNING, "walshadow request");
-			if (!ws_serve_request(conns[serve]))
+			if (!ws_serve_request(&conns[serve]))
 				ws_drop_conn(conns, &nconns, serve);
 			pgstat_report_activity(STATE_IDLE, NULL);
 		}
 	}
 
+	if (set != NULL)
+		FreeWaitEventSet(set);
 	while (nconns > 0)
 		ws_drop_conn(conns, &nconns, 0);
 	closesocket(listen_fd);
@@ -645,8 +732,10 @@ ws_serve_loop(pgsocket listen_fd)
 void
 ws_worker_main(Datum main_arg)
 {
+	int			idx = DatumGetInt32(main_arg);
 	pgsocket	listen_fd;
 	char		buf[32];
+	char		path[MAXPGPATH];
 
 	pqsignal(SIGTERM, SignalHandlerForShutdownRequest);
 	pqsignal(SIGHUP, SignalHandlerForConfigReload);
@@ -679,10 +768,14 @@ ws_worker_main(Datum main_arg)
 										   "walshadow request",
 										   ALLOCSET_DEFAULT_SIZES);
 
-	listen_fd = ws_listen(ws_socket_path);
+	if (idx == 0)
+		strlcpy(path, ws_socket_path, sizeof(path));
+	else
+		snprintf(path, sizeof(path), "%s.%d", ws_socket_path, idx);
+	listen_fd = ws_listen(path);
 	ereport(LOG,
 			(errmsg("walshadow bridge listening on \"%s\" (proto %d)",
-					ws_socket_path, WS_PROTO_VERSION)));
+					path, WS_PROTO_VERSION)));
 
 	ws_serve_loop(listen_fd);
 
@@ -700,6 +793,7 @@ void
 _PG_init(void)
 {
 	BackgroundWorker worker;
+	int			i;
 
 	/*
 	 * Worker registration and its postmaster-scoped GUCs are only legal
@@ -736,20 +830,33 @@ _PG_init(void)
 							1000, 0, INT_MAX,
 							PGC_POSTMASTER, GUC_UNIT_MS,
 							NULL, NULL, NULL);
+	DefineCustomIntVariable("walshadow.bridge_workers",
+							"Bridge workers to register.",
+							"Worker 0 listens on socket_path, worker i on "
+							"socket_path.i. Each serves one request at a "
+							"time, so this bounds concurrent decode.",
+							&ws_bridge_workers,
+							1, 1, WS_MAX_WORKERS,
+							PGC_POSTMASTER, 0,
+							NULL, NULL, NULL);
 
 	MarkGUCPrefixReserved("walshadow");
 
 	if (ws_socket_path[0] == '\0')
 		return;
 
-	memset(&worker, 0, sizeof(worker));
-	worker.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
-	/* Catalog reads need a database connection, so not before consistency */
-	worker.bgw_start_time = BgWorkerStart_ConsistentState;
-	worker.bgw_restart_time = 5;
-	strlcpy(worker.bgw_library_name, "walshadow", BGW_MAXLEN);
-	strlcpy(worker.bgw_function_name, "ws_worker_main", BGW_MAXLEN);
-	strlcpy(worker.bgw_name, "walshadow bridge", BGW_MAXLEN);
-	strlcpy(worker.bgw_type, "walshadow bridge", BGW_MAXLEN);
-	RegisterBackgroundWorker(&worker);
+	for (i = 0; i < ws_bridge_workers; i++)
+	{
+		memset(&worker, 0, sizeof(worker));
+		worker.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
+		/* Catalog reads need a database connection, so not before consistency */
+		worker.bgw_start_time = BgWorkerStart_ConsistentState;
+		worker.bgw_restart_time = 5;
+		worker.bgw_main_arg = Int32GetDatum(i);
+		strlcpy(worker.bgw_library_name, "walshadow", BGW_MAXLEN);
+		strlcpy(worker.bgw_function_name, "ws_worker_main", BGW_MAXLEN);
+		snprintf(worker.bgw_name, BGW_MAXLEN, "walshadow bridge %d", i);
+		strlcpy(worker.bgw_type, "walshadow bridge", BGW_MAXLEN);
+		RegisterBackgroundWorker(&worker);
+	}
 }

--- a/plans/performance.md
+++ b/plans/performance.md
@@ -29,7 +29,7 @@ Check process uptime and cumulative series remain valid across phase changes
 
 | Measured limit | Candidate |
 |---|---|
-| Bootstrap page decode cannot feed inserters | Move page decode out of shared sink into bounded workers |
+| Bootstrap page decode cannot feed inserters | Add decode workers behind the per-entry page walk |
 | ClickHouse round trips leave workers idle | Tune inserter count and batch size within memory and part-count budgets |
 | One hot table saturates batcher | Shard by stable row key, measure extra part cost |
 | Catalog-boundary holds dominate | Evaluate [replay callback](custom_rmgr.md) |
@@ -52,11 +52,12 @@ cost before changing framing or allocation
 
 ## Bootstrap worker shape
 
-Move expensive tuple decode out of `PageWalkSink::chunk` only after profiling
-shared-sink serialization. Keep page framing and slot walk in producer; submit
-owned tuple bytes, full physical locator, load boundary, and completion identity
-to bounded workers. Reuse decode/resolve/route logic where job semantics match
-WAL jobs already containing decoded heaps need not share bootstrap wire shape
+Each tap entry decodes its own segment, so add decode workers only after
+profiling shows per-entry decode rather than source concurrency as the limit
+Keep page framing and slot walk in producer; submit owned tuple bytes, full
+physical locator, load boundary, and completion identity to bounded workers
+Reuse decode/resolve/route logic where job semantics match. WAL jobs already
+containing decoded heaps need not share bootstrap wire shape
 
 Assign sequence and expected completion counts before worker reordering. Current
 [bootstrap drain](../src/emit/pipeline/bootstrap.rs) infers sequence boundaries

--- a/src/backfill/backfill_bootstrap.rs
+++ b/src/backfill/backfill_bootstrap.rs
@@ -27,7 +27,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_postgres::Client;
 use walrus::pg::walparser::{Oid, RelFileNode};
@@ -38,10 +38,18 @@ use crate::backfill::backup_page_walk::{
 use crate::backfill::backup_sink::{
     CatalogFilenodes, DiskLanderSink, DiskLanderStats, MultiplexSink,
 };
-use crate::backfill::backup_source::{BackupSink, BackupSource, EndInfo, StartInfo};
+use crate::backfill::backup_source::{BackupSink, BackupSource, EndInfo, PumpStats, StartInfo};
 use crate::decode::decoder_sink::TupleObserver;
 use crate::schema::{RelAttr, RelDescriptor, RelName, ReplIdent};
-use ahash::HashSet;
+
+/// Live counter handles, readable while the pump runs. The pump publishes
+/// into these, so a caller ticks `/metrics` off them instead of waiting for
+/// [`BootstrapOutcome`]
+#[derive(Debug, Clone, Default)]
+pub struct BootstrapProgress {
+    pub pump: Arc<PumpStats>,
+    pub page_walk: Arc<PageWalkStats>,
+}
 
 #[derive(Debug, Clone)]
 pub struct BootstrapConfig {
@@ -52,9 +60,10 @@ pub struct BootstrapConfig {
     /// `rel_node < 16384` bootstrap rule misses. Empty in greenfield where
     /// seed runs after bootstrap
     pub catalog_filenodes: CatalogFilenodes,
-    /// Main filenodes whose pages nothing downstream keeps, declined
-    /// before decode. See [`PageWalkSink::with_skip_filenodes`]
-    pub skip_filenodes: HashSet<(Oid, Oid)>,
+    /// Filenodes worth decoding: mapped relations plus their TOAST heaps.
+    /// `None` taps every seeded relation
+    pub tap_filenodes: Option<Arc<ahash::HashSet<(Oid, Oid)>>>,
+    pub progress: BootstrapProgress,
 }
 
 impl BootstrapConfig {
@@ -62,7 +71,8 @@ impl BootstrapConfig {
         Self {
             shadow_data_dir,
             catalog_filenodes: CatalogFilenodes::new(),
-            skip_filenodes: HashSet::default(),
+            tap_filenodes: None,
+            progress: BootstrapProgress::default(),
         }
     }
 
@@ -71,8 +81,10 @@ impl BootstrapConfig {
         self
     }
 
-    pub fn with_skip_filenodes(mut self, skip: HashSet<(Oid, Oid)>) -> Self {
-        self.skip_filenodes = skip;
+    /// Decline every filenode outside `set` at `begin`, so unmapped
+    /// relations drain off the wire without a page decode
+    pub fn with_tap_filenodes(mut self, set: Arc<ahash::HashSet<(Oid, Oid)>>) -> Self {
+        self.tap_filenodes = Some(set);
         self
     }
 }
@@ -81,8 +93,60 @@ impl BootstrapConfig {
 pub struct BootstrapOutcome {
     pub start: StartInfo,
     pub end: EndInfo,
-    pub disk: DiskLanderStats,
-    pub page_walk: PageWalkStats,
+    pub disk: Arc<DiskLanderStats>,
+    pub page_walk: Arc<PageWalkStats>,
+    pub pump: Arc<PumpStats>,
+}
+
+/// Filenodes worth page-walking: main files of relations `walked` accepts,
+/// plus the TOAST heap of every relation `routed` accepts. `begin` declines
+/// everything else, so an unreplicated relation's bytes drain off the wire
+/// without a page decode.
+///
+/// The two predicates differ on initial-load opt-outs: their rows never walk,
+/// but their CDC updates can carry unchanged external pointers, and those
+/// resolve only against a mirror the chunk pages seeded.
+///
+/// `None` disables the filter: a routed relation whose `reltoastrelid` the
+/// seed did not resolve would otherwise have its TOAST heap skipped, and its
+/// referring rows would fail resolution mid-drain. Fail open, walk everything.
+pub fn tap_filenode_set(
+    catalog: &CatalogMap,
+    routed: impl Fn(&RelName) -> bool,
+    walked: impl Fn(&RelName) -> bool,
+) -> Option<ahash::HashSet<(Oid, Oid)>> {
+    use ahash::HashSetExt;
+    let by_oid: ahash::HashMap<Oid, (Oid, Oid)> = catalog
+        .descriptors()
+        .map(|d| (d.oid, (d.rfn.db_node, d.rfn.rel_node)))
+        .collect();
+    let mut set = ahash::HashSet::new();
+    for d in catalog.descriptors() {
+        if !routed(&d.rel_name) {
+            continue;
+        }
+        if walked(&d.rel_name) {
+            set.insert((d.rfn.db_node, d.rfn.rel_node));
+        }
+        if d.toast_oid == 0 {
+            continue;
+        }
+        match by_oid.get(&d.toast_oid) {
+            Some(&key) => {
+                set.insert(key);
+            }
+            None => {
+                tracing::warn!(
+                    target: "walshadow::bootstrap",
+                    relation = %d.rel_name,
+                    toast_oid = d.toast_oid,
+                    "toast heap absent from the catalog seed, walking every relation",
+                );
+                return None;
+            }
+        }
+    }
+    Some(set)
 }
 
 /// Spawn pump on a tokio task, yield `(rx, handle)` so caller drains
@@ -112,12 +176,12 @@ pub fn spawn_greenfield_bootstrap(
     // count + skip (disabled mode, values NULL/default-filled).
     store_toast: bool,
 ) -> (
-    mpsc::Receiver<BackfillTuple>,
+    mpsc::Receiver<Vec<BackfillTuple>>,
     JoinHandle<Result<BootstrapOutcome>>,
 ) {
     // Bounded: PageWalkSink::chunk awaits a free slot, so a slow drain
     // backpressures the source instead of buffering the whole relation
-    let (tx, rx) = mpsc::channel::<BackfillTuple>(BOOTSTRAP_TUPLE_CHANNEL_CAP);
+    let (tx, rx) = mpsc::channel::<Vec<BackfillTuple>>(BOOTSTRAP_TUPLE_CHANNEL_CAP);
     let pump = tokio::spawn(async move {
         tokio::fs::create_dir_all(&cfg.shadow_data_dir)
             .await
@@ -129,47 +193,31 @@ pub fn spawn_greenfield_bootstrap(
             })?;
 
         let lander = DiskLanderSink::new(cfg.catalog_filenodes);
-        let page_walk =
-            PageWalkSink::new(catalog_map, tx, store_toast).with_skip_filenodes(cfg.skip_filenodes);
-        let mux = MultiplexSink::new(lander, page_walk);
-
-        // Keep typed Arc beside erased trait-object Arc to recover stats
-        // after source completes; both point at the same Mutex
-        let typed: Arc<Mutex<MultiplexSink<PageWalkSink>>> = Arc::new(Mutex::new(mux));
-        let erased: Arc<Mutex<dyn BackupSink>> = typed.clone();
+        let disk = lander.stats.clone();
+        let mut page_walk = PageWalkSink::new(catalog_map, tx, store_toast)
+            .with_stats(cfg.progress.page_walk.clone());
+        if let Some(set) = cfg.tap_filenodes.clone() {
+            page_walk = page_walk.with_tap_filenodes(set);
+        }
+        // Counters are atomics on shared handles, so the sink never has to
+        // come back out of the source
+        let sink: Arc<dyn BackupSink> = Arc::new(MultiplexSink::new(lander, page_walk));
 
         let data_dir = cfg.shadow_data_dir.clone();
         let (start, end) = source
-            .run(data_dir, erased)
+            .run(data_dir, sink, cfg.progress.pump.clone())
             .await
             .context("bootstrap: source.run")?;
 
-        // Source dropped its `erased` clone on return, so `try_unwrap`
-        // succeeds unless a clone leaked; else read through the Mutex
-        let outcome = match Arc::try_unwrap(typed) {
-            Ok(mtx) => {
-                let mux = mtx.into_inner();
-                let (lander, page_walk) = mux.into_inner();
-                // Dropping `page_walk` closes the channel sender in `out_tx`,
-                // so a concurrent drain observes channel-close on next recv
-                BootstrapOutcome {
-                    start,
-                    end,
-                    disk: lander.stats,
-                    page_walk: page_walk.stats,
-                }
-            }
-            Err(arc) => {
-                let g = arc.lock().await;
-                BootstrapOutcome {
-                    start,
-                    end,
-                    disk: g.lander_stats().clone(),
-                    page_walk: PageWalkStats::default(),
-                }
-            }
-        };
-        Ok(outcome)
+        // Dropping the last sink Arc closes the channel sender in `out_tx`,
+        // so a concurrent drain observes channel-close on next recv
+        Ok(BootstrapOutcome {
+            start,
+            end,
+            disk,
+            page_walk: cfg.progress.page_walk.clone(),
+            pump: cfg.progress.pump.clone(),
+        })
     });
     (rx, pump)
 }
@@ -187,8 +235,8 @@ pub async fn run_greenfield_bootstrap(
     let (mut rx, pump) = spawn_greenfield_bootstrap(cfg, source, catalog_map, store_toast);
     let drain = tokio::spawn(async move {
         let mut out = Vec::new();
-        while let Some(t) = rx.recv().await {
-            out.push(t);
+        while let Some(slab) = rx.recv().await {
+            out.extend(slab);
         }
         out
     });
@@ -213,28 +261,30 @@ pub async fn run_greenfield_bootstrap(
 /// Final `on_xact_end` after channel-close lets the transitional emitter
 /// release CH state before the daemon swaps to the shadow-catalog emitter.
 pub async fn drain_backfill<O: TupleObserver + ?Sized>(
-    mut rx: mpsc::Receiver<BackfillTuple>,
+    mut rx: mpsc::Receiver<Vec<BackfillTuple>>,
     observer: &mut O,
 ) -> Result<u64> {
     let mut shipped: u64 = 0;
     let mut last_rfn: Option<RelFileNode> = None;
     let mut last_lsn: u64 = 0;
-    while let Some(tuple) = rx.recv().await {
-        if let Some(prev) = last_rfn
-            && prev != tuple.rfn
-        {
-            observer.on_xact_end(last_lsn).await.map_err(|e| {
-                anyhow::anyhow!("bootstrap drain: emitter rejected mid-table xact end: {e}")
-            })?;
+    while let Some(slab) = rx.recv().await {
+        for tuple in slab {
+            if let Some(prev) = last_rfn
+                && prev != tuple.rfn
+            {
+                observer.on_xact_end(last_lsn).await.map_err(|e| {
+                    anyhow::anyhow!("bootstrap drain: emitter rejected mid-table xact end: {e}")
+                })?;
+            }
+            last_rfn = Some(tuple.rfn);
+            last_lsn = tuple.source_lsn;
+            let committed = tuple.into_committed_insert();
+            observer
+                .on_tuple(&committed)
+                .await
+                .map_err(|e| anyhow::anyhow!("bootstrap drain: emitter rejected tuple: {e}"))?;
+            shipped += 1;
         }
-        last_rfn = Some(tuple.rfn);
-        last_lsn = tuple.source_lsn;
-        let committed = tuple.into_committed_insert();
-        observer
-            .on_tuple(&committed)
-            .await
-            .map_err(|e| anyhow::anyhow!("bootstrap drain: emitter rejected tuple: {e}"))?;
-        shipped += 1;
     }
     observer
         .on_xact_end(last_lsn)
@@ -249,6 +299,16 @@ pub async fn drain_backfill<O: TupleObserver + ?Sized>(
 /// filenode. Wrap in [`seed_in_snapshot`] when DDL quiescence isn't external.
 /// Filenode 0 (partitioned parents, views) has no heap to page-walk; skipped.
 pub async fn seed_catalog_from_source(client: &Client) -> Result<CatalogMap> {
+    seed_catalog(client, None).await
+}
+
+/// Re-read one relation for descriptor validation. Silent: repair calls it
+/// once per locked batch, not once per pass
+pub(crate) async fn seed_relation_from_source(client: &Client, oid: u32) -> Result<CatalogMap> {
+    seed_catalog(client, Some(oid)).await
+}
+
+async fn seed_catalog(client: &Client, oid: Option<u32>) -> Result<CatalogMap> {
     let db_oid = current_database_oid(client).await?;
     let rows = client
         .query(
@@ -267,8 +327,9 @@ pub async fn seed_catalog_from_source(client: &Client) -> Result<CatalogMap> {
                 coalesce(pg_relation_filenode(c.oid), 0)::oid \
              FROM pg_class c \
              JOIN pg_namespace n ON n.oid = c.relnamespace \
-             WHERE c.oid >= 16384 AND c.relkind IN ('r', 't', 'm')",
-            &[],
+             WHERE c.oid >= 16384 AND c.relkind IN ('r', 't', 'm') \
+               AND ($1::oid IS NULL OR c.oid = $1)",
+            &[&oid],
         )
         .await
         .context("bootstrap: enumerate user relations on source")?;
@@ -309,11 +370,13 @@ pub async fn seed_catalog_from_source(client: &Client) -> Result<CatalogMap> {
         };
         map.insert(Arc::new(desc));
     }
-    tracing::info!(
-        target = "walshadow::backfill_bootstrap",
-        relations = map.len(),
-        "catalog seed populated"
-    );
+    if oid.is_none() {
+        tracing::info!(
+            target = "walshadow::backfill_bootstrap",
+            relations = map.len(),
+            "catalog seed populated"
+        );
+    }
     Ok(map)
 }
 
@@ -421,27 +484,17 @@ mod tests {
         async fn run(
             self: Box<Self>,
             data_dir: PathBuf,
-            sink: Arc<Mutex<dyn BackupSink>>,
+            sink: Arc<dyn BackupSink>,
+            stats: Arc<PumpStats>,
         ) -> Result<(StartInfo, EndInfo)> {
-            {
-                let mut g = sink.lock().await;
-                g.start(&self.start).await?;
-            }
-            for (i, (meta, body)) in self.files.iter().enumerate() {
+            sink.start(&self.start).await?;
+            let target =
+                crate::backfill::backup_source::PumpTarget::new(data_dir, sink.clone(), stats);
+            for (meta, body) in self.files.iter() {
                 let mut cur: &[u8] = body;
-                crate::backfill::backup_source::pump_entry(
-                    &mut cur,
-                    meta,
-                    &data_dir,
-                    &sink,
-                    crate::backfill::backup_source::EntryId(i as u64),
-                )
-                .await?;
+                crate::backfill::backup_source::pump_entry(&mut cur, meta, &target).await?;
             }
-            {
-                let mut g = sink.lock().await;
-                g.finish(&self.end).await?;
-            }
+            sink.finish(&self.end).await?;
             Ok((self.start.clone(), self.end.clone()))
         }
     }
@@ -534,14 +587,14 @@ mod tests {
     async fn drain_backfill_synthesises_inserts_into_observer() {
         use crate::decode::decoder_sink::CollectingTupleObserver;
 
-        let (tx, rx) = mpsc::channel::<BackfillTuple>(64);
+        let (tx, rx) = mpsc::channel::<Vec<BackfillTuple>>(64);
         let rfn = RelFileNode {
             spc_node: 1663,
             db_node: 5,
             rel_node: 16400,
         };
         for v in 0..3 {
-            tx.send(BackfillTuple {
+            tx.send(vec![BackfillTuple {
                 rfn,
                 xid: 100 + v,
                 xmax: 0,
@@ -552,7 +605,7 @@ mod tests {
                 columns: vec![Some(crate::decode::heap_decoder::ColumnValue::Int4(
                     v as i32,
                 ))],
-            })
+            }])
             .await
             .unwrap();
         }
@@ -620,9 +673,9 @@ mod tests {
             db_node: 5,
             rel_node: 16400,
         };
-        let (tx, rx) = mpsc::channel::<BackfillTuple>(64);
+        let (tx, rx) = mpsc::channel::<Vec<BackfillTuple>>(64);
         for v in 0..4u32 {
-            tx.send(BackfillTuple {
+            tx.send(vec![BackfillTuple {
                 rfn,
                 xid: v,
                 xmax: 0,
@@ -633,7 +686,7 @@ mod tests {
                 columns: vec![Some(crate::decode::heap_decoder::ColumnValue::Int4(
                     v as i32,
                 ))],
-            })
+            }])
             .await
             .unwrap();
         }
@@ -651,7 +704,7 @@ mod tests {
     async fn drain_backfill_calls_on_xact_end_even_on_empty_channel() {
         // Sender dropped without a tuple; `on_xact_end` still fires so the
         // transitional emitter's INSERT cleanup runs unconditionally
-        let (tx, rx) = mpsc::channel::<BackfillTuple>(64);
+        let (tx, rx) = mpsc::channel::<Vec<BackfillTuple>>(64);
         drop(tx);
         let mut obs = CountingObserver::default();
         let shipped = drain_backfill(rx, &mut obs).await.unwrap();

--- a/src/backfill/backup_backfill.rs
+++ b/src/backfill/backup_backfill.rs
@@ -53,12 +53,11 @@ use crate::backfill::backup_page_walk::{
     BOOTSTRAP_TUPLE_CHANNEL_CAP, BackfillTuple, CatalogMap, PageWalkSink,
 };
 use crate::backfill::backup_sentinel::build_lsn_pair;
-use crate::backfill::backup_source::{BackupSink, BackupSource};
+use crate::backfill::backup_source::{BackupSink, BackupSource, PumpStats};
 use crate::backfill::backup_source_direct::DirectSource;
 use crate::backfill::backup_source_object_store::ObjectStoreSource;
 use crate::backfill::spool::{DEFERRED_SPOOL_MEM_MAX, DeferredSpool};
-use crate::backfill::visibility_gate::{GateStats, Undecidable, resolve_phase, stream_phase};
-use crate::backfill::visibility_repair::PendingSet;
+use crate::backfill::visibility_gate::{GateOutput, GateStats, resolve_phase, stream_phase};
 use crate::backfill::wal_replay::{
     ReplayStats, ReplayTargets, WalReplayInputs, WalReplaySink, pump_segments_through,
 };
@@ -305,14 +304,15 @@ async fn walk_and_ship(
 
     let pg_xact = Arc::new(std::sync::Mutex::new(PgXactAccum::new()));
     let pg_multixact = Arc::new(std::sync::Mutex::new(PgMultiXactAccum::new()));
-    let (walk_tx, walk_rx) = mpsc::channel::<BackfillTuple>(BOOTSTRAP_TUPLE_CHANNEL_CAP);
-    let (gated_tx, gated_rx) = mpsc::channel::<BackfillTuple>(BOOTSTRAP_TUPLE_CHANNEL_CAP);
+    let (walk_tx, walk_rx) = mpsc::channel::<Vec<BackfillTuple>>(BOOTSTRAP_TUPLE_CHANNEL_CAP);
+    let (gated_tx, gated_rx) = mpsc::channel::<Vec<BackfillTuple>>(BOOTSTRAP_TUPLE_CHANNEL_CAP);
 
-    let sink = PageWalkSink::new(filter.clone(), walk_tx, store_toast)
-        .with_pg_xact_accum(pg_xact.clone())
-        .with_pg_multixact_accum(pg_multixact.clone())
-        .with_lsn_overrides(lsn_overrides);
-    let erased: Arc<Mutex<dyn BackupSink>> = Arc::new(Mutex::new(sink));
+    let sink: Arc<dyn BackupSink> = Arc::new(
+        PageWalkSink::new(filter.clone(), walk_tx, store_toast)
+            .with_pg_xact_accum(pg_xact.clone())
+            .with_pg_multixact_accum(pg_multixact.clone())
+            .with_lsn_overrides(lsn_overrides),
+    );
 
     // data_dir is never written: PageWalkSink only Taps/Skips
     let data_dir = ctx.scratch_dir.join("void");
@@ -338,12 +338,12 @@ async fn walk_and_ship(
     let drain = tokio::spawn(bootstrap::drain(
         gated_rx,
         filter,
-        ctx.mapping.clone(),
+        ctx.mapping.snapshot().await,
         tail.msg_tx.clone(),
         tail.ack.clone(),
         ctx.stats.clone(),
         resolver.clone(),
-        DeferredSpool::new(toast_spool_path, DEFERRED_SPOOL_MEM_MAX),
+        Some(DeferredSpool::new(toast_spool_path, DEFERRED_SPOOL_MEM_MAX)),
         ctx.emitter.row_policy(),
         ctx.config_rx.as_ref().map(|rx| rx.borrow().clone()),
         HashSet::new(),
@@ -353,7 +353,7 @@ async fn walk_and_ship(
     // against a complete pg_xact accum; a failed source drops the sender
     // and the gate discards them instead
     let run_res = source
-        .run(data_dir, erased)
+        .run(data_dir, sink, Arc::new(PumpStats::default()))
         .await
         .context("backup_backfill: source.run");
     if run_res.is_ok() {
@@ -434,8 +434,8 @@ async fn walk_and_ship(
 /// Run visibility gate and track `pg_xact` segments
 #[allow(clippy::too_many_arguments)]
 async fn gate_task(
-    mut rx: mpsc::Receiver<BackfillTuple>,
-    tx: mpsc::Sender<BackfillTuple>,
+    mut rx: mpsc::Receiver<Vec<BackfillTuple>>,
+    tx: mpsc::Sender<Vec<BackfillTuple>>,
     filter: CatalogMap,
     pg_xact: Arc<std::sync::Mutex<PgXactAccum>>,
     pg_multixact: Arc<std::sync::Mutex<PgMultiXactAccum>>,
@@ -445,12 +445,10 @@ async fn gate_task(
 ) -> Result<(GateStats, usize), String> {
     let mut stats = GateStats::default();
     // Per-table loads abort on unprovable tuples
-    let mut no_pending = PendingSet::empty();
     stream_phase(
         &mut rx,
-        &tx,
+        &GateOutput::Rows(&tx),
         &filter,
-        &mut no_pending,
         &mut deferred,
         &mut stats,
     )
@@ -465,7 +463,7 @@ async fn gate_task(
     let multi = std::mem::take(&mut *pg_multixact.lock().expect("pg_multixact accum lock"));
     let segments = accum.segment_count();
     let view = PgXactView::new(&accum, &patch).with_multixact(&multi);
-    resolve_phase(deferred, &view, &tx, Undecidable::Abort, &mut stats).await?;
+    resolve_phase(deferred, &view, &GateOutput::Rows(&tx), &mut stats).await?;
     Ok((stats, segments))
 }
 
@@ -1230,30 +1228,30 @@ mod tests {
 
         // Hinted-committed: passes through immediately
         walk_tx
-            .send(tuple(
+            .send(vec![tuple(
                 16400,
                 100,
                 0,
                 HEAP_XMIN_COMMITTED | HEAP_XMAX_INVALID,
-            ))
+            )])
             .await
             .unwrap();
         // Hinted-aborted: gated
         walk_tx
-            .send(tuple(16400, 101, 0, HEAP_XMIN_INVALID))
+            .send(vec![tuple(16400, 101, 0, HEAP_XMIN_INVALID)])
             .await
             .unwrap();
         // Unhinted, gap-committed writer: deferred, then emitted via patch
-        walk_tx.send(tuple(16400, 500, 0, 0)).await.unwrap();
+        walk_tx.send(vec![tuple(16400, 500, 0, 0)]).await.unwrap();
         // Unhinted, gap-aborted writer: deferred, then gated via patch
-        walk_tx.send(tuple(16400, 600, 0, 0)).await.unwrap();
+        walk_tx.send(vec![tuple(16400, 600, 0, 0)]).await.unwrap();
         drop(walk_tx);
         walk_ok_tx.send(()).unwrap();
 
         let (stats, _segments) = gate.await.unwrap().unwrap();
         let mut got = Vec::new();
         while let Some(t) = gated_rx.recv().await {
-            got.push(t.xid);
+            got.extend(t.iter().map(|x| x.xid));
         }
         assert_eq!(got, [100, 500]);
         assert_eq!(stats.emitted, 2);
@@ -1294,23 +1292,23 @@ mod tests {
 
         // Hinted-committed: routed before the failure, stays flushed
         walk_tx
-            .send(tuple(
+            .send(vec![tuple(
                 16400,
                 100,
                 0,
                 HEAP_XMIN_COMMITTED | HEAP_XMAX_INVALID,
-            ))
+            )])
             .await
             .unwrap();
         // Unhinted: deferred, must be discarded
-        walk_tx.send(tuple(16400, 500, 0, 0)).await.unwrap();
+        walk_tx.send(vec![tuple(16400, 500, 0, 0)]).await.unwrap();
         drop(walk_tx);
         drop(walk_ok_tx);
 
         let (stats, _segments) = gate.await.unwrap().unwrap();
         let mut got = Vec::new();
         while let Some(t) = gated_rx.recv().await {
-            got.push(t.xid);
+            got.extend(t.iter().map(|x| x.xid));
         }
         assert_eq!(got, [100], "deferred tuple not emitted");
         assert_eq!(stats.emitted, 1);
@@ -1359,12 +1357,12 @@ mod tests {
         ));
 
         walk_tx
-            .send(tuple(
+            .send(vec![tuple(
                 16400,
                 100,
                 10,
                 HEAP_XMIN_COMMITTED | HEAP_XMAX_IS_MULTI,
-            ))
+            )])
             .await
             .unwrap();
         drop(walk_tx);
@@ -1399,12 +1397,12 @@ mod tests {
         ));
 
         walk_tx
-            .send(tuple(
+            .send(vec![tuple(
                 16400,
                 100,
                 10,
                 HEAP_XMIN_COMMITTED | HEAP_XMAX_IS_MULTI,
-            ))
+            )])
             .await
             .unwrap();
         drop(walk_tx);

--- a/src/backfill/backup_page_walk.rs
+++ b/src/backfill/backup_page_walk.rs
@@ -14,6 +14,8 @@
 
 use std::io;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 use async_trait::async_trait;
 use thiserror::Error;
@@ -21,7 +23,7 @@ use tokio::sync::mpsc;
 use walrus::pg::walparser::{Oid, RelFileNode};
 
 use crate::backfill::backup_source::{
-    BackupSink, EndInfo, EntryId, FileAction, FileKind, FileMeta, StartInfo,
+    BackupSink, EntrySink, FileAction, FileKind, FileMeta, StartInfo,
 };
 use crate::backfill::pg_path::{BaseRelFile, RelFork, parse_base_path};
 use crate::decode::heap_decoder::{
@@ -45,11 +47,16 @@ pub const LP_NORMAL: u8 = 1;
 /// `pg_toast` regnamespace; TOAST tables ship as `pg_toast_<relid>`
 pub const PG_TOAST_NS: &str = "pg_toast";
 
-/// Bootstrap tuple channel depth. Small + bounded so a saturated CH
-/// inserter parks the page walk (and its source fetch) rather than
-/// buffering a whole relation in RAM. Just deep enough to absorb a
-/// page's worth of tuples without thrashing wakeups.
-pub const BOOTSTRAP_TUPLE_CHANNEL_CAP: usize = 256;
+/// Body bytes a segment accumulates before its complete pages walk. Sets
+/// the `spawn_blocking` grain and, with the channel depth, the pages in
+/// flight; 16 pages decode in well under a millisecond, so the hop cost
+/// amortizes without pinning much heap.
+pub const SLAB_BYTES: usize = 16 * PAGE_BYTES;
+/// Bootstrap tuple channel depth, in slabs. Small + bounded so a saturated
+/// CH inserter parks the page walk (and its source fetch) rather than
+/// buffering a whole relation in RAM. `SLAB_BYTES * CAP` bounds the heap
+/// payload in flight per concurrent segment.
+pub const BOOTSTRAP_TUPLE_CHANNEL_CAP: usize = 8;
 
 #[derive(Debug, Error)]
 pub enum PageWalkError {
@@ -77,8 +84,7 @@ pub struct BackfillTuple {
     /// `t_xmin`; sequencing not load-bearing, every backfill row shares
     /// the same `_lsn = start_lsn`
     pub xid: u32,
-    /// `t_xmax`; read with `infomask` by the backfill visibility gate
-    /// ([`crate::decode::visibility`]), ignored on the greenfield path
+    /// `t_xmax`, read with `infomask` by bootstrap visibility gate
     pub xmax: u32,
     /// `t_infomask` hint bits
     pub infomask: u16,
@@ -92,6 +98,15 @@ pub struct BackfillTuple {
 }
 
 impl BackfillTuple {
+    pub fn has_mapped_external(&self, mapping: &crate::mapping::TableMapping) -> bool {
+        mapping.columns.iter().any(|c| {
+            usize::try_from(i32::from(c.src_attnum) - 1)
+                .ok()
+                .and_then(|i| self.columns.get(i))
+                .is_some_and(|v| matches!(v, Some(ColumnValue::ExternalToast(_))))
+        })
+    }
+
     /// start_lsn rides as both source_lsn and commit_lsn so
     /// ReplacingMergeTree(_lsn) collapses duplicates the WAL decoder
     /// re-emits for records in [start_lsn, end_lsn]
@@ -155,25 +170,62 @@ impl CatalogMap {
     }
 }
 
-/// Per-pump counters, operator-visible
-#[derive(Debug, Default, Clone)]
-pub struct PageWalkStats {
-    pub files_seen: u64,
-    pub files_walked: u64,
-    /// Filenode absent from catalog map, typically a race against the seed
-    pub files_skipped_unknown_filenode: u64,
-    /// Main files the caller declined up front: relations whose rows the
-    /// drain or visibility repair would replace
-    pub files_skipped_by_caller: u64,
-    pub toast_files_observed: u64,
+crate::atomic_stats! {
+    /// Per-pump counters, operator-visible. Atomic so per-entry walkers
+    /// share one handle instead of funnelling through the sink lock
+    pub struct PageWalkStats {
+        pub files_seen,
+        pub files_walked,
+        /// Filenode absent from catalog map, typically a race against the seed
+        pub files_skipped_unknown_filenode,
+        /// Filenode outside the mapped set, declined before any page decode
+        pub files_skipped_unmapped,
+        pub toast_files_observed,
+        pub pages_walked,
+        pub slots_seen,
+        pub tuples_emitted,
+        pub tuples_skipped_lp_flag,
+        pub tuples_skipped_truncated,
+        /// Trailing partial-page bytes; PG heap files are page-aligned so
+        /// nonzero is anomalous
+        pub tail_bytes_dropped,
+        /// `PageWalker::walk_page` CPU, decode included
+        pub decode_nanos,
+        /// Blocked on a free tuple-channel slot: the bootstrap
+        /// backpressure point, so this is emitter drain time seen by the walk
+        pub channel_block_nanos,
+    }
+}
+
+/// Plain tally one `walk_page` fills, published into [`PageWalkStats`] once
+/// per slab. Per-tuple `fetch_add` on a line the reader task also touches
+/// (the shared `Arc`'s refcount sits in the same allocation) costs more
+/// than the decode it counts
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PageWalkTally {
     pub pages_walked: u64,
     pub slots_seen: u64,
     pub tuples_emitted: u64,
     pub tuples_skipped_lp_flag: u64,
     pub tuples_skipped_truncated: u64,
-    /// Trailing partial-page bytes; PG heap files are page-aligned so
-    /// nonzero is anomalous
-    pub tail_bytes_dropped: u64,
+}
+
+impl PageWalkTally {
+    pub fn publish(&self, stats: &PageWalkStats) {
+        let add = |c: &AtomicU64, v: u64| {
+            if v > 0 {
+                c.fetch_add(v, Ordering::Relaxed);
+            }
+        };
+        add(&stats.pages_walked, self.pages_walked);
+        add(&stats.slots_seen, self.slots_seen);
+        add(&stats.tuples_emitted, self.tuples_emitted);
+        add(&stats.tuples_skipped_lp_flag, self.tuples_skipped_lp_flag);
+        add(
+            &stats.tuples_skipped_truncated,
+            self.tuples_skipped_truncated,
+        );
+    }
 }
 
 /// Walks one 8 KiB page, emitting `BackfillTuple`s for `LP_NORMAL`
@@ -194,7 +246,7 @@ impl<'a> PageWalker<'a> {
         page: &[u8],
         block_no: u32,
         out: &mut Vec<BackfillTuple>,
-        stats: &mut PageWalkStats,
+        tally: &mut PageWalkTally,
     ) -> Result<(), PageWalkError> {
         if page.len() < SIZE_OF_PAGE_HEADER {
             return Err(PageWalkError::BadPageHeader {
@@ -210,12 +262,12 @@ impl<'a> PageWalker<'a> {
         let pd_lower = u16::from_le_bytes(page[12..14].try_into().unwrap());
         let pd_upper = u16::from_le_bytes(page[14..16].try_into().unwrap());
         if pd_upper == 0 && page.iter().all(|&byte| byte == 0) {
-            stats.pages_walked += 1;
+            tally.pages_walked += 1;
             return Ok(());
         }
         if pd_lower as usize == SIZE_OF_PAGE_HEADER && pd_upper as usize == PAGE_BYTES {
             // Fresh / empty page
-            stats.pages_walked += 1;
+            tally.pages_walked += 1;
             return Ok(());
         }
         if (pd_lower as usize) < SIZE_OF_PAGE_HEADER
@@ -229,9 +281,10 @@ impl<'a> PageWalker<'a> {
             });
         }
         let n_slots = (pd_lower as usize - SIZE_OF_PAGE_HEADER) / SIZE_OF_ITEM_ID;
-        stats.pages_walked += 1;
+        tally.pages_walked += 1;
+        tally.slots_seen += n_slots as u64;
+        out.reserve(n_slots);
         for i in 0..n_slots {
-            stats.slots_seen += 1;
             let off = SIZE_OF_PAGE_HEADER + i * SIZE_OF_ITEM_ID;
             let raw = u32::from_le_bytes(page[off..off + 4].try_into().unwrap());
             // bit-packed: lp_off (15) | lp_flags (2) | lp_len (15)
@@ -239,11 +292,11 @@ impl<'a> PageWalker<'a> {
             let lp_flags = ((raw >> 15) & 0x3) as u8;
             let lp_len = ((raw >> 17) & 0x7FFF) as usize;
             if lp_flags != LP_NORMAL {
-                stats.tuples_skipped_lp_flag += 1;
+                tally.tuples_skipped_lp_flag += 1;
                 continue;
             }
             if lp_off + lp_len > PAGE_BYTES || lp_len == 0 {
-                stats.tuples_skipped_truncated += 1;
+                tally.tuples_skipped_truncated += 1;
                 continue;
             }
             let tuple_bytes = &page[lp_off..lp_off + lp_len];
@@ -260,9 +313,9 @@ impl<'a> PageWalker<'a> {
                         offnum: (i + 1) as u16,
                         columns,
                     });
-                    stats.tuples_emitted += 1;
+                    tally.tuples_emitted += 1;
                 }
-                None => stats.tuples_skipped_truncated += 1,
+                None => tally.tuples_skipped_truncated += 1,
             }
         }
         Ok(())
@@ -351,32 +404,30 @@ pub(crate) fn decode_on_page_tuple(
     }
 }
 
-/// Tap sink that buffers tar entry bytes and walks them 8 KiB at a
-/// time, shipping tuples over `out_tx` to an async drain task.
+/// Tap router: resolves a segment's descriptor at `begin` and hands back a
+/// [`PageWalkEntry`] that owns the walk. Nothing here is on the body path,
+/// so concurrent tar parts never queue behind each other.
 pub struct PageWalkSink {
     catalog: CatalogMap,
-    source_lsn: u64,
+    /// `StartInfo.start_lsn`, set once before any `begin`
+    source_lsn: AtomicU64,
     /// Per-rfn `_lsn` tag overriding `source_lsn` (backup-sourced opt-in
     /// backfills tag each rel with its own boundary; greenfield leaves
     /// this empty). Keyed `(db_node, rel_node)`.
     lsn_overrides: HashMap<(Oid, Oid), u64>,
-    /// Main filenodes to decline at `begin`, keyed `(db_node, rel_node)`.
-    /// Their bodies drain unread instead of paying page decode
-    skip: HashSet<(Oid, Oid)>,
-    pub stats: PageWalkStats,
-    /// Bounded ([`BOOTSTRAP_TUPLE_CHANNEL_CAP`]): `chunk` is async, so a
-    /// full channel awaits in `ship_tuple`, parking the source body read
+    pub stats: Arc<PageWalkStats>,
+    /// Bounded ([`BOOTSTRAP_TUPLE_CHANNEL_CAP`]) slab channel: a full
+    /// channel awaits in the entry sink, parking that entry's body read
     /// instead of buffering. Backpressure, not a buffer.
-    out_tx: Option<mpsc::Sender<BackfillTuple>>,
+    out_tx: Option<mpsc::Sender<Vec<BackfillTuple>>>,
     /// Test-only capture, populated when `out_tx` is None
-    pub captured: Vec<BackfillTuple>,
-    /// Per-entry state keyed by `EntryId`. A map, not one slot, because
-    /// object_store fan-out interleaves begin/chunk across concurrent
-    /// parts; one slot would let part B's begin clobber part A's
-    /// in-flight entry, mis-framing pages and misattributing rfns.
-    cur: HashMap<EntryId, TapEntry>,
+    captured: Arc<std::sync::Mutex<Vec<BackfillTuple>>>,
     /// Decode TOAST pages only when configured store consumes them
     store_toast: bool,
+    /// Filenodes worth decoding, mapped relations plus their TOAST heaps.
+    /// `None` taps everything the catalog map holds. A superset filter, not a
+    /// second source of truth: the drain's `skip_initial` stays the authority
+    tap_filenodes: Option<Arc<HashSet<(Oid, Oid)>>>,
     /// `pg_xact/` segments Tap into here for backfill visibility gate
     /// (architecture/bootstrap.md); `None` (greenfield) keeps Skip.
     pg_xact: Option<Arc<std::sync::Mutex<crate::decode::visibility::PgXactAccum>>>,
@@ -392,37 +443,21 @@ enum SlruSegment {
     MultiMembers(u32),
 }
 
-struct TapEntry {
-    /// Block number within the relation, global across `.N` segments
-    /// (seeded `segno * RELSEG_BLOCKS`): TOAST rows key on
-    /// `(blkno, offnum)`, and all walk rows share one LSN, so per-file
-    /// numbering would collide segment TIDs at equal version
-    block_no: u32,
-    /// Carry-over bytes when a chunk read straddled a page boundary
-    page_buf: Vec<u8>,
-    is_toast: bool,
-    desc: Option<Arc<RelDescriptor>>,
-    /// `Some` for SLRU entries (`pg_xact/`, `pg_multixact/`): bytes
-    /// accumulate whole (no page framing) and install at `end()`
-    slru: Option<SlruSegment>,
-}
-
 impl PageWalkSink {
     pub fn new(
         catalog: CatalogMap,
-        out_tx: mpsc::Sender<BackfillTuple>,
+        out_tx: mpsc::Sender<Vec<BackfillTuple>>,
         store_toast: bool,
     ) -> Self {
         Self {
             catalog,
-            source_lsn: 0,
+            source_lsn: AtomicU64::new(0),
             lsn_overrides: HashMap::new(),
-            skip: HashSet::default(),
-            stats: PageWalkStats::default(),
+            stats: Arc::new(PageWalkStats::default()),
             out_tx: Some(out_tx),
-            captured: Vec::new(),
-            cur: HashMap::new(),
+            captured: Arc::default(),
             store_toast,
+            tap_filenodes: None,
             pg_xact: None,
             pg_multixact: None,
         }
@@ -446,18 +481,23 @@ impl PageWalkSink {
         self
     }
 
-    /// Tag listed rfns' rows with their own `_lsn` instead of `source_lsn`.
-    pub fn with_lsn_overrides(mut self, overrides: HashMap<(Oid, Oid), u64>) -> Self {
-        self.lsn_overrides = overrides;
+    /// Decline filenodes outside `set` at `begin`. Bytes still drain off the
+    /// wire; tuples never decode
+    pub fn with_tap_filenodes(mut self, set: Arc<HashSet<(Oid, Oid)>>) -> Self {
+        self.tap_filenodes = Some(set);
         self
     }
 
-    /// Decline listed main filenodes before decode. Caller policy: rows a
-    /// mapping snapshot never routes, or a relation visibility repair reads
-    /// whole. `pg_toast_*` filenodes are never declined, the mirror seeds
-    /// from every one of them
-    pub fn with_skip_filenodes(mut self, skip: HashSet<(Oid, Oid)>) -> Self {
-        self.skip = skip;
+    /// Share the counter handle so a caller watches the walk live instead
+    /// of waiting for the pump to hand its sink back.
+    pub fn with_stats(mut self, stats: Arc<PageWalkStats>) -> Self {
+        self.stats = stats;
+        self
+    }
+
+    /// Tag listed rfns' rows with their own `_lsn` instead of `source_lsn`.
+    pub fn with_lsn_overrides(mut self, overrides: HashMap<(Oid, Oid), u64>) -> Self {
+        self.lsn_overrides = overrides;
         self
     }
 
@@ -466,14 +506,13 @@ impl PageWalkSink {
     pub fn new_capturing(catalog: CatalogMap) -> Self {
         Self {
             catalog,
-            source_lsn: 0,
+            source_lsn: AtomicU64::new(0),
             lsn_overrides: HashMap::new(),
-            skip: HashSet::default(),
-            stats: PageWalkStats::default(),
+            stats: Arc::new(PageWalkStats::default()),
             out_tx: None,
-            captured: Vec::new(),
-            cur: HashMap::new(),
+            captured: Arc::default(),
             store_toast: false,
+            tap_filenodes: None,
             pg_xact: None,
             pg_multixact: None,
         }
@@ -488,8 +527,14 @@ impl PageWalkSink {
         }
     }
 
+    /// Tuples a capturing sink collected. Empty once `out_tx` is wired
+    #[cfg(test)]
+    pub fn captured(&self) -> Vec<BackfillTuple> {
+        self.captured.lock().expect("captured lock").clone()
+    }
+
     pub fn source_lsn(&self) -> u64 {
-        self.source_lsn
+        self.source_lsn.load(Ordering::Relaxed)
     }
 
     fn classify(&self, meta: &FileMeta) -> Option<BaseRelFile> {
@@ -514,91 +559,25 @@ impl PageWalkSink {
         }
         None
     }
-
-    async fn flush_full_pages(&mut self, id: EntryId) -> io::Result<()> {
-        loop {
-            // Take the page so the entry borrow drops before touching
-            // self.stats / out_tx.send
-            let (block_no, is_toast, desc_opt, page) = {
-                let Some(entry) = self.cur.get_mut(&id) else {
-                    return Ok(());
-                };
-                if entry.slru.is_some() || entry.page_buf.len() < PAGE_BYTES {
-                    return Ok(());
-                }
-                let block_no = entry.block_no;
-                entry.block_no = entry.block_no.saturating_add(1);
-                let page: Vec<u8> = entry.page_buf.drain(..PAGE_BYTES).collect();
-                (block_no, entry.is_toast, entry.desc.clone(), page)
-            };
-
-            if is_toast && !self.store_toast {
-                self.stats.pages_walked += 1;
-                continue;
-            }
-            let Some(desc) = desc_opt else {
-                // Filenode absent from seed; stats counted at begin()
-                continue;
-            };
-            let lsn = self
-                .lsn_overrides
-                .get(&(desc.rfn.db_node, desc.rfn.rel_node))
-                .copied()
-                .unwrap_or(self.source_lsn);
-            let walker = PageWalker::new(&desc, lsn);
-            let mut local_out = Vec::new();
-            if let Err(e) = walker.walk_page(&page, block_no, &mut local_out, &mut self.stats) {
-                tracing::warn!(
-                    target = "walshadow::backup_page_walk",
-                    block = block_no,
-                    error = %e,
-                    "page walk skipped due to framing error"
-                );
-                continue;
-            }
-            for t in local_out {
-                self.ship_tuple(t).await?;
-            }
-        }
-    }
-
-    async fn ship_tuple(&mut self, t: BackfillTuple) -> io::Result<()> {
-        match &self.out_tx {
-            // Awaits a free slot when full: this is the bootstrap
-            // backpressure point, parking the source until CH drains
-            Some(tx) => tx.send(t).await.map_err(|e| {
-                io::Error::other(format!("PageWalkSink: emitter channel closed: {e}"))
-            }),
-            None => {
-                self.captured.push(t);
-                Ok(())
-            }
-        }
-    }
 }
 
 #[async_trait]
 impl BackupSink for PageWalkSink {
-    async fn start(&mut self, info: &StartInfo) -> io::Result<()> {
-        self.source_lsn = info.start_lsn;
+    async fn start(&self, info: &StartInfo) -> io::Result<()> {
+        self.source_lsn.store(info.start_lsn, Ordering::Relaxed);
         Ok(())
     }
 
-    async fn begin(&mut self, entry: EntryId, meta: &FileMeta) -> io::Result<FileAction> {
+    async fn begin(&self, meta: &FileMeta) -> io::Result<FileAction> {
         if matches!(meta.kind, FileKind::File)
             && let Some(slru) = self.classify_slru(&meta.path)
         {
-            self.cur.insert(
-                entry,
-                TapEntry {
-                    block_no: 0,
-                    page_buf: Vec::with_capacity(meta.size as usize),
-                    is_toast: false,
-                    desc: None,
-                    slru: Some(slru),
-                },
-            );
-            return Ok(FileAction::Tap);
+            return Ok(FileAction::Tap(Box::new(SlruEntry {
+                seg: slru,
+                buf: Vec::with_capacity(meta.size as usize),
+                pg_xact: self.pg_xact.clone(),
+                pg_multixact: self.pg_multixact.clone(),
+            })));
         }
         let Some(f) = self.classify(meta) else {
             // Not base/<db>/<filenode>; multiplex sink falls back to lander
@@ -608,90 +587,281 @@ impl BackupSink for PageWalkSink {
             // fsm/vm carry no tuples; keep them out of the TID-producing walk
             return Ok(FileAction::Skip);
         }
-        self.stats.files_seen += 1;
-        let desc = self.catalog.get(f.db, f.filenode);
-        let is_toast = self.catalog.is_toast(f.db, f.filenode);
-        if !is_toast && self.skip.contains(&(f.db, f.filenode)) {
-            self.stats.files_skipped_by_caller += 1;
+        self.stats.files_seen.fetch_add(1, Ordering::Relaxed);
+        // Mapping filter first: an unmapped relation would decode every page
+        // only for the drain to discard it into `unsupported_relations`
+        if self
+            .tap_filenodes
+            .as_ref()
+            .is_some_and(|set| !set.contains(&(f.db, f.filenode)))
+        {
+            self.stats
+                .files_skipped_unmapped
+                .fetch_add(1, Ordering::Relaxed);
             return Ok(FileAction::Skip);
         }
+        let desc = self.catalog.get(f.db, f.filenode);
+        let is_toast = self.catalog.is_toast(f.db, f.filenode);
         if is_toast {
-            self.stats.toast_files_observed += 1;
+            self.stats
+                .toast_files_observed
+                .fetch_add(1, Ordering::Relaxed);
         } else if desc.is_some() {
-            self.stats.files_walked += 1;
+            self.stats.files_walked.fetch_add(1, Ordering::Relaxed);
         } else {
             // Filenode absent from map: seed race (greenfield) or non-opted
             // rel (filtered backfill pass, where this is most files). Skip
             // drains body without page buffering; mux honours the decline
-            self.stats.files_skipped_unknown_filenode += 1;
+            self.stats
+                .files_skipped_unknown_filenode
+                .fetch_add(1, Ordering::Relaxed);
             return Ok(FileAction::Skip);
         }
-        self.cur.insert(
-            entry,
-            TapEntry {
-                block_no: f.segno.saturating_mul(RELSEG_BLOCKS),
-                page_buf: Vec::with_capacity(PAGE_BYTES * 2),
-                is_toast,
-                desc,
-                slru: None,
+        let Some(desc) = desc else {
+            // TOAST heap whose descriptor the map lacks; count pages, no walk
+            return Ok(FileAction::Tap(Box::new(PageWalkEntry::counting(
+                f.segno.saturating_mul(RELSEG_BLOCKS),
+                self.stats.clone(),
+            ))));
+        };
+        let lsn = self
+            .lsn_overrides
+            .get(&(desc.rfn.db_node, desc.rfn.rel_node))
+            .copied()
+            .unwrap_or_else(|| self.source_lsn());
+        Ok(FileAction::Tap(Box::new(PageWalkEntry {
+            block_no: f.segno.saturating_mul(RELSEG_BLOCKS),
+            slab: Vec::with_capacity(SLAB_BYTES + PAGE_BYTES),
+            spare: None,
+            walk: (!is_toast || self.store_toast).then_some(WalkTarget { desc, lsn }),
+            out: match &self.out_tx {
+                Some(tx) => Out::Channel(tx.clone()),
+                None => Out::Captured(self.captured.clone()),
             },
-        );
-        Ok(FileAction::Tap)
+            stats: self.stats.clone(),
+            pending: None,
+        })))
+    }
+}
+
+/// Descriptor a slab walks against. `None` on a TOAST heap the configured
+/// store does not consume: its pages are counted, never decoded
+struct WalkTarget {
+    desc: Arc<RelDescriptor>,
+    lsn: u64,
+}
+
+enum Out {
+    Channel(mpsc::Sender<Vec<BackfillTuple>>),
+    Captured(Arc<std::sync::Mutex<Vec<BackfillTuple>>>),
+}
+
+/// One user-heap segment's walk. Owns its slab, so page framing and decode
+/// run without touching the router; the walk itself goes to `spawn_blocking`
+/// so tar read and decompress overlap it.
+pub struct PageWalkEntry {
+    /// Block number within the relation, global across `.N` segments
+    /// (seeded `segno * RELSEG_BLOCKS`): TOAST rows key on
+    /// `(blkno, offnum)`, and all walk rows share one LSN, so per-file
+    /// numbering would collide segment TIDs at equal version
+    block_no: u32,
+    /// Accumulates body bytes; complete pages walk in place out of it and
+    /// only a sub-page remainder carries into the next slab
+    slab: Vec<u8>,
+    /// The slab last handed to the walk, back for reuse. Two buffers
+    /// ping-pong, so a segment allocates twice however long it is
+    spare: Option<Vec<u8>>,
+    walk: Option<WalkTarget>,
+    out: Out,
+    stats: Arc<PageWalkStats>,
+    /// Previous slab's walk, still running. One slab of overlap: the tar
+    /// reader refills while the blocking pool decodes, so read and decode
+    /// cost `max`, not `sum`
+    pending: Option<tokio::task::JoinHandle<(Vec<u8>, Vec<BackfillTuple>)>>,
+}
+
+impl PageWalkEntry {
+    /// Counts pages without decoding them
+    fn counting(block_no: u32, stats: Arc<PageWalkStats>) -> Self {
+        Self {
+            block_no,
+            slab: Vec::with_capacity(SLAB_BYTES + PAGE_BYTES),
+            spare: None,
+            walk: None,
+            out: Out::Captured(Arc::default()),
+            stats,
+            pending: None,
+        }
     }
 
-    async fn chunk(&mut self, entry: EntryId, bytes: &[u8]) -> io::Result<()> {
-        match self.cur.get_mut(&entry) {
-            Some(e) => e.page_buf.extend_from_slice(bytes),
-            None => return Err(io::Error::other("PageWalkSink: chunk before begin")),
+    /// Collect the in-flight walk: recover its slab and ship its tuples.
+    /// Shipping here is what carries emitter backpressure back to the read
+    async fn join_pending(&mut self) -> io::Result<()> {
+        let Some(handle) = self.pending.take() else {
+            return Ok(());
+        };
+        let (walked, tuples) = handle.await.map_err(io::Error::other)?;
+        self.spare = Some(walked);
+        self.ship(tuples).await
+    }
+
+    /// Hand every complete page in the slab to the walk, carrying the
+    /// sub-page remainder into the next slab.
+    async fn drain_slab(&mut self) -> io::Result<()> {
+        let full = self.slab.len() / PAGE_BYTES;
+        if full == 0 {
+            return Ok(());
         }
-        self.flush_full_pages(entry).await?;
+        let take = full * PAGE_BYTES;
+        let first_block = self.block_no;
+        self.block_no = self.block_no.saturating_add(full as u32);
+
+        let Some(target) = self.walk.as_ref() else {
+            self.stats
+                .pages_walked
+                .fetch_add(full as u64, Ordering::Relaxed);
+            self.slab.drain(..take);
+            return Ok(());
+        };
+        let desc = target.desc.clone();
+        let lsn = target.lsn;
+
+        // At most one walk in flight, so a segment holds two slabs, never more
+        self.join_pending().await?;
+        let mut next = self
+            .spare
+            .take()
+            .unwrap_or_else(|| Vec::with_capacity(SLAB_BYTES + PAGE_BYTES));
+        next.clear();
+        next.extend_from_slice(&self.slab[take..]);
+        let mut walked = std::mem::replace(&mut self.slab, next);
+        walked.truncate(take);
+
+        let stats = self.stats.clone();
+        // Pure CPU over a byte slice; off the async runtime so the drain
+        // stage it feeds keeps a worker to itself
+        self.pending = Some(tokio::task::spawn_blocking(move || {
+            let walker = PageWalker::new(&desc, lsn);
+            let mut out = Vec::new();
+            let mut tally = PageWalkTally::default();
+            let started = Instant::now();
+            for i in 0..full {
+                let page = &walked[i * PAGE_BYTES..(i + 1) * PAGE_BYTES];
+                let block = first_block.saturating_add(i as u32);
+                if let Err(e) = walker.walk_page(page, block, &mut out, &mut tally) {
+                    tracing::warn!(
+                        target = "walshadow::backup_page_walk",
+                        block,
+                        error = %e,
+                        "page walk skipped due to framing error"
+                    );
+                }
+            }
+            tally.publish(&stats);
+            stats
+                .decode_nanos
+                .fetch_add(started.elapsed().as_nanos() as u64, Ordering::Relaxed);
+            (walked, out)
+        }));
         Ok(())
     }
 
-    async fn end(&mut self, entry: EntryId) -> io::Result<()> {
-        if let Some(e) = self.cur.remove(&entry) {
-            match e.slru {
-                Some(SlruSegment::PgXact(segno)) => {
-                    if let Some(accum) = &self.pg_xact {
-                        accum
-                            .lock()
-                            .expect("pg_xact accum lock")
-                            .insert_segment(segno, e.page_buf);
-                    }
-                    return Ok(());
-                }
-                Some(SlruSegment::MultiOffsets(segno)) => {
-                    if let Some(accum) = &self.pg_multixact {
-                        accum
-                            .lock()
-                            .expect("pg_multixact accum lock")
-                            .insert_offsets_segment(segno, e.page_buf);
-                    }
-                    return Ok(());
-                }
-                Some(SlruSegment::MultiMembers(segno)) => {
-                    if let Some(accum) = &self.pg_multixact {
-                        accum
-                            .lock()
-                            .expect("pg_multixact accum lock")
-                            .insert_members_segment(segno, e.page_buf);
-                    }
-                    return Ok(());
-                }
-                None => {}
+    async fn ship(&self, tuples: Vec<BackfillTuple>) -> io::Result<()> {
+        if tuples.is_empty() {
+            return Ok(());
+        }
+        match &self.out {
+            // Awaits a free slot when full: this is the bootstrap
+            // backpressure point, parking this segment until CH drains
+            Out::Channel(tx) => {
+                let started = Instant::now();
+                let res = tx.send(tuples).await.map_err(|e| {
+                    io::Error::other(format!("PageWalkSink: emitter channel closed: {e}"))
+                });
+                self.stats
+                    .channel_block_nanos
+                    .fetch_add(started.elapsed().as_nanos() as u64, Ordering::Relaxed);
+                res
             }
-            let trailing = e.page_buf.len() as u64;
-            if trailing > 0 {
-                // PG heap files are page-aligned; trailing bytes are
-                // zero-padding or anomalous, so count without decoding
-                self.stats.tail_bytes_dropped += trailing;
+            Out::Captured(buf) => {
+                buf.lock().expect("captured lock").extend(tuples);
+                Ok(())
             }
+        }
+    }
+}
+
+#[async_trait]
+impl EntrySink for PageWalkEntry {
+    async fn chunk(&mut self, bytes: &[u8]) -> io::Result<()> {
+        self.slab.extend_from_slice(bytes);
+        if self.slab.len() >= SLAB_BYTES {
+            self.drain_slab().await?;
         }
         Ok(())
     }
 
-    async fn finish(&mut self, _info: &EndInfo) -> io::Result<()> {
-        // Channel close happens when caller drops this sink's Arc
+    async fn end(mut self: Box<Self>) -> io::Result<()> {
+        self.drain_slab().await?;
+        self.join_pending().await?;
+        let trailing = self.slab.len() as u64;
+        if trailing > 0 {
+            // PG heap files are page-aligned; trailing bytes are
+            // zero-padding or anomalous, so count without decoding
+            self.stats
+                .tail_bytes_dropped
+                .fetch_add(trailing, Ordering::Relaxed);
+        }
+        Ok(())
+    }
+}
+
+/// `pg_xact` / `pg_multixact` segment: no page framing, bytes accumulate
+/// whole and install into the visibility accum at `end`
+struct SlruEntry {
+    seg: SlruSegment,
+    buf: Vec<u8>,
+    pg_xact: Option<Arc<std::sync::Mutex<crate::decode::visibility::PgXactAccum>>>,
+    pg_multixact: Option<Arc<std::sync::Mutex<crate::decode::visibility::PgMultiXactAccum>>>,
+}
+
+#[async_trait]
+impl EntrySink for SlruEntry {
+    async fn chunk(&mut self, bytes: &[u8]) -> io::Result<()> {
+        self.buf.extend_from_slice(bytes);
+        Ok(())
+    }
+
+    async fn end(self: Box<Self>) -> io::Result<()> {
+        let SlruEntry {
+            seg,
+            buf,
+            pg_xact,
+            pg_multixact,
+        } = *self;
+        match seg {
+            SlruSegment::PgXact(segno) => {
+                if let Some(a) = pg_xact {
+                    a.lock()
+                        .expect("pg_xact accum lock")
+                        .insert_segment(segno, buf);
+                }
+            }
+            SlruSegment::MultiOffsets(segno) => {
+                if let Some(a) = pg_multixact {
+                    a.lock()
+                        .expect("pg_multixact accum lock")
+                        .insert_offsets_segment(segno, buf);
+                }
+            }
+            SlruSegment::MultiMembers(segno) => {
+                if let Some(a) = pg_multixact {
+                    a.lock()
+                        .expect("pg_multixact accum lock")
+                        .insert_members_segment(segno, buf);
+                }
+            }
+        }
         Ok(())
     }
 }
@@ -780,12 +950,35 @@ pub(crate) fn synth_single_tuple_page(value: i32) -> [u8; PAGE_BYTES] {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::backfill::backup_source::EndInfo;
+
+    fn ld(a: &AtomicU64) -> u64 {
+        a.load(Ordering::Relaxed)
+    }
+
+    /// `begin` must tap; hands back the owned entry sink
+    async fn tap(sink: &PageWalkSink, meta: &FileMeta) -> Box<dyn EntrySink> {
+        match sink.begin(meta).await.unwrap() {
+            FileAction::Tap(e) => e,
+            other => panic!("expected Tap for {}, got {other:?}", meta.path.display()),
+        }
+    }
+
+    fn heap_meta(path: &str) -> FileMeta {
+        FileMeta {
+            path: PathBuf::from(path),
+            size: PAGE_BYTES as u64,
+            mode: 0o600,
+            kind: FileKind::File,
+        }
+    }
     use crate::schema::RelName;
     use std::path::PathBuf;
 
     #[tokio::test]
     async fn source_lsn_reflects_start_info() {
-        let mut sink = PageWalkSink::new_capturing(CatalogMap::new());
+        let sink = PageWalkSink::new_capturing(CatalogMap::new());
         assert_eq!(sink.source_lsn(), 0);
         sink.start(&StartInfo {
             start_lsn: 0xABCD_1234,
@@ -803,15 +996,15 @@ mod tests {
         let walker = PageWalker::new(&rel, 0xABCD);
         let page = synth_single_tuple_page(42);
         let mut out = Vec::new();
-        let mut stats = PageWalkStats::default();
-        walker.walk_page(&page, 0, &mut out, &mut stats).unwrap();
+        let mut tally = PageWalkTally::default();
+        walker.walk_page(&page, 0, &mut out, &mut tally).unwrap();
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].source_lsn, 0xABCD);
         assert_eq!(out[0].xid, 99);
         assert_eq!(out[0].columns.len(), 1);
         assert!(matches!(out[0].columns[0], Some(ColumnValue::Int4(42))));
-        assert_eq!(stats.pages_walked, 1);
-        assert_eq!(stats.tuples_emitted, 1);
+        assert_eq!(tally.pages_walked, 1);
+        assert_eq!(tally.tuples_emitted, 1);
     }
 
     #[test]
@@ -823,11 +1016,11 @@ mod tests {
         page[12..14].copy_from_slice(&(SIZE_OF_PAGE_HEADER as u16).to_le_bytes());
         page[14..16].copy_from_slice(&(PAGE_BYTES as u16).to_le_bytes());
         let mut out = Vec::new();
-        let mut stats = PageWalkStats::default();
-        walker.walk_page(&page, 0, &mut out, &mut stats).unwrap();
+        let mut tally = PageWalkTally::default();
+        walker.walk_page(&page, 0, &mut out, &mut tally).unwrap();
         assert!(out.is_empty());
-        assert_eq!(stats.pages_walked, 1);
-        assert_eq!(stats.slots_seen, 0);
+        assert_eq!(tally.pages_walked, 1);
+        assert_eq!(tally.slots_seen, 0);
     }
 
     #[test]
@@ -835,13 +1028,13 @@ mod tests {
         let rel = make_rel();
         let walker = PageWalker::new(&rel, 0);
         let mut out = Vec::new();
-        let mut stats = PageWalkStats::default();
+        let mut tally = PageWalkTally::default();
         walker
-            .walk_page(&[0; PAGE_BYTES], 0, &mut out, &mut stats)
+            .walk_page(&[0; PAGE_BYTES], 0, &mut out, &mut tally)
             .unwrap();
         assert!(out.is_empty());
-        assert_eq!(stats.pages_walked, 1);
-        assert_eq!(stats.slots_seen, 0);
+        assert_eq!(tally.pages_walked, 1);
+        assert_eq!(tally.slots_seen, 0);
     }
 
     #[test]
@@ -860,11 +1053,11 @@ mod tests {
         let new_raw = lp_off | (3u32 << 15) | (lp_len << 17);
         page[SIZE_OF_PAGE_HEADER..SIZE_OF_PAGE_HEADER + 4].copy_from_slice(&new_raw.to_le_bytes());
         let mut out = Vec::new();
-        let mut stats = PageWalkStats::default();
-        walker.walk_page(&page, 0, &mut out, &mut stats).unwrap();
+        let mut tally = PageWalkTally::default();
+        walker.walk_page(&page, 0, &mut out, &mut tally).unwrap();
         assert!(out.is_empty());
-        assert_eq!(stats.tuples_skipped_lp_flag, 1);
-        assert_eq!(stats.tuples_emitted, 0);
+        assert_eq!(tally.tuples_skipped_lp_flag, 1);
+        assert_eq!(tally.tuples_emitted, 0);
     }
 
     #[test]
@@ -876,8 +1069,8 @@ mod tests {
         page[12..14].copy_from_slice(&(PAGE_BYTES as u16).to_le_bytes());
         page[14..16].copy_from_slice(&(SIZE_OF_PAGE_HEADER as u16).to_le_bytes());
         let mut out = Vec::new();
-        let mut stats = PageWalkStats::default();
-        let err = walker.walk_page(&page, 0, &mut out, &mut stats);
+        let mut tally = PageWalkTally::default();
+        let err = walker.walk_page(&page, 0, &mut out, &mut tally);
         assert!(matches!(err, Err(PageWalkError::BadPageHeader { .. })));
     }
 
@@ -903,7 +1096,7 @@ mod tests {
     async fn pagewalk_sink_decodes_one_page_via_chunk_stream() {
         let mut catalog = CatalogMap::new();
         catalog.insert(Arc::new(make_rel()));
-        let mut sink = PageWalkSink::new_capturing(catalog);
+        let sink = PageWalkSink::new_capturing(catalog);
         sink.start(&StartInfo {
             start_lsn: 0x1234_5678,
             timeline: 1,
@@ -911,20 +1104,12 @@ mod tests {
         })
         .await
         .unwrap();
-        let meta = FileMeta {
-            path: PathBuf::from("base/5/16400"),
-            size: PAGE_BYTES as u64,
-            mode: 0o600,
-            kind: FileKind::File,
-        };
-        let id = EntryId(0);
-        let action = sink.begin(id, &meta).await.unwrap();
-        assert_eq!(action, FileAction::Tap);
+        let mut entry = tap(&sink, &heap_meta("base/5/16400")).await;
         let page = synth_single_tuple_page(99);
         // Two chunks exercise the buffer-across-chunk path
-        sink.chunk(id, &page[..4096]).await.unwrap();
-        sink.chunk(id, &page[4096..]).await.unwrap();
-        sink.end(id).await.unwrap();
+        entry.chunk(&page[..4096]).await.unwrap();
+        entry.chunk(&page[4096..]).await.unwrap();
+        entry.end().await.unwrap();
         sink.finish(&EndInfo {
             end_lsn: 0,
             timeline: 1,
@@ -932,17 +1117,18 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(sink.captured.len(), 1);
-        assert_eq!(sink.captured[0].source_lsn, 0x1234_5678);
-        assert_eq!(sink.captured[0].xid, 99);
+        let captured = sink.captured();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].source_lsn, 0x1234_5678);
+        assert_eq!(captured[0].xid, 99);
         assert!(matches!(
-            sink.captured[0].columns[0],
+            captured[0].columns[0],
             Some(ColumnValue::Int4(99))
         ));
-        assert_eq!(sink.stats.files_seen, 1);
-        assert_eq!(sink.stats.files_walked, 1);
-        assert_eq!(sink.stats.pages_walked, 1);
-        assert_eq!(sink.stats.tuples_emitted, 1);
+        assert_eq!(ld(&sink.stats.files_seen), 1);
+        assert_eq!(ld(&sink.stats.files_walked), 1);
+        assert_eq!(ld(&sink.stats.pages_walked), 1);
+        assert_eq!(ld(&sink.stats.tuples_emitted), 1);
     }
 
     /// `.N` segment tuples get global block numbers: same local page +
@@ -952,7 +1138,7 @@ mod tests {
     async fn pagewalk_sink_seeds_segment_block_numbers() {
         let mut catalog = CatalogMap::new();
         catalog.insert(Arc::new(make_rel()));
-        let mut sink = PageWalkSink::new_capturing(catalog);
+        let sink = PageWalkSink::new_capturing(catalog);
         sink.start(&StartInfo {
             start_lsn: 0x1000,
             timeline: 1,
@@ -960,26 +1146,20 @@ mod tests {
         })
         .await
         .unwrap();
-        for (i, path) in ["base/5/16400", "base/5/16400.1"].iter().enumerate() {
-            let meta = FileMeta {
-                path: PathBuf::from(path),
-                size: PAGE_BYTES as u64,
-                mode: 0o600,
-                kind: FileKind::File,
-            };
-            let id = EntryId(i as u64);
-            assert_eq!(sink.begin(id, &meta).await.unwrap(), FileAction::Tap);
-            sink.chunk(id, &synth_single_tuple_page(7)).await.unwrap();
-            sink.end(id).await.unwrap();
+        for path in ["base/5/16400", "base/5/16400.1"] {
+            let mut entry = tap(&sink, &heap_meta(path)).await;
+            entry.chunk(&synth_single_tuple_page(7)).await.unwrap();
+            entry.end().await.unwrap();
         }
-        assert_eq!(sink.captured.len(), 2);
+        let captured = sink.captured();
+        assert_eq!(captured.len(), 2);
         assert_eq!(
-            (sink.captured[0].blkno, sink.captured[0].offnum),
+            (captured[0].blkno, captured[0].offnum),
             (0, 1),
             "base file walks from block 0"
         );
         assert_eq!(
-            (sink.captured[1].blkno, sink.captured[1].offnum),
+            (captured[1].blkno, captured[1].offnum),
             (RELSEG_BLOCKS, 1),
             "segment 1 walks from its global block"
         );
@@ -990,7 +1170,7 @@ mod tests {
     async fn pagewalk_sink_skips_non_main_forks() {
         let mut catalog = CatalogMap::new();
         catalog.insert(Arc::new(make_rel()));
-        let mut sink = PageWalkSink::new_capturing(catalog);
+        let sink = PageWalkSink::new_capturing(catalog);
         sink.start(&StartInfo {
             start_lsn: 0x1000,
             timeline: 1,
@@ -999,26 +1179,22 @@ mod tests {
         .await
         .unwrap();
         for path in ["base/5/16400_fsm", "base/5/16400_vm", "base/5/16400_vm.1"] {
-            let meta = FileMeta {
-                path: PathBuf::from(path),
-                size: PAGE_BYTES as u64,
-                mode: 0o600,
-                kind: FileKind::File,
-            };
-            assert_eq!(
-                sink.begin(EntryId(9), &meta).await.unwrap(),
-                FileAction::Skip,
+            assert!(
+                matches!(
+                    sink.begin(&heap_meta(path)).await.unwrap(),
+                    FileAction::Skip
+                ),
                 "{path}"
             );
         }
-        assert_eq!(sink.stats.files_seen, 0);
+        assert_eq!(ld(&sink.stats.files_seen), 0);
     }
 
-    /// Caller-declined main files drain unread: the drain drops unmapped
-    /// rows and repair replaces pending ones. Chunk files still walk, the
-    /// mirror seeds from every toast rel
+    /// An initial-load opt-out keeps its main file out of the tap set while
+    /// its chunk file stays in: CDC rows carrying unchanged external
+    /// pointers still need the mirror
     #[tokio::test]
-    async fn pagewalk_sink_declines_caller_skipped_main_files() {
+    async fn tap_filenode_filter_keeps_toast_of_declined_main() {
         use crate::schema::RelName;
         let mut catalog = CatalogMap::new();
         catalog.insert(Arc::new(make_rel()));
@@ -1027,8 +1203,8 @@ mod tests {
         toast.oid = 16401;
         toast.rel_name = RelName::new("pg_toast", "pg_toast_16400");
         catalog.insert(Arc::new(toast));
-        let mut sink = PageWalkSink::new_capturing_with_toast(catalog)
-            .with_skip_filenodes([(5, 16400), (5, 16401)].into_iter().collect());
+        let sink = PageWalkSink::new_capturing_with_toast(catalog)
+            .with_tap_filenodes(Arc::new([(5, 16401)].into_iter().collect()));
         sink.start(&StartInfo {
             start_lsn: 0x1000,
             timeline: 1,
@@ -1036,24 +1212,17 @@ mod tests {
         })
         .await
         .unwrap();
-        for (i, (path, want)) in [
-            ("base/5/16400", FileAction::Skip),
-            ("base/5/16401", FileAction::Tap),
-        ]
-        .iter()
-        .enumerate()
-        {
-            let meta = FileMeta {
-                path: PathBuf::from(path),
-                size: PAGE_BYTES as u64,
-                mode: 0o600,
-                kind: FileKind::File,
-            };
-            assert_eq!(sink.begin(EntryId(i as u64), &meta).await.unwrap(), *want);
-        }
-        assert_eq!(sink.stats.files_skipped_by_caller, 1);
-        assert_eq!(sink.stats.files_walked, 0);
-        assert_eq!(sink.stats.toast_files_observed, 1);
+        assert!(matches!(
+            sink.begin(&heap_meta("base/5/16400")).await.unwrap(),
+            FileAction::Skip
+        ));
+        assert!(matches!(
+            sink.begin(&heap_meta("base/5/16401")).await.unwrap(),
+            FileAction::Tap(_)
+        ));
+        assert_eq!(ld(&sink.stats.files_skipped_unmapped), 1);
+        assert_eq!(ld(&sink.stats.files_walked), 0);
+        assert_eq!(ld(&sink.stats.toast_files_observed), 1);
     }
 
     #[tokio::test]
@@ -1075,7 +1244,6 @@ mod tests {
             })
         );
 
-        let mut sink = sink;
         sink.start(&StartInfo {
             start_lsn: 0,
             timeline: 1,
@@ -1083,28 +1251,97 @@ mod tests {
         })
         .await
         .unwrap();
-        let meta = FileMeta {
-            path: PathBuf::from("base/5/16400"),
-            size: PAGE_BYTES as u64,
-            mode: 0o600,
-            kind: FileKind::File,
-        };
-        let id = EntryId(0);
-        let action = sink.begin(id, &meta).await.unwrap();
         // Skip so source drains body without chunk() delivery; filtered
         // backfill pass relies on this for every non-opted rel
-        assert_eq!(action, FileAction::Skip);
-        sink.end(id).await.unwrap();
-        assert!(sink.captured.is_empty());
-        assert_eq!(sink.stats.files_seen, 1);
-        assert_eq!(sink.stats.files_skipped_unknown_filenode, 1);
-        assert_eq!(sink.stats.tuples_emitted, 0);
-        assert_eq!(sink.stats.pages_walked, 0);
+        assert!(matches!(
+            sink.begin(&heap_meta("base/5/16400")).await.unwrap(),
+            FileAction::Skip
+        ));
+        assert!(sink.captured().is_empty());
+        assert_eq!(ld(&sink.stats.files_seen), 1);
+        assert_eq!(ld(&sink.stats.files_skipped_unknown_filenode), 1);
+        assert_eq!(ld(&sink.stats.tuples_emitted), 0);
+        assert_eq!(ld(&sink.stats.pages_walked), 0);
+    }
+
+    /// Item 3.4: an unmapped relation's bytes drain off the wire without a
+    /// page decode. Before the filter the walk decoded every seeded rel and
+    /// the drain discarded them into `unsupported_relations`.
+    #[tokio::test]
+    async fn tap_filenode_filter_declines_unmapped_relations() {
+        let mut catalog = CatalogMap::new();
+        let mapped = make_rel();
+        let mut unmapped = make_rel();
+        unmapped.rfn.rel_node = 16401;
+        unmapped.oid = 16401;
+        catalog.insert(Arc::new(mapped));
+        catalog.insert(Arc::new(unmapped));
+        let sink = PageWalkSink::new_capturing(catalog)
+            .with_tap_filenodes(Arc::new([(5, 16400)].into_iter().collect()));
+        sink.start(&StartInfo {
+            start_lsn: 0x1000,
+            timeline: 1,
+            tablespaces: Vec::new(),
+        })
+        .await
+        .unwrap();
+
+        let mut entry = tap(&sink, &heap_meta("base/5/16400")).await;
+        entry.chunk(&synth_single_tuple_page(1)).await.unwrap();
+        entry.end().await.unwrap();
+        assert!(matches!(
+            sink.begin(&heap_meta("base/5/16401")).await.unwrap(),
+            FileAction::Skip
+        ));
+
+        assert_eq!(sink.captured().len(), 1, "only the mapped rel decoded");
+        assert_eq!(ld(&sink.stats.files_seen), 2);
+        assert_eq!(ld(&sink.stats.files_walked), 1);
+        assert_eq!(ld(&sink.stats.files_skipped_unmapped), 1);
+        assert_eq!(ld(&sink.stats.pages_walked), 1);
+    }
+
+    /// A slab boundary must not lose the page it straddles, nor renumber
+    /// blocks: 64 KiB chunks against a 16-page slab put the split mid-page.
+    #[tokio::test]
+    async fn slab_boundary_keeps_every_page_and_block_number() {
+        let mut catalog = CatalogMap::new();
+        catalog.insert(Arc::new(make_rel()));
+        let sink = PageWalkSink::new_capturing(catalog);
+        sink.start(&StartInfo {
+            start_lsn: 0x1000,
+            timeline: 1,
+            tablespaces: Vec::new(),
+        })
+        .await
+        .unwrap();
+
+        // 40 pages, one tuple each, delivered in 6000-byte chunks so no
+        // chunk edge lands on a page or slab edge
+        let pages = 40usize;
+        let mut body = Vec::with_capacity(pages * PAGE_BYTES);
+        for i in 0..pages {
+            body.extend_from_slice(&synth_single_tuple_page(i as i32));
+        }
+        let mut entry = tap(&sink, &heap_meta("base/5/16400")).await;
+        for chunk in body.chunks(6000) {
+            entry.chunk(chunk).await.unwrap();
+        }
+        entry.end().await.unwrap();
+
+        let captured = sink.captured();
+        assert_eq!(captured.len(), pages);
+        assert_eq!(ld(&sink.stats.pages_walked), pages as u64);
+        assert_eq!(ld(&sink.stats.tail_bytes_dropped), 0);
+        for (i, t) in captured.iter().enumerate() {
+            assert_eq!(t.blkno, i as u32, "page {i} kept its block number");
+            assert!(matches!(t.columns[0], Some(ColumnValue::Int4(v)) if v == i as i32));
+        }
     }
 
     #[tokio::test]
     async fn pagewalk_sink_rejects_non_base_paths() {
-        let mut sink = PageWalkSink::new_capturing(CatalogMap::new());
+        let sink = PageWalkSink::new_capturing(CatalogMap::new());
         sink.start(&StartInfo {
             start_lsn: 0,
             timeline: 1,
@@ -1112,23 +1349,23 @@ mod tests {
         })
         .await
         .unwrap();
-        let meta = FileMeta {
-            path: PathBuf::from("pg_control"),
-            size: 0,
-            mode: 0,
-            kind: FileKind::File,
-        };
-        assert_eq!(
-            sink.begin(EntryId(0), &meta).await.unwrap(),
+        assert!(matches!(
+            sink.begin(&FileMeta {
+                path: PathBuf::from("pg_control"),
+                size: 0,
+                mode: 0,
+                kind: FileKind::File,
+            })
+            .await
+            .unwrap(),
             FileAction::Skip
-        );
+        ));
     }
 
     /// object_store fan-out interleaves begin/chunk across concurrent
-    /// parts on the shared sink (mutex released across each body read).
-    /// Per-entry keying keeps each file's page-walk state separate; a
-    /// single `cur` slot would let a later begin clobber an in-flight
-    /// entry, misframing pages against the wrong relation.
+    /// parts. Each entry owns its walk state, so a later begin cannot
+    /// clobber an in-flight entry and misframe pages against the wrong
+    /// relation.
     #[tokio::test]
     async fn interleaved_entries_keep_independent_state() {
         let mut catalog = CatalogMap::new();
@@ -1138,7 +1375,7 @@ mod tests {
         rel_b.oid = 16401;
         catalog.insert(Arc::new(rel_a));
         catalog.insert(Arc::new(rel_b));
-        let mut sink = PageWalkSink::new_capturing(catalog);
+        let sink = PageWalkSink::new_capturing(catalog);
         sink.start(&StartInfo {
             start_lsn: 0x1000,
             timeline: 1,
@@ -1147,38 +1384,25 @@ mod tests {
         .await
         .unwrap();
 
-        let meta_a = FileMeta {
-            path: PathBuf::from("base/5/16400"),
-            size: PAGE_BYTES as u64,
-            mode: 0o600,
-            kind: FileKind::File,
-        };
-        let meta_b = FileMeta {
-            path: PathBuf::from("base/5/16401"),
-            size: PAGE_BYTES as u64,
-            mode: 0o600,
-            kind: FileKind::File,
-        };
-        let (a, b) = (EntryId(0), EntryId(1));
-
         // Both open before either streams, chunks arrive reversed, ends
         // interleave: worst case for a shared slot
-        assert_eq!(sink.begin(a, &meta_a).await.unwrap(), FileAction::Tap);
-        assert_eq!(sink.begin(b, &meta_b).await.unwrap(), FileAction::Tap);
-        sink.chunk(b, &synth_single_tuple_page(200)).await.unwrap();
-        sink.chunk(a, &synth_single_tuple_page(100)).await.unwrap();
-        sink.end(a).await.unwrap();
-        sink.end(b).await.unwrap();
+        let mut a = tap(&sink, &heap_meta("base/5/16400")).await;
+        let mut b = tap(&sink, &heap_meta("base/5/16401")).await;
+        b.chunk(&synth_single_tuple_page(200)).await.unwrap();
+        a.chunk(&synth_single_tuple_page(100)).await.unwrap();
+        a.end().await.unwrap();
+        b.end().await.unwrap();
 
         // Each tuple carries its own file's rfn + value; a shared slot
         // would attribute both to rel B
+        let captured = sink.captured();
         let mut by_rel: HashMap<Oid, i32> = HashMap::new();
-        for t in &sink.captured {
+        for t in &captured {
             if let Some(Some(ColumnValue::Int4(v))) = t.columns.first() {
                 by_rel.insert(t.rfn.rel_node, *v);
             }
         }
-        assert_eq!(sink.captured.len(), 2);
+        assert_eq!(captured.len(), 2);
         assert_eq!(by_rel.get(&16400), Some(&100), "entry A decoded vs rel A");
         assert_eq!(by_rel.get(&16401), Some(&200), "entry B decoded vs rel B");
     }

--- a/src/backfill/backup_sink.rs
+++ b/src/backfill/backup_sink.rs
@@ -11,15 +11,17 @@
 //! `CatalogTracker::seed_from_source`.
 
 use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use async_trait::async_trait;
 
 use crate::backfill::backup_source::{
-    BackupSink, EndInfo, EntryId, FileAction, FileKind, FileMeta, StartInfo,
+    BackupSink, EndInfo, FileAction, FileKind, FileMeta, StartInfo,
 };
 use crate::backfill::pg_path::{is_system_dir, parse_base_path};
 use crate::schema::FIRST_NORMAL_OBJECT_ID;
-use ahash::{HashSet, HashSetExt};
+use ahash::HashSet;
 
 /// `relfilenode < 16384` is always bootstrap catalog. Rotated-catalog
 /// filenodes (`VACUUM FULL` / `REINDEX` on a catalog) land in `whitelist`.
@@ -71,23 +73,24 @@ impl FromIterator<(u32, u32)> for CatalogFilenodes {
 /// (PG recovery refuses to start without them).
 pub struct DiskLanderSink {
     pub catalog_filenodes: CatalogFilenodes,
-    pub stats: DiskLanderStats,
+    pub stats: Arc<DiskLanderStats>,
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct DiskLanderStats {
-    pub kept_files: u64,
-    pub kept_dirs: u64,
-    pub kept_symlinks: u64,
-    pub skipped_denylist: u64,
-    pub skipped_user_heap: u64,
+crate::atomic_stats! {
+    pub struct DiskLanderStats {
+        pub kept_files,
+        pub kept_dirs,
+        pub kept_symlinks,
+        pub skipped_denylist,
+        pub skipped_user_heap,
+    }
 }
 
 impl DiskLanderSink {
     pub fn new(catalog_filenodes: CatalogFilenodes) -> Self {
         Self {
             catalog_filenodes,
-            stats: DiskLanderStats::default(),
+            stats: Arc::new(DiskLanderStats::default()),
         }
     }
 
@@ -117,7 +120,7 @@ impl DiskLanderSink {
 }
 
 /// Distinguishes skip-denylist from skip-user-heap so MultiplexSink can
-/// flip the latter to `Tap` when a page-walk sink is composed in.
+/// flip the latter to a tap when a page-walk sink is composed in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiskAction {
     Keep,
@@ -125,64 +128,56 @@ pub enum DiskAction {
     SkipUserHeap,
 }
 
-#[async_trait]
-impl BackupSink for DiskLanderSink {
-    async fn begin(&mut self, _entry: EntryId, meta: &FileMeta) -> io::Result<FileAction> {
-        let action = match self.classify(meta) {
-            DiskAction::Keep => FileAction::Keep,
-            DiskAction::SkipDenylist | DiskAction::SkipUserHeap => FileAction::Skip,
+impl DiskLanderSink {
+    /// Count one routing decision. Split out so `MultiplexSink` records the
+    /// lander's view of an entry it hands to the tap instead
+    fn record(&self, action: DiskAction, meta: &FileMeta) {
+        let bump = |c: &AtomicU64| {
+            c.fetch_add(1, Ordering::Relaxed);
         };
-        if action == FileAction::Keep {
-            match meta.kind {
-                FileKind::File => self.stats.kept_files += 1,
-                FileKind::Dir => self.stats.kept_dirs += 1,
-                FileKind::Symlink { .. } => self.stats.kept_symlinks += 1,
-            }
-        } else {
-            match self.classify(meta) {
-                DiskAction::SkipDenylist => self.stats.skipped_denylist += 1,
-                DiskAction::SkipUserHeap => self.stats.skipped_user_heap += 1,
-                DiskAction::Keep => unreachable!(),
-            }
+        match action {
+            DiskAction::Keep => match meta.kind {
+                FileKind::File => bump(&self.stats.kept_files),
+                FileKind::Dir => bump(&self.stats.kept_dirs),
+                FileKind::Symlink { .. } => bump(&self.stats.kept_symlinks),
+            },
+            DiskAction::SkipDenylist => bump(&self.stats.skipped_denylist),
+            DiskAction::SkipUserHeap => bump(&self.stats.skipped_user_heap),
         }
-        Ok(action)
-    }
-    async fn chunk(&mut self, _entry: EntryId, _bytes: &[u8]) -> io::Result<()> {
-        // Never returns Tap, so chunk() should never fire
-        Err(io::Error::other(
-            "DiskLanderSink::chunk called — sink only ever Keeps or Skips",
-        ))
-    }
-    async fn end(&mut self, _entry: EntryId) -> io::Result<()> {
-        Ok(())
     }
 }
 
-/// Multiplexes a DiskLanderSink (Keep / Skip) and a Tap-target sink
-/// (typically PageWalkSink) over one source pass; begin() picks the
-/// route, chunk/end follow it.
+#[async_trait]
+impl BackupSink for DiskLanderSink {
+    async fn begin(&self, meta: &FileMeta) -> io::Result<FileAction> {
+        let action = self.classify(meta);
+        self.record(action, meta);
+        Ok(match action {
+            DiskAction::Keep => FileAction::Keep,
+            DiskAction::SkipDenylist | DiskAction::SkipUserHeap => FileAction::Skip,
+        })
+    }
+}
+
+/// Routes a DiskLanderSink (Keep / Skip) and a tap-target sink
+/// (typically PageWalkSink) over one source pass. Pure router: the tap's
+/// own `EntrySink` carries the body, so nothing here is on the hot path.
 pub struct MultiplexSink<T> {
     lander: DiskLanderSink,
     tap: T,
-    /// Entries routed to the tap. A set, not a flag, so concurrent
-    /// entries (object_store fan-out) dispatch to the right inner sink
-    /// instead of racing one shared bool.
-    tap_entries: HashSet<EntryId>,
 }
 
 impl<T: BackupSink> MultiplexSink<T> {
     pub fn new(lander: DiskLanderSink, tap: T) -> Self {
-        Self {
-            lander,
-            tap,
-            tap_entries: HashSet::new(),
-        }
+        Self { lander, tap }
     }
 
-    pub fn lander_stats(&self) -> &DiskLanderStats {
+    #[cfg(test)]
+    pub fn lander_stats(&self) -> &Arc<DiskLanderStats> {
         &self.lander.stats
     }
 
+    #[cfg(test)]
     pub fn into_inner(self) -> (DiskLanderSink, T) {
         (self.lander, self.tap)
     }
@@ -190,49 +185,25 @@ impl<T: BackupSink> MultiplexSink<T> {
 
 #[async_trait]
 impl<T: BackupSink> BackupSink for MultiplexSink<T> {
-    async fn start(&mut self, info: &StartInfo) -> io::Result<()> {
+    async fn start(&self, info: &StartInfo) -> io::Result<()> {
         self.lander.start(info).await?;
         self.tap.start(info).await?;
         Ok(())
     }
-    async fn begin(&mut self, entry: EntryId, meta: &FileMeta) -> io::Result<FileAction> {
-        let action = match self.lander.classify(meta) {
-            DiskAction::Keep => {
-                self.lander.begin(entry, meta).await?;
-                FileAction::Keep
-            }
-            DiskAction::SkipDenylist => {
-                self.lander.begin(entry, meta).await?;
-                FileAction::Skip
-            }
-            DiskAction::SkipUserHeap => {
-                // Flip to Tap if the inner sink accepts; honour its
-                // decline (Skip / Keep) otherwise
-                let inner_action = self.tap.begin(entry, meta).await?;
-                if inner_action == FileAction::Tap {
-                    self.tap_entries.insert(entry);
-                }
-                inner_action
-            }
-        };
-        Ok(action)
-    }
-    async fn chunk(&mut self, entry: EntryId, bytes: &[u8]) -> io::Result<()> {
-        if self.tap_entries.contains(&entry) {
-            self.tap.chunk(entry, bytes).await
-        } else {
-            Err(io::Error::other("MultiplexSink: chunk without active tap"))
+    async fn begin(&self, meta: &FileMeta) -> io::Result<FileAction> {
+        let disk = self.lander.classify(meta);
+        if disk != DiskAction::SkipUserHeap {
+            return self.lander.begin(meta).await;
         }
-    }
-    async fn end(&mut self, entry: EntryId) -> io::Result<()> {
-        if self.tap_entries.remove(&entry) {
-            self.tap.end(entry).await?;
-        } else {
-            self.lander.end(entry).await?;
+        // Hand it to the tap; honour its decline (Skip / Keep) otherwise,
+        // counting the lander's own verdict only when it keeps the entry
+        let inner = self.tap.begin(meta).await?;
+        if !inner.is_tap() {
+            self.lander.record(disk, meta);
         }
-        Ok(())
+        Ok(inner)
     }
-    async fn finish(&mut self, info: &EndInfo) -> io::Result<()> {
+    async fn finish(&self, info: &EndInfo) -> io::Result<()> {
         self.lander.finish(info).await?;
         self.tap.finish(info).await?;
         Ok(())
@@ -414,28 +385,43 @@ mod tests {
         }
     }
 
-    /// Counts begin / chunk / end, always returns Tap. Exercises
-    /// MultiplexSink without the full page walker.
-    #[derive(Debug, Default)]
-    struct CountingTap {
-        begins: u64,
-        chunks: u64,
-        ends: u64,
-        bytes: u64,
+    fn ld(a: &AtomicU64) -> u64 {
+        a.load(Ordering::Relaxed)
     }
+
+    /// Counts begin / chunk / end, always taps. Exercises MultiplexSink
+    /// without the full page walker.
+    #[derive(Debug, Default)]
+    struct TapCounts {
+        begins: AtomicU64,
+        chunks: AtomicU64,
+        ends: AtomicU64,
+        bytes: AtomicU64,
+    }
+
+    struct CountingTap(Arc<TapCounts>);
+
     #[async_trait]
     impl BackupSink for CountingTap {
-        async fn begin(&mut self, _entry: EntryId, _meta: &FileMeta) -> io::Result<FileAction> {
-            self.begins += 1;
-            Ok(FileAction::Tap)
+        async fn begin(&self, _meta: &FileMeta) -> io::Result<FileAction> {
+            self.0.begins.fetch_add(1, Ordering::Relaxed);
+            Ok(FileAction::Tap(Box::new(CountingEntry(self.0.clone()))))
         }
-        async fn chunk(&mut self, _entry: EntryId, bytes: &[u8]) -> io::Result<()> {
-            self.chunks += 1;
-            self.bytes += bytes.len() as u64;
+    }
+
+    struct CountingEntry(Arc<TapCounts>);
+
+    #[async_trait]
+    impl crate::backfill::backup_source::EntrySink for CountingEntry {
+        async fn chunk(&mut self, bytes: &[u8]) -> io::Result<()> {
+            self.0.chunks.fetch_add(1, Ordering::Relaxed);
+            self.0
+                .bytes
+                .fetch_add(bytes.len() as u64, Ordering::Relaxed);
             Ok(())
         }
-        async fn end(&mut self, _entry: EntryId) -> io::Result<()> {
-            self.ends += 1;
+        async fn end(self: Box<Self>) -> io::Result<()> {
+            self.0.ends.fetch_add(1, Ordering::Relaxed);
             Ok(())
         }
     }
@@ -443,49 +429,43 @@ mod tests {
     #[tokio::test]
     async fn multiplex_sink_routes_user_heap_to_tap() {
         let lander = DiskLanderSink::new(CatalogFilenodes::new());
-        let tap = CountingTap::default();
-        let mut mux = MultiplexSink::new(lander, tap);
+        let counts = Arc::new(TapCounts::default());
+        let mux = MultiplexSink::new(lander, CountingTap(counts.clone()));
 
-        let m = FileMeta {
-            path: PathBuf::from("base/5/1259"),
+        let file = |p: &str| FileMeta {
+            path: PathBuf::from(p),
             size: 0,
             mode: 0,
             kind: FileKind::File,
         };
-        assert_eq!(mux.begin(EntryId(0), &m).await.unwrap(), FileAction::Keep);
-        mux.end(EntryId(0)).await.unwrap();
+        assert!(matches!(
+            mux.begin(&file("base/5/1259")).await.unwrap(),
+            FileAction::Keep
+        ));
 
-        let m = FileMeta {
-            path: PathBuf::from("base/5/16400"),
-            size: 0,
-            mode: 0,
-            kind: FileKind::File,
+        let FileAction::Tap(mut entry) = mux.begin(&file("base/5/16400")).await.unwrap() else {
+            panic!("user heap must tap");
         };
-        assert_eq!(mux.begin(EntryId(1), &m).await.unwrap(), FileAction::Tap);
-        mux.chunk(EntryId(1), &[0u8; 1024]).await.unwrap();
-        mux.chunk(EntryId(1), &[1u8; 512]).await.unwrap();
-        mux.end(EntryId(1)).await.unwrap();
+        entry.chunk(&[0u8; 1024]).await.unwrap();
+        entry.chunk(&[1u8; 512]).await.unwrap();
+        entry.end().await.unwrap();
 
-        let m = FileMeta {
-            path: PathBuf::from("pg_replslot/0/state"),
-            size: 0,
-            mode: 0,
-            kind: FileKind::File,
-        };
-        assert_eq!(mux.begin(EntryId(2), &m).await.unwrap(), FileAction::Skip);
-        mux.end(EntryId(2)).await.unwrap();
+        assert!(matches!(
+            mux.begin(&file("pg_replslot/0/state")).await.unwrap(),
+            FileAction::Skip
+        ));
 
-        let (lander, tap) = mux.into_inner();
-        assert_eq!(tap.begins, 1);
-        assert_eq!(tap.chunks, 2);
-        assert_eq!(tap.ends, 1);
-        assert_eq!(tap.bytes, 1536);
-        assert_eq!(lander.stats.kept_files, 1);
-        // User heap delegated to tap; lander never begin'd it so
-        // skipped_user_heap stays 0. tap.begins == 1 is the
-        // operator-visible "routed away from disk" signal.
-        assert_eq!(lander.stats.skipped_user_heap, 0);
-        assert_eq!(lander.stats.skipped_denylist, 1);
+        let (lander, _) = mux.into_inner();
+        assert_eq!(ld(&counts.begins), 1);
+        assert_eq!(ld(&counts.chunks), 2);
+        assert_eq!(ld(&counts.ends), 1);
+        assert_eq!(ld(&counts.bytes), 1536);
+        assert_eq!(ld(&lander.stats.kept_files), 1);
+        // User heap delegated to tap, so the lander's own skip counter
+        // stays 0. `counts.begins == 1` is the operator-visible
+        // "routed away from disk" signal.
+        assert_eq!(ld(&lander.stats.skipped_user_heap), 0);
+        assert_eq!(ld(&lander.stats.skipped_denylist), 1);
     }
 
     #[test]
@@ -505,26 +485,18 @@ mod tests {
     #[tokio::test]
     async fn multiplex_lander_stats_exposes_disk_counters() {
         let lander = DiskLanderSink::new(CatalogFilenodes::new());
-        let mut mux = MultiplexSink::new(lander, CountingTap::default());
-        let m = FileMeta {
-            path: PathBuf::from("base/5/1259"),
+        let mux = MultiplexSink::new(lander, CountingTap(Arc::default()));
+        let file = |p: &str| FileMeta {
+            path: PathBuf::from(p),
             size: 0,
             mode: 0,
             kind: FileKind::File,
         };
-        assert_eq!(mux.begin(EntryId(0), &m).await.unwrap(), FileAction::Keep);
-        mux.end(EntryId(0)).await.unwrap();
-        let m = FileMeta {
-            path: PathBuf::from("pg_replslot/0/state"),
-            size: 0,
-            mode: 0,
-            kind: FileKind::File,
-        };
-        assert_eq!(mux.begin(EntryId(1), &m).await.unwrap(), FileAction::Skip);
-        mux.end(EntryId(1)).await.unwrap();
+        mux.begin(&file("base/5/1259")).await.unwrap();
+        mux.begin(&file("pg_replslot/0/state")).await.unwrap();
 
         let stats = mux.lander_stats();
-        assert_eq!(stats.kept_files, 1);
-        assert_eq!(stats.skipped_denylist, 1);
+        assert_eq!(ld(&stats.kept_files), 1);
+        assert_eq!(ld(&stats.skipped_denylist), 1);
     }
 }

--- a/src/backfill/backup_source.rs
+++ b/src/backfill/backup_source.rs
@@ -25,13 +25,26 @@
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
+use std::time::Instant;
 
 use async_trait::async_trait;
 use tokio::io::{AsyncRead, AsyncReadExt};
-use tokio::sync::Mutex;
 
 use walrus::pg::replication::base_backup::Tablespace;
+
+crate::atomic_stats! {
+    /// Bootstrap pump stage attribution, shared from the orchestrator down
+    /// through the source. Measures what the pump hands over, not what a
+    /// sink made of it: entry counts live on the sinks' own stats
+    pub struct PumpStats {
+        /// Body bytes handed to a `Tap` entry
+        pub bytes_tapped,
+        /// Inside `EntrySink::chunk`: page framing, decode, channel send.
+        /// Against `page_walk.decode_nanos` this is the tap's overhead
+        pub sink_chunk_nanos,
+    }
+}
 
 /// Filesystem-object kind. Tar-driven sources translate tar entry types
 /// here; the trait does not expose tar.
@@ -63,24 +76,48 @@ pub struct FileMeta {
 }
 
 /// Sink routing decision per file at `begin()`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FileAction {
     /// Source writes body / materializes dir or symlink under
-    /// `data_dir`; no `chunk()`
+    /// `data_dir`; no body callbacks
     Keep,
-    /// Source drains body unread; no land, no `chunk()`
+    /// Source drains body unread; no land, no body callbacks
     Skip,
-    /// Source streams body through `chunk()`, no land. Dir / Symlink
-    /// fire `chunk()` zero times
-    Tap,
+    /// Source streams the body into this owned sink, then drops it.
+    /// Owned rather than a shared-state decision so concurrent entries
+    /// need no lock on the body path. Dir / Symlink chunk zero times
+    Tap(Box<dyn EntrySink>),
 }
 
-/// Per-file token threaded through `begin`/`chunk`/`end`. Sinks key
-/// per-entry state on it so concurrent entries (object_store fan-out
-/// under `buffer_unordered`, sink mutex released across body reads)
-/// keep independent state. Monotonic per source run, globally unique.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct EntryId(pub u64);
+impl FileAction {
+    pub fn is_tap(&self) -> bool {
+        matches!(self, FileAction::Tap(_))
+    }
+}
+
+impl std::fmt::Debug for FileAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            FileAction::Keep => "Keep",
+            FileAction::Skip => "Skip",
+            FileAction::Tap(_) => "Tap",
+        })
+    }
+}
+
+/// One `Tap` entry's body consumer. Owned by the source task driving that
+/// entry, so nothing here contends with another entry: whatever state a
+/// page walk or SLRU accumulator needs lives in the impl, and shared
+/// state it does touch (catalog map, counters, channel sender) is
+/// already `Sync`.
+#[async_trait]
+pub trait EntrySink: Send {
+    /// Body bytes in file order, arbitrary chunk sizes. Awaiting here
+    /// backpressures the source
+    async fn chunk(&mut self, bytes: &[u8]) -> io::Result<()>;
+
+    /// Fires once, after the last `chunk`
+    async fn end(self: Box<Self>) -> io::Result<()>;
+}
 
 /// Mirrors wal-rus `pg::replication::base_backup::StartInfo` so callers
 /// wired to wal-rus types don't translate.
@@ -98,44 +135,54 @@ pub struct EndInfo {
     pub timeline: u32,
 }
 
-/// Per-file consumer, driven by [`BackupSource::run`]: `start` once,
-/// then per file `begin` / (if `Tap`) zero-or-more `chunk` / `end`,
-/// then `finish` once.
+/// Per-file router, driven by [`BackupSource::run`]: `start` once, then
+/// `begin` per file, then `finish` once. A `Tap` decision hands back its
+/// own [`EntrySink`], so the body path never re-enters here.
 ///
-/// `Send` because parallel source impls drive the sink from worker
-/// tasks. All methods async so a sink can backpressure its driver
-/// directly: `chunk` awaiting a full downstream channel parks the body
-/// read, which parks the source fetch. No intermediate buffer.
+/// `&self` throughout: routing reads immutable state and bumps atomics, so
+/// parallel source impls share one `Arc` with no lock. A source that holds
+/// a lock across a body read serializes every other entry behind it,
+/// which is what the owned entry sink exists to avoid.
 #[async_trait]
-pub trait BackupSink: Send {
-    async fn start(&mut self, _info: &StartInfo) -> io::Result<()> {
+pub trait BackupSink: Send + Sync {
+    async fn start(&self, _info: &StartInfo) -> io::Result<()> {
         Ok(())
     }
 
     /// Must be cheap; per-file dispatch is the hot path
-    async fn begin(&mut self, entry: EntryId, meta: &FileMeta) -> io::Result<FileAction>;
+    async fn begin(&self, meta: &FileMeta) -> io::Result<FileAction>;
 
-    /// Body bytes for a `Tap` entry, in file order per entry, arbitrary
-    /// chunk sizes. Calls for distinct entries may interleave. Awaiting
-    /// here backpressures the source.
-    async fn chunk(&mut self, entry: EntryId, bytes: &[u8]) -> io::Result<()>;
-
-    /// Fires once per `begin()`, regardless of action returned
-    async fn end(&mut self, entry: EntryId) -> io::Result<()>;
-
-    async fn finish(&mut self, _info: &EndInfo) -> io::Result<()> {
+    async fn finish(&self, _info: &EndInfo) -> io::Result<()> {
         Ok(())
     }
 }
 
-/// `data_dir` receives `Keep`d bodies. Sink behind `Arc<Mutex<_>>` so
-/// parallel source impls share it without per-worker copies.
+/// Everything a tar-part driver needs behind one `Arc`, so a parallel
+/// source hands its workers a clone instead of four arguments. `data_dir`
+/// receives `Keep`d bodies.
+pub struct PumpTarget {
+    pub data_dir: PathBuf,
+    pub sink: Arc<dyn BackupSink>,
+    pub stats: Arc<PumpStats>,
+}
+
+impl PumpTarget {
+    pub fn new(data_dir: PathBuf, sink: Arc<dyn BackupSink>, stats: Arc<PumpStats>) -> Self {
+        Self {
+            data_dir,
+            sink,
+            stats,
+        }
+    }
+}
+
 #[async_trait]
 pub trait BackupSource: Send {
     async fn run(
         self: Box<Self>,
         data_dir: PathBuf,
-        sink: Arc<Mutex<dyn BackupSink>>,
+        sink: Arc<dyn BackupSink>,
+        stats: Arc<PumpStats>,
     ) -> anyhow::Result<(StartInfo, EndInfo)>;
 }
 
@@ -190,11 +237,9 @@ pub(crate) fn tar_entry_meta<R: AsyncRead + Unpin>(
 /// Drain one tokio_tar archive against a sink, emitting per-entry
 /// callbacks. Called by `DirectSource` (per `BackupEvent::Archive.body`)
 /// and `ObjectStoreSource` (per fetched tar part).
-pub(crate) async fn pump_tar_to_sink<R>(
+pub async fn pump_tar_to_sink<R>(
     archive: &mut tokio_tar::Archive<R>,
-    data_dir: &Path,
-    sink: &Arc<Mutex<dyn BackupSink>>,
-    next_entry: &AtomicU64,
+    target: &PumpTarget,
 ) -> io::Result<()>
 where
     R: AsyncRead + Unpin + Send,
@@ -207,35 +252,22 @@ where
         let Some(meta) = tar_entry_meta(&entry)? else {
             continue;
         };
-        let id = EntryId(next_entry.fetch_add(1, Ordering::Relaxed));
-        pump_entry(&mut entry, &meta, data_dir, sink, id).await?;
+        pump_entry(&mut entry, &meta, target).await?;
     }
     Ok(())
 }
 
 /// One tar entry through the sink. Factored so callers can drive
 /// non-tar-shaped FileMeta sequences (e.g. inline symlink emission).
-pub(crate) async fn pump_entry<R>(
-    body: &mut R,
-    meta: &FileMeta,
-    data_dir: &Path,
-    sink: &Arc<Mutex<dyn BackupSink>>,
-    entry: EntryId,
-) -> io::Result<()>
+pub async fn pump_entry<R>(body: &mut R, meta: &FileMeta, target: &PumpTarget) -> io::Result<()>
 where
     R: AsyncRead + Unpin + ?Sized,
 {
-    let action = {
-        let mut s = sink.lock().await;
-        s.begin(entry, meta).await?
-    };
-    match action {
-        FileAction::Keep => write_kept(body, meta, data_dir).await?,
-        FileAction::Skip => drain_to_void(body).await?,
-        FileAction::Tap => stream_to_sink(body, meta, sink, entry).await?,
+    match target.sink.begin(meta).await? {
+        FileAction::Keep => write_kept(body, meta, &target.data_dir).await,
+        FileAction::Skip => drain_to_void(body).await,
+        FileAction::Tap(entry) => stream_to_entry(body, meta, entry, &target.stats).await,
     }
-    let mut s = sink.lock().await;
-    s.end(entry).await
 }
 
 async fn drain_to_void<R>(body: &mut R) -> io::Result<()>
@@ -252,18 +284,18 @@ where
     Ok(())
 }
 
-async fn stream_to_sink<R>(
+async fn stream_to_entry<R>(
     body: &mut R,
     meta: &FileMeta,
-    sink: &Arc<Mutex<dyn BackupSink>>,
-    entry: EntryId,
+    mut entry: Box<dyn EntrySink>,
+    stats: &PumpStats,
 ) -> io::Result<()>
 where
     R: AsyncRead + Unpin + ?Sized,
 {
     if !matches!(meta.kind, FileKind::File) {
         drain_to_void(body).await?;
-        return Ok(());
+        return entry.end().await;
     }
     let mut buf = [0u8; 64 * 1024];
     loop {
@@ -271,13 +303,16 @@ where
         if n == 0 {
             break;
         }
-        // Guard held across the chunk await: a full downstream channel
-        // parks this read (and any concurrent part contending the lock),
-        // propagating backpressure to the source fetch
-        let mut s = sink.lock().await;
-        s.chunk(entry, &buf[..n]).await?;
+        stats.bytes_tapped.fetch_add(n as u64, Ordering::Relaxed);
+        // Awaiting here parks only this entry's read, and through it this
+        // part's fetch. Other parts keep draining
+        let entered = Instant::now();
+        entry.chunk(&buf[..n]).await?;
+        stats
+            .sink_chunk_nanos
+            .fetch_add(entered.elapsed().as_nanos() as u64, Ordering::Relaxed);
     }
-    Ok(())
+    entry.end().await
 }
 
 async fn write_kept<R>(body: &mut R, meta: &FileMeta, data_dir: &Path) -> io::Result<()>
@@ -339,9 +374,7 @@ where
 #[allow(dead_code)]
 pub(crate) async fn emit_tablespace_symlink(
     tablespace: &Tablespace,
-    data_dir: &Path,
-    sink: &Arc<Mutex<dyn BackupSink>>,
-    entry: EntryId,
+    target: &PumpTarget,
 ) -> io::Result<()> {
     if tablespace.is_default() {
         return Ok(());
@@ -355,7 +388,7 @@ pub(crate) async fn emit_tablespace_symlink(
         },
     };
     let mut body = tokio::io::empty();
-    pump_entry(&mut body, &meta, data_dir, sink, entry).await
+    pump_entry(&mut body, &meta, target).await
 }
 
 #[cfg(test)]
@@ -417,34 +450,59 @@ mod tests {
     use super::*;
 
     /// Collects every callback into `events` so tests assert on the
-    /// exact sequence; `tapped` holds captured Tap chunks per file.
+    /// exact sequence; `tapped` holds captured Tap bodies per file.
     #[derive(Debug, Default)]
     pub(crate) struct RecordingSink {
-        pub events: Vec<Event>,
-        pub tapped: Vec<(PathBuf, Vec<u8>)>,
-        cur_path: Option<PathBuf>,
-        cur_tap: Option<Vec<u8>>,
+        pub events: std::sync::Mutex<Vec<Event>>,
+        pub tapped: std::sync::Mutex<Vec<(PathBuf, Vec<u8>)>>,
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub(crate) enum Event {
         Start { start_lsn: u64, timeline: u32 },
-        Begin { path: PathBuf, action: FileAction },
+        Begin { path: PathBuf, action: &'static str },
         Chunk { len: usize },
         End { path: PathBuf },
         Finish { end_lsn: u64 },
     }
 
+    /// Owned per-entry recorder, so the sink itself stays lock-free on the
+    /// body path exactly as production sinks do
+    struct RecordingEntry {
+        sink: Arc<RecordingSink>,
+        path: PathBuf,
+        body: Vec<u8>,
+    }
+
     #[async_trait]
-    impl BackupSink for RecordingSink {
-        async fn start(&mut self, info: &StartInfo) -> io::Result<()> {
-            self.events.push(Event::Start {
+    impl EntrySink for RecordingEntry {
+        async fn chunk(&mut self, bytes: &[u8]) -> io::Result<()> {
+            self.sink
+                .events
+                .lock()
+                .unwrap()
+                .push(Event::Chunk { len: bytes.len() });
+            self.body.extend_from_slice(bytes);
+            Ok(())
+        }
+        async fn end(self: Box<Self>) -> io::Result<()> {
+            let RecordingEntry { sink, path, body } = *self;
+            sink.tapped.lock().unwrap().push((path.clone(), body));
+            sink.events.lock().unwrap().push(Event::End { path });
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl BackupSink for Arc<RecordingSink> {
+        async fn start(&self, info: &StartInfo) -> io::Result<()> {
+            self.events.lock().unwrap().push(Event::Start {
                 start_lsn: info.start_lsn,
                 timeline: info.timeline,
             });
             Ok(())
         }
-        async fn begin(&mut self, _entry: EntryId, meta: &FileMeta) -> io::Result<FileAction> {
+        async fn begin(&self, meta: &FileMeta) -> io::Result<FileAction> {
             let s = meta.path.to_string_lossy();
             let action = if s.starts_with("pg_replslot/") {
                 if matches!(meta.kind, FileKind::Dir) {
@@ -453,35 +511,31 @@ mod tests {
                     FileAction::Skip
                 }
             } else if s == "base/5/16400" {
-                FileAction::Tap
+                FileAction::Tap(Box::new(RecordingEntry {
+                    sink: self.clone(),
+                    path: meta.path.clone(),
+                    body: Vec::new(),
+                }))
             } else {
                 FileAction::Keep
             };
-            self.events.push(Event::Begin {
+            self.events.lock().unwrap().push(Event::Begin {
                 path: meta.path.clone(),
-                action,
+                action: match action {
+                    FileAction::Keep => "Keep",
+                    FileAction::Skip => "Skip",
+                    FileAction::Tap(_) => "Tap",
+                },
             });
-            self.cur_path = Some(meta.path.clone());
-            self.cur_tap = (action == FileAction::Tap).then(Vec::new);
+            if !action.is_tap() {
+                self.events.lock().unwrap().push(Event::End {
+                    path: meta.path.clone(),
+                });
+            }
             Ok(action)
         }
-        async fn chunk(&mut self, _entry: EntryId, bytes: &[u8]) -> io::Result<()> {
-            self.events.push(Event::Chunk { len: bytes.len() });
-            if let Some(buf) = self.cur_tap.as_mut() {
-                buf.extend_from_slice(bytes);
-            }
-            Ok(())
-        }
-        async fn end(&mut self, _entry: EntryId) -> io::Result<()> {
-            let path = self.cur_path.take().unwrap_or_default();
-            if let Some(buf) = self.cur_tap.take() {
-                self.tapped.push((path.clone(), buf));
-            }
-            self.events.push(Event::End { path });
-            Ok(())
-        }
-        async fn finish(&mut self, info: &EndInfo) -> io::Result<()> {
-            self.events.push(Event::Finish {
+        async fn finish(&self, info: &EndInfo) -> io::Result<()> {
+            self.events.lock().unwrap().push(Event::Finish {
                 end_lsn: info.end_lsn,
             });
             Ok(())
@@ -573,13 +627,11 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
         let tar_bytes = testing::build_synthetic_tar().await;
-        let recording = Arc::new(Mutex::new(RecordingSink::default()));
-        let sink: Arc<Mutex<dyn BackupSink>> = recording.clone();
+        let recording = Arc::new(RecordingSink::default());
+        let sink: Arc<dyn BackupSink> = Arc::new(recording.clone());
         let mut archive = tokio_tar::Archive::new(std::io::Cursor::new(tar_bytes));
-        let next_entry = AtomicU64::new(0);
-        pump_tar_to_sink(&mut archive, data_dir, &sink, &next_entry)
-            .await
-            .unwrap();
+        let target = PumpTarget::new(data_dir.to_path_buf(), sink, Arc::new(PumpStats::default()));
+        pump_tar_to_sink(&mut archive, &target).await.unwrap();
 
         assert!(data_dir.join("base/5/1259").exists(), "catalog must land");
         assert!(data_dir.join("global/1213").exists(), "global must land");
@@ -590,10 +642,9 @@ mod tests {
         // User heap tapped, not landed
         assert!(!data_dir.join("base/5/16400").exists());
 
-        let r = recording.lock().await;
+        let events = recording.events.lock().unwrap();
         // Last file event must be pg_control end (contract 3)
-        let last_end = r
-            .events
+        let last_end = events
             .iter()
             .rev()
             .find_map(|e| match e {
@@ -603,8 +654,7 @@ mod tests {
             .unwrap();
         assert_eq!(last_end, PathBuf::from("pg_control"));
         // Tapped chunks sum to the file body length
-        let tapped_bytes: usize = r
-            .events
+        let tapped_bytes: usize = events
             .iter()
             .filter_map(|e| match e {
                 Event::Chunk { len } => Some(*len),

--- a/src/backfill/backup_source_direct.rs
+++ b/src/backfill/backup_source_direct.rs
@@ -10,18 +10,17 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
 
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::mpsc;
 use walrus::pg::replication::base_backup::{
     BackupEvent, BaseBackupOpts, ChannelReader, run_base_backup,
 };
 use walrus::pg::replication::conn::{PgConfig, ReplicationConn};
 
 use crate::backfill::backup_source::{
-    BackupSink, BackupSource, EndInfo, StartInfo, pump_tar_to_sink,
+    BackupSink, BackupSource, EndInfo, PumpStats, PumpTarget, StartInfo, pump_tar_to_sink,
 };
 
 /// Replication-protocol BASE_BACKUP issuer
@@ -41,7 +40,8 @@ impl BackupSource for DirectSource {
     async fn run(
         self: Box<Self>,
         data_dir: PathBuf,
-        sink: Arc<Mutex<dyn BackupSink>>,
+        sink: Arc<dyn BackupSink>,
+        stats: Arc<PumpStats>,
     ) -> Result<(StartInfo, EndInfo)> {
         let DirectSource { source, opts } = *self;
 
@@ -58,9 +58,7 @@ impl BackupSource for DirectSource {
 
         let mut start: Option<StartInfo> = None;
         let mut end: Option<EndInfo> = None;
-        // Archives drain sequentially here; shared counter kept for
-        // symmetry with object_store's concurrent parts
-        let next_entry = AtomicU64::new(0);
+        let target = PumpTarget::new(data_dir, sink.clone(), stats);
 
         while let Some(ev) = rx.recv().await {
             let ev = ev.context("DirectSource: BASE_BACKUP event channel")?;
@@ -71,10 +69,7 @@ impl BackupSource for DirectSource {
                         timeline: s.timeline,
                         tablespaces: s.tablespaces,
                     };
-                    {
-                        let mut g = sink.lock().await;
-                        g.start(&s).await?;
-                    }
+                    sink.start(&s).await?;
                     start = Some(s);
                 }
                 BackupEvent::Archive { meta, body } => {
@@ -84,17 +79,14 @@ impl BackupSource for DirectSource {
                         oid = meta.oid,
                         "archive open",
                     );
-                    drive_archive(body, &data_dir, sink.clone(), &next_entry).await?;
+                    drive_archive(body, &target).await?;
                 }
                 BackupEvent::Finish(e) => {
                     let e = EndInfo {
                         end_lsn: e.end_lsn,
                         timeline: e.timeline,
                     };
-                    {
-                        let mut g = sink.lock().await;
-                        g.finish(&e).await?;
-                    }
+                    sink.finish(&e).await?;
                     end = Some(e);
                 }
             }
@@ -115,13 +107,11 @@ impl BackupSource for DirectSource {
 /// SyncIoBridge / spawn_blocking.
 async fn drive_archive(
     body: mpsc::Receiver<std::io::Result<bytes::Bytes>>,
-    data_dir: &std::path::Path,
-    sink: Arc<Mutex<dyn BackupSink>>,
-    next_entry: &AtomicU64,
+    target: &PumpTarget,
 ) -> Result<()> {
     let reader = ChannelReader::new(body);
     let mut archive = tokio_tar::Archive::new(reader);
-    pump_tar_to_sink(&mut archive, data_dir, &sink, next_entry)
+    pump_tar_to_sink(&mut archive, target)
         .await
         .context("DirectSource: tar unpack")?;
     Ok(())

--- a/src/backfill/backup_source_object_store.rs
+++ b/src/backfill/backup_source_object_store.rs
@@ -28,9 +28,6 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
-
-use tokio::sync::Mutex;
 
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
@@ -45,7 +42,7 @@ use crate::backfill::backup_sentinel::build_lsn_pair;
 #[cfg(test)]
 use crate::backfill::backup_sentinel::{parse_timeline_from_name, tablespaces_from_spec};
 use crate::backfill::backup_source::{
-    BackupSink, BackupSource, EndInfo, StartInfo, pump_tar_to_sink,
+    BackupSink, BackupSource, EndInfo, PumpStats, PumpTarget, StartInfo, pump_tar_to_sink,
 };
 
 /// `parallelism` bounds in-flight data parts; `pg_control` always runs
@@ -90,7 +87,8 @@ impl BackupSource for ObjectStoreSource {
     async fn run(
         self: Box<Self>,
         data_dir: PathBuf,
-        sink: Arc<Mutex<dyn BackupSink>>,
+        sink: Arc<dyn BackupSink>,
+        stats: Arc<PumpStats>,
     ) -> Result<(StartInfo, EndInfo)> {
         let ObjectStoreSource {
             settings,
@@ -124,10 +122,7 @@ impl BackupSource for ObjectStoreSource {
         }
 
         let (start, end) = build_lsn_pair(&resolved, &sentinel)?;
-        {
-            let mut g = sink.lock().await;
-            g.start(&start).await?;
-        }
+        sink.start(&start).await?;
 
         let parts = list_tar_parts(&storage, &resolved).await?;
         if parts.is_empty() {
@@ -149,10 +144,7 @@ impl BackupSource for ObjectStoreSource {
             "draining tar partitions"
         );
 
-        // Shared counter across concurrent parts; unique EntryId per
-        // entry keeps interleaved begin/chunk on the shared sink mutex
-        // from clobbering each other's page-walk slot.
-        let next_entry = Arc::new(AtomicU64::new(0));
+        let target = Arc::new(PumpTarget::new(data_dir, sink.clone(), stats));
 
         // Phase A: bounded fan-out of data parts via buffer_unordered
         // try_collect short-circuits on the first part error. A plain
@@ -161,16 +153,9 @@ impl BackupSource for ObjectStoreSource {
             .map(|key| {
                 let storage = storage.clone();
                 let settings = settings.clone();
-                let data_dir = data_dir.clone();
-                let sink = sink.clone();
-                let next_entry = next_entry.clone();
                 let spool = part_spool_dir.clone();
-                async move {
-                    unpack_one_part(
-                        &settings, &storage, &key, &data_dir, &spool, sink, next_entry,
-                    )
-                    .await
-                }
+                let target = target.clone();
+                async move { unpack_one_part(&settings, &storage, &key, &spool, &target).await }
             })
             .buffer_unordered(parallelism)
             .try_collect::<Vec<_>>()
@@ -179,22 +164,10 @@ impl BackupSource for ObjectStoreSource {
         // Phase B: pg_control barrier, single-task. wal-g emits one
         // control part; walk in sorted order if ever more
         for key in &control_parts {
-            unpack_one_part(
-                &settings,
-                &storage,
-                key,
-                &data_dir,
-                &part_spool_dir,
-                sink.clone(),
-                next_entry.clone(),
-            )
-            .await?;
+            unpack_one_part(&settings, &storage, key, &part_spool_dir, &target).await?;
         }
 
-        {
-            let mut g = sink.lock().await;
-            g.finish(&end).await?;
-        }
+        sink.finish(&end).await?;
         Ok((start, end))
     }
 }
@@ -206,10 +179,8 @@ async fn unpack_one_part(
     settings: &Settings,
     storage: &DynStorage,
     key: &str,
-    data_dir: &std::path::Path,
     part_spool_dir: &std::path::Path,
-    sink: Arc<Mutex<dyn BackupSink>>,
-    next_entry: Arc<AtomicU64>,
+    target: &PumpTarget,
 ) -> Result<()> {
     let method = method_from_key(key);
     let body = storage
@@ -222,7 +193,7 @@ async fn unpack_one_part(
     let decoded = compression::decode(method, Box::pin(spooled));
 
     let mut archive = tokio_tar::Archive::new(decoded);
-    pump_tar_to_sink(&mut archive, data_dir, &sink, &next_entry)
+    pump_tar_to_sink(&mut archive, target)
         .await
         .with_context(|| format!("ObjectStoreSource: tar unpack {key}"))?;
     tracing::info!(
@@ -242,6 +213,13 @@ async fn unpack_one_part(
 /// so no error or panic path can leak it. Same trick as
 /// [`crate::spill::BodySpoolFile`]. Bytes are still compressed here, so
 /// scratch tracks object size rather than the unpacked tar.
+///
+/// Per-entry tap sinks removed the shared-lock stall this was also
+/// covering, and the page walk outruns any realistic GET, but the spool
+/// stays: the pipeline it feeds backpressures
+/// on ClickHouse by design, so a live body would be held for however long
+/// CH is the limiter, which the 60s cap does not allow. Decode speed was
+/// never the binding term.
 async fn spool_backup_part(
     dir: &std::path::Path,
     key: &str,

--- a/src/backfill/bootstrap_oracle.rs
+++ b/src/backfill/bootstrap_oracle.rs
@@ -28,6 +28,7 @@ impl BootstrapOracle {
         source_conninfo: String,
         source_password: Option<String>,
         bridge_lib_dir: Option<PathBuf>,
+        workers: usize,
         connect_budget: Duration,
     ) -> Result<Self> {
         let data_dir = base_dir.join("pg");
@@ -73,6 +74,7 @@ impl BootstrapOracle {
             let mut bridge = BridgeConf::in_dir(&b_sock);
             bridge.socket_path = b_bridge;
             bridge.library_dir = bridge_lib_dir;
+            bridge.workers = workers;
             let cfg_b = oracle_cfg(&b_data, &b_base, &b_sock, Some(bridge));
             let b = Shadow::new(cfg_b);
             b.write_base_conf().context("serve conf")?;
@@ -83,9 +85,10 @@ impl BootstrapOracle {
         .context("bootstrap oracle provision task")?
         .context("bootstrap oracle provision")?;
 
-        let bridge = crate::ops::bridge::connect_with_budget(&bridge_socket, connect_budget)
-            .await
-            .context("bootstrap oracle bridge connect")?;
+        let bridge =
+            crate::ops::bridge::connect_with_budget(&bridge_socket, workers, connect_budget)
+                .await
+                .context("bootstrap oracle bridge connect")?;
         Ok(Self {
             shadow,
             oracle: Arc::new(Oracle::new(Arc::new(bridge))),
@@ -95,6 +98,12 @@ impl BootstrapOracle {
 
     pub fn oracle(&self) -> Arc<Oracle> {
         self.oracle.clone()
+    }
+
+    /// Outlives the throwaway PG, so bootstrap's oracle cost keeps rendering
+    /// after handoff
+    pub fn bridge_stats(&self) -> Arc<crate::ops::bridge::BridgeStats> {
+        self.oracle.bridge_stats()
     }
 }
 
@@ -260,6 +269,7 @@ fn should_drop_entry(seg: &[&str], excluded: &std::collections::HashSet<&str>) -
     })
 }
 
+/// Include every mapped relation, window WAL also emits snapshot opt-outs
 pub fn needs_oracle(
     catalog: &CatalogMap,
     tables: &MappingSnapshot,

--- a/src/backfill/bootstrap_window.rs
+++ b/src/backfill/bootstrap_window.rs
@@ -35,9 +35,6 @@ use ahash::HashSet;
 /// Wind-down poll while source sends no WAL
 const STOP_POLL: Duration = Duration::from_millis(100);
 
-/// Maximum wait for transactions open below handoff
-const WIND_DOWN_MAX: Duration = Duration::from_secs(5);
-
 /// Inputs shared with concurrent bootstrap drain
 #[derive(Clone)]
 pub struct WindowLegConfig {
@@ -60,6 +57,7 @@ pub struct WindowLegConfig {
     pub pg_major: u32,
     pub system_id: String,
     pub timeline: u32,
+    pub wind_down: Duration,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -85,7 +83,7 @@ pub async fn stream_window(
     let leg = Leg::open(&cfg, from_lsn)
         .await
         .context("bootstrap window leg: open")?;
-    run_live(leg, cfg.timeline, feed, from_lsn, stop).await
+    run_live(leg, cfg.timeline, feed, from_lsn, stop, cfg.wind_down).await
 }
 
 /// Replay window WAL already on disk
@@ -194,7 +192,7 @@ impl Leg {
         let (filter_rfns, targets) = replay_scope(&cfg.catalog);
         let tail = OwnedTail::spawn(
             &cfg.emitter,
-            1,
+            cfg.emitter.inserter_pool_size,
             cfg.stats.clone(),
             cfg.fatal.clone(),
             None,
@@ -312,6 +310,7 @@ async fn run_live(
     feed: &mut SourceFeed,
     from_lsn: u64,
     mut stop: watch::Receiver<Option<u64>>,
+    wind_down_max: Duration,
 ) -> Result<WindowLegStats> {
     let begin = read_start(from_lsn);
     feed.start_physical_replication(None, begin, timeline)
@@ -333,7 +332,7 @@ async fn run_live(
                 break Ok(());
             }
             let since = *wind_down.get_or_insert_with(std::time::Instant::now);
-            if since.elapsed() >= WIND_DOWN_MAX {
+            if since.elapsed() >= wind_down_max {
                 // Pump resumes from open_floor to rebuild these transactions
                 tracing::warn!(
                     target: "walshadow::bootstrap",

--- a/src/backfill/copy_backfill.rs
+++ b/src/backfill/copy_backfill.rs
@@ -85,6 +85,13 @@ use crate::schema::{
 };
 use crate::source::source_feed::open_sql_client;
 use crate::toast::ToastResolver;
+
+/// Rows per COPY-backfill channel hop. Byte trigger below bounds the wide-row
+/// case, so this only caps the narrow-row hop rate
+const COPY_SLAB_ROWS: usize = 1024;
+/// Decoded value bytes per hop. With
+/// [`BOOTSTRAP_TUPLE_CHANNEL_CAP`] this is the resident payload ceiling
+const COPY_SLAB_BYTES: usize = 1 << 20;
 use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 
 const LEDGER_FILENAME: &str = "backfills.toml";
@@ -330,15 +337,67 @@ fn column_plan(desc: &RelDescriptor) -> CopyPlan {
 }
 
 /// Copy visible, detoasted rows from `desc` into `tx`, tagged `lsn`
+///
+/// Slabs the channel: one hop per [`COPY_SLAB_BYTES`] of decoded values, not
+/// one per row. Byte-triggered so wide rows keep the resident bound whatever
+/// the row count
 pub(crate) async fn copy_rows_into(
     client: &tokio_postgres::Client,
     desc: &RelDescriptor,
     lsn: u64,
-    tx: &mpsc::Sender<BackfillTuple>,
+    tx: &mpsc::Sender<Vec<BackfillTuple>>,
+) -> anyhow::Result<u64> {
+    copy_selected_rows_into(client, desc, lsn, tx, None, &CopyRate::new(None)).await
+}
+
+#[derive(Clone)]
+pub struct CopyRate {
+    bytes_per_sec: Option<u64>,
+    next: Arc<Mutex<tokio::time::Instant>>,
+}
+
+impl CopyRate {
+    pub fn new(kib: Option<u32>) -> Self {
+        Self {
+            bytes_per_sec: kib.filter(|n| *n != 0).map(|n| u64::from(n) * 1024),
+            next: Arc::new(Mutex::new(tokio::time::Instant::now())),
+        }
+    }
+
+    async fn consume(&self, bytes: usize) {
+        if let Some(rate) = self.bytes_per_sec {
+            let mut next = self.next.lock().await;
+            *next = (*next).max(tokio::time::Instant::now())
+                + Duration::from_secs_f64(bytes as f64 / rate as f64);
+            tokio::time::sleep_until(*next).await;
+        }
+    }
+}
+
+pub(crate) async fn copy_selected_rows_into(
+    client: &tokio_postgres::Client,
+    desc: &RelDescriptor,
+    lsn: u64,
+    tx: &mpsc::Sender<Vec<BackfillTuple>>,
+    tids: Option<&[(u32, u16)]>,
+    rate: &CopyRate,
 ) -> anyhow::Result<u64> {
     let plan = column_plan(desc);
+    let predicate = if let Some(tids) = tids {
+        if tids.is_empty() {
+            return Ok(0);
+        }
+        let tids = tids
+            .iter()
+            .map(|(blk, off)| format!("'({blk},{off})'::tid"))
+            .collect::<Vec<_>>()
+            .join(",");
+        format!(" WHERE ctid = ANY (ARRAY[{tids}])")
+    } else {
+        String::new()
+    };
     let sql = format!(
-        "COPY (SELECT {} FROM ONLY {}.{}) TO STDOUT (FORMAT binary)",
+        "COPY (SELECT {} FROM ONLY {}.{}{predicate}) TO STDOUT (FORMAT binary)",
         plan.select,
         quote_ident(&desc.rel_name.namespace),
         quote_ident(&desc.rel_name.name),
@@ -348,11 +407,16 @@ pub(crate) async fn copy_rows_into(
     let stream = BinaryCopyOutStream::new(copy, &byte_fields);
     futures::pin_mut!(stream);
     let mut rows = 0u64;
+    let mut slab: Vec<BackfillTuple> = Vec::new();
+    let mut slab_bytes = 0usize;
+    let mut wire_bytes = 0;
     while let Some(row) = stream.next().await {
         let row = row.context("backfill: COPY stream")?;
         let mut columns: Vec<Option<ColumnValue>> = vec![None; plan.natts];
+        wire_bytes += 2 + 4 * plan.cols.len();
         for (i, cp) in plan.cols.iter().enumerate() {
             let raw: Option<&[u8]> = row.try_get(i).context("backfill: COPY field")?;
+            wire_bytes += raw.map_or(0, <[u8]>::len);
             let v = raw
                 .map(|raw| decode_field(cp.kind, cp.type_oid, raw))
                 .transpose()
@@ -360,7 +424,12 @@ pub(crate) async fn copy_rows_into(
                 .unwrap_or(ColumnValue::Null);
             columns[(cp.attnum - 1).max(0) as usize] = Some(v);
         }
-        tx.send(BackfillTuple {
+        slab_bytes += columns
+            .iter()
+            .flatten()
+            .map(ColumnValue::approx_bytes)
+            .sum::<usize>();
+        slab.push(BackfillTuple {
             rfn: desc.rfn,
             xid: 0,
             xmax: 0,
@@ -370,10 +439,21 @@ pub(crate) async fn copy_rows_into(
             blkno: 0,
             offnum: 0,
             columns,
-        })
-        .await
-        .map_err(|_| anyhow::anyhow!("backfill: drain closed early"))?;
+        });
         rows += 1;
+        if slab.len() >= COPY_SLAB_ROWS || slab_bytes >= COPY_SLAB_BYTES {
+            slab_bytes = 0;
+            rate.consume(std::mem::take(&mut wire_bytes)).await;
+            tx.send(std::mem::take(&mut slab))
+                .await
+                .map_err(|_| anyhow::anyhow!("backfill: drain closed early"))?;
+        }
+    }
+    if !slab.is_empty() {
+        rate.consume(wire_bytes).await;
+        tx.send(slab)
+            .await
+            .map_err(|_| anyhow::anyhow!("backfill: drain closed early"))?;
     }
     Ok(rows)
 }
@@ -1128,20 +1208,16 @@ impl CopyBackfiller {
 
         let mut catalog = CatalogMap::new();
         catalog.insert(desc.clone());
-        let (tup_tx, tup_rx) = mpsc::channel::<BackfillTuple>(BOOTSTRAP_TUPLE_CHANNEL_CAP);
+        let (tup_tx, tup_rx) = mpsc::channel::<Vec<BackfillTuple>>(BOOTSTRAP_TUPLE_CHANNEL_CAP);
         let drain = tokio::spawn(bootstrap::drain(
             tup_rx,
             catalog,
-            self.mapping.clone(),
+            self.mapping.snapshot().await,
             tail.msg_tx.clone(),
             tail.ack.clone(),
             self.stats.clone(),
-            // Disabled resolver never defers; spool stays empty
             ToastResolver::disabled(),
-            crate::backfill::spool::DeferredSpool::new(
-                self.spill_dir.join("copy_deferred.bin"),
-                crate::backfill::spool::DEFERRED_SPOOL_MEM_MAX,
-            ),
+            None,
             self.emitter.row_policy(),
             self.config_rx.as_ref().map(|rx| rx.borrow().clone()),
             HashSet::new(),
@@ -1195,6 +1271,27 @@ struct CopyOutcome {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn copy_rate_charges_each_batch_without_banking_idle_time() {
+        let rate = CopyRate::new(Some(32));
+        let start = tokio::time::Instant::now();
+        rate.consume(32 * 1024).await;
+        assert_eq!(start.elapsed(), Duration::from_secs(1));
+        let sibling = rate.clone();
+        let next = tokio::time::Instant::now();
+        tokio::join!(rate.consume(16 * 1024), sibling.consume(16 * 1024));
+        assert_eq!(next.elapsed(), Duration::from_secs(1));
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        let next = tokio::time::Instant::now();
+        rate.consume(16 * 1024).await;
+        assert_eq!(next.elapsed(), Duration::from_millis(500));
+        let unlimited = CopyRate::new(None);
+        let start = tokio::time::Instant::now();
+        unlimited.consume(1024 * 1024).await;
+        assert_eq!(start.elapsed(), Duration::ZERO);
+    }
+
     use crate::schema::{RelAttr, RelName, ReplIdent};
     use walrus::pg::walparser::RelFileNode;
 

--- a/src/backfill/visibility_gate.rs
+++ b/src/backfill/visibility_gate.rs
@@ -2,27 +2,32 @@
 //!
 //! [`stream_phase`] resolves hint bits and spools unknowns. [`resolve_phase`]
 //! uses complete backup transaction logs plus WAL commit overlay. Greenfield
-//! repairs relations whose tuples remain undecidable
+//! repairs tuples whose visibility remains undecidable
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use tokio::sync::mpsc;
+use tokio_util::task::AbortOnDropHandle;
 use walrus::pg::replication::conn::PgConfig;
 
 use crate::backfill::backup_page_walk::{BOOTSTRAP_TUPLE_CHANNEL_CAP, BackfillTuple, CatalogMap};
-use crate::backfill::spool::{DEFERRED_SPOOL_MEM_MAX, DeferredSpool};
-use crate::backfill::visibility_repair::{PendingReason, PendingSet, RepairStats, repair};
+use crate::backfill::copy_backfill::CopyRate;
+use crate::backfill::spool::DeferredSpool;
+use crate::backfill::visibility_repair::{RepairBatch, RepairScope, RepairStats, RowRepair};
 use crate::config::ResolvedConfig;
 use crate::decode::visibility::{
-    HEAP_XMAX_IS_MULTI, PgMultiXactAccum, PgXactAccum, PgXactPatch, PgXactView, Visibility,
-    read_pg_multixact, read_pg_xact, tuple_visibility,
+    HEAP_XMAX_IS_MULTI, PgXactPatch, PgXactView, Visibility, read_pg_multixact, read_pg_xact,
+    tuple_visibility,
 };
 use crate::emit::ch_emitter::{EmitterConfig, EmitterStats};
+use crate::emit::pipeline::ack::AckHandle;
+use crate::emit::pipeline::batcher::BatcherMsg;
+use crate::emit::pipeline::bootstrap::BootstrapDrainOutcome;
 use crate::emit::pipeline::tail::OwnedTail;
 use crate::emit::pipeline::{Fatal, bootstrap};
-use crate::mapping::MappingHandle;
+use crate::mapping::MappingSnapshot;
 use crate::schema::RelName;
 use crate::toast::ToastResolver;
 use ahash::HashSet;
@@ -35,69 +40,69 @@ pub struct GateStats {
     pub multixact_emitted: u64,
     /// Chunk tuples the hint bits proved dead, dropped before the store
     pub chunks_gated: u64,
-    /// Walked tuples replaced by relation repair
-    pub pending_discarded: u64,
-    /// Relations handed to visibility repair
-    pub pending_relations: u64,
-    /// Relations pending for undecidable multixacts
-    pub pending_multixact: u64,
+    /// Tuples handed to source visibility repair
+    pub unresolved: u64,
     /// Rows emitted by visibility repair
     pub repaired_rows: u64,
     /// Source write head after final repair read
     pub p_hi: u64,
 }
 
-/// Policy for tuples remaining undecidable
-#[derive(Debug)]
-pub enum Undecidable<'a> {
-    /// Abort per-table loads
-    Abort,
-    /// Hand greenfield relation to repair
-    Pending(&'a mut PendingSet),
+pub enum GateOutput<'a> {
+    Rows(&'a mpsc::Sender<Vec<BackfillTuple>>),
+    Repair(&'a mpsc::Sender<RepairBatch>),
+}
+
+impl GateOutput<'_> {
+    async fn send(&self, rows: Vec<BackfillTuple>, unresolved: bool) -> bool {
+        match self {
+            Self::Rows(tx) => tx.send(rows).await.is_ok(),
+            Self::Repair(tx) => tx.send(RepairBatch { rows, unresolved }).await.is_ok(),
+        }
+    }
 }
 
 /// Resolve hint bits, spool unknown main tuples, pass chunks unless proven dead
+///
+/// Slab in, slab out: the walk's batching survives the gate, which only drops
+/// what the verdict removes
 pub async fn stream_phase(
-    rx: &mut mpsc::Receiver<BackfillTuple>,
-    tx: &mpsc::Sender<BackfillTuple>,
+    rx: &mut mpsc::Receiver<Vec<BackfillTuple>>,
+    tx: &GateOutput<'_>,
     catalog: &CatalogMap,
-    pending: &mut PendingSet,
     deferred: &mut DeferredSpool,
     stats: &mut GateStats,
 ) -> Result<(), String> {
-    while let Some(t) = rx.recv().await {
-        if catalog.is_toast(t.rfn.db_node, t.rfn.rel_node) {
-            if tuple_visibility(t.xid, t.xmax, t.infomask, None) == Visibility::Skip {
-                stats.chunks_gated += 1;
+    while let Some(slab) = rx.recv().await {
+        let mut pass = Vec::with_capacity(slab.len());
+        for t in slab {
+            if catalog.is_toast(t.rfn.db_node, t.rfn.rel_node) {
+                if tuple_visibility(t.xid, t.xmax, t.infomask, None) == Visibility::Skip {
+                    stats.chunks_gated += 1;
+                    continue;
+                }
+                pass.push(t);
                 continue;
             }
-            if tx.send(t).await.is_err() {
-                break;
-            }
-            continue;
-        }
-        // Repair replaces main-page tuples
-        if pending.holds(t.rfn.db_node, t.rfn.rel_node) {
-            stats.pending_discarded += 1;
-            continue;
-        }
-        let visibility = tuple_visibility(t.xid, t.xmax, t.infomask, None);
-        if visibility != Visibility::Skip && pending.observe_external(&t) {
-            stats.pending_discarded += 1;
-            continue;
-        }
-        match visibility {
-            Visibility::Emit => {
-                if !emit(t, tx, stats).await {
-                    break;
+            let visibility = tuple_visibility(t.xid, t.xmax, t.infomask, None);
+            match visibility {
+                Visibility::Emit => {
+                    if t.infomask & HEAP_XMAX_IS_MULTI != 0 {
+                        stats.multixact_emitted += 1;
+                    }
+                    stats.emitted += 1;
+                    pass.push(t);
                 }
+                Visibility::Skip => stats.gated += 1,
+                // Multixact verdict requires complete view
+                Visibility::Defer | Visibility::Unresolvable => deferred
+                    .push(t)
+                    .await
+                    .map_err(|e| format!("visibility gate: deferred spool: {e}"))?,
             }
-            Visibility::Skip => stats.gated += 1,
-            // Multixact verdict requires complete view
-            Visibility::Defer | Visibility::Unresolvable => deferred
-                .push(t)
-                .await
-                .map_err(|e| format!("visibility gate: deferred spool: {e}"))?,
+        }
+        if !pass.is_empty() && !tx.send(pass, false).await {
+            break;
         }
     }
     stats.deferred = deferred.records();
@@ -108,10 +113,11 @@ pub async fn stream_phase(
 pub async fn resolve_phase(
     deferred: DeferredSpool,
     view: &PgXactView<'_>,
-    tx: &mpsc::Sender<BackfillTuple>,
-    mut undecidable: Undecidable<'_>,
+    tx: &GateOutput<'_>,
     stats: &mut GateStats,
 ) -> Result<(), String> {
+    let mut out = SlabTx::new(tx, false);
+    let mut repair = SlabTx::new(tx, true);
     let mut replay = deferred
         .into_reader()
         .await
@@ -122,31 +128,33 @@ pub async fn resolve_phase(
         .await
         .map_err(|e| format!("visibility gate: deferred spool replay: {e}"))?
     {
-        if let Undecidable::Pending(set) = &undecidable
-            && set.holds(t.rfn.db_node, t.rfn.rel_node)
-        {
-            stats.pending_discarded += 1;
-            continue;
-        }
         match tuple_visibility(t.xid, t.xmax, t.infomask, Some(view)) {
             Visibility::Emit => {
-                if !emit(t, tx, stats).await {
+                if t.infomask & HEAP_XMAX_IS_MULTI != 0 {
+                    stats.multixact_emitted += 1;
+                }
+                stats.emitted += 1;
+                if !out.push(t).await {
                     break;
                 }
             }
             Visibility::Skip | Visibility::Defer => stats.gated += 1,
-            Visibility::Unresolvable => match &mut undecidable {
-                Undecidable::Abort => {
+            Visibility::Unresolvable => match tx {
+                GateOutput::Rows(_) => {
                     fail = Some(undecidable_multixact(&t));
                     break;
                 }
-                Undecidable::Pending(set) => {
-                    set.mark(t.rfn, PendingReason::UnresolvedMultiXact);
-                    stats.pending_discarded += 1;
+                GateOutput::Repair(_) => {
+                    stats.unresolved += 1;
+                    if !repair.push(t).await {
+                        break;
+                    }
                 }
             },
         }
     }
+    out.flush().await;
+    repair.flush().await;
     replay
         .finish()
         .await
@@ -157,13 +165,47 @@ pub async fn resolve_phase(
     }
 }
 
-async fn emit(t: BackfillTuple, tx: &mpsc::Sender<BackfillTuple>, stats: &mut GateStats) -> bool {
-    if t.infomask & HEAP_XMAX_IS_MULTI != 0 {
-        stats.multixact_emitted += 1;
-    }
-    stats.emitted += 1;
-    tx.send(t).await.is_ok()
+/// Regroup a per-tuple source into walk-sized slabs, so the spool replay and
+/// repair reads cost the drain one channel hop per batch, not per row
+struct SlabTx<'a> {
+    tx: &'a GateOutput<'a>,
+    unresolved: bool,
+    buf: Vec<BackfillTuple>,
+    closed: bool,
 }
+
+impl<'a> SlabTx<'a> {
+    fn new(tx: &'a GateOutput<'a>, unresolved: bool) -> Self {
+        Self {
+            tx,
+            unresolved,
+            buf: Vec::with_capacity(GATE_SLAB_ROWS),
+            closed: false,
+        }
+    }
+
+    /// `false` once the drain hangs up
+    async fn push(&mut self, t: BackfillTuple) -> bool {
+        self.buf.push(t);
+        if self.buf.len() < GATE_SLAB_ROWS {
+            return !self.closed;
+        }
+        self.flush().await
+    }
+
+    async fn flush(&mut self) -> bool {
+        if self.closed || self.buf.is_empty() {
+            return !self.closed;
+        }
+        let slab = std::mem::replace(&mut self.buf, Vec::with_capacity(GATE_SLAB_ROWS));
+        self.closed = !self.tx.send(slab, self.unresolved).await;
+        !self.closed
+    }
+}
+
+/// Rows per slab out of the spool replay and repair reads. Row width is
+/// unbounded here, so the drain's own budget is the resident ceiling
+const GATE_SLAB_ROWS: usize = 256;
 
 fn undecidable_multixact(t: &BackfillTuple) -> String {
     format!(
@@ -173,31 +215,98 @@ fn undecidable_multixact(t: &BackfillTuple) -> String {
     )
 }
 
-/// Greenfield resolution inputs
-pub struct PendingGate {
-    pub deferred: DeferredSpool,
+/// Destination both greenfield legs write: page walk, then deferred
+/// resolution. One frozen mapping serves the repair scope and the drain's
+/// routes, so a route can never want a value the repair never read
+pub struct GreenfieldSink {
+    /// Source endpoint for repair reads
+    pub source: PgConfig,
     pub catalog: CatalogMap,
-    pub mapping: MappingHandle,
+    pub mapping: MappingSnapshot,
+    pub repair_scope: RepairScope,
+    pub copy_rate: CopyRate,
     pub config: Arc<ResolvedConfig>,
     pub emitter: EmitterConfig,
     pub stats: Arc<EmitterStats>,
     pub resolver: ToastResolver,
-    pub oracle: Option<Arc<crate::ops::oracle::Oracle>>,
     /// Relations excluded from initial load
     pub skip_initial: HashSet<RelName>,
-    /// Source endpoint for repair reads
-    pub source: PgConfig,
-    /// Relations handed to repair
-    pub pending: PendingSet,
-    /// Coverage tag for walked and repaired rows
-    pub start_lsn: u64,
-    /// Repair spill root
-    pub spill_dir: PathBuf,
+}
+
+/// Spawned repair and drain stages of one leg
+pub struct RepairDrain {
+    repair: AbortOnDropHandle<Result<RepairStats>>,
+    drain: AbortOnDropHandle<Result<BootstrapDrainOutcome, String>>,
+}
+
+impl GreenfieldSink {
+    /// Spawn source repair feeding the bootstrap drain. Gate stage owns the
+    /// returned sender; dropping it winds both stages down
+    pub fn spawn(
+        &self,
+        msg_tx: mpsc::Sender<BatcherMsg>,
+        ack: AckHandle,
+    ) -> (mpsc::Sender<RepairBatch>, RepairDrain) {
+        let (tx, rx) = mpsc::channel(BOOTSTRAP_TUPLE_CHANNEL_CAP);
+        let (repaired_tx, repaired_rx) = mpsc::channel(BOOTSTRAP_TUPLE_CHANNEL_CAP);
+        let repair = AbortOnDropHandle::new(tokio::spawn(
+            RowRepair {
+                source: self.source.clone(),
+                catalog: self.catalog.clone(),
+                scope: self.repair_scope.clone(),
+                rate: self.copy_rate.clone(),
+            }
+            .run(rx, repaired_tx),
+        ));
+        let drain = AbortOnDropHandle::new(tokio::spawn(bootstrap::drain(
+            repaired_rx,
+            self.catalog.clone(),
+            self.mapping.clone(),
+            msg_tx,
+            ack,
+            self.stats.clone(),
+            self.resolver.clone(),
+            // Repair strips mapped external pointers, so nothing defers
+            None,
+            self.emitter.row_policy(),
+            Some(self.config.clone()),
+            self.skip_initial.clone(),
+        )));
+        (tx, RepairDrain { repair, drain })
+    }
+}
+
+impl RepairDrain {
+    /// Join both stages before surfacing either error, so a failed repair
+    /// still lets the drain finish what it holds
+    pub async fn join(self) -> Result<(RepairStats, BootstrapDrainOutcome), String> {
+        let repaired = join_stage(self.repair, "row repair").await;
+        let drained = join_stage(self.drain, "drain").await;
+        Ok((repaired?, drained?))
+    }
+}
+
+async fn join_stage<T, E: std::fmt::Display>(
+    handle: AbortOnDropHandle<Result<T, E>>,
+    stage: &str,
+) -> Result<T, String> {
+    match handle.await {
+        Ok(Ok(v)) => Ok(v),
+        Ok(Err(e)) => Err(format!("bootstrap {stage}: {e:#}")),
+        Err(e) => Err(format!("bootstrap {stage} join: {e}")),
+    }
+}
+
+/// Greenfield resolution inputs
+pub struct PendingGate {
+    pub deferred: DeferredSpool,
+    pub sink: GreenfieldSink,
+    pub oracle: Option<Arc<crate::ops::oracle::Oracle>>,
     /// Streaming-phase counters
     pub stream_stats: GateStats,
 }
 
-/// Resolve deferred tuples and repair pending relations
+/// Resolve deferred tuples and repair unresolved visibility
 pub async fn resolve_greenfield(
     gate: PendingGate,
     data_dir: &Path,
@@ -205,42 +314,21 @@ pub async fn resolve_greenfield(
 ) -> Result<GateStats> {
     let PendingGate {
         deferred,
-        catalog,
-        mapping,
-        config,
-        emitter,
-        stats,
-        resolver,
+        sink,
         oracle,
-        skip_initial,
-        source,
-        mut pending,
-        start_lsn,
-        spill_dir,
         stream_stats: mut gate_stats,
     } = gate;
-    if deferred.records() == 0 && pending.is_empty() {
+    if deferred.records() == 0 {
         return Ok(gate_stats);
     }
-    // Repair rides the same drain, so it needs its own view of what the
-    // drain takes ownership of
-    let repair_catalog = catalog.clone();
-    let repair_skip = skip_initial.clone();
-    // SLRUs only answer the spool; a pending-only pass reads none of them
-    let (accum, multi) = if deferred.records() == 0 {
-        (PgXactAccum::new(), PgMultiXactAccum::new())
-    } else {
-        (
-            read_pg_xact(data_dir).await?,
-            read_pg_multixact(data_dir).await?,
-        )
-    };
+    let accum = read_pg_xact(data_dir).await?;
+    let multi = read_pg_multixact(data_dir).await?;
     let view = PgXactView::new(&accum, patch).with_multixact(&multi);
 
     let tail = OwnedTail::spawn(
-        &emitter,
-        1,
-        stats.clone(),
+        &sink.emitter,
+        sink.emitter.inserter_pool_size,
+        sink.stats.clone(),
         Fatal::new(),
         None,
         oracle,
@@ -249,57 +337,16 @@ pub async fn resolve_greenfield(
     .await
     .map_err(anyhow::Error::msg)?;
 
-    let toast_spool = spill_dir.join("bootstrap_gate_toast.bin");
-    tokio::fs::remove_file(&toast_spool).await.ok();
-    let (tx, rx) = mpsc::channel::<BackfillTuple>(BOOTSTRAP_TUPLE_CHANNEL_CAP);
-    let drain = tokio::spawn(bootstrap::drain(
-        rx,
-        catalog,
-        mapping,
-        tail.msg_tx.clone(),
-        tail.ack.clone(),
-        stats,
-        resolver,
-        DeferredSpool::new(toast_spool, DEFERRED_SPOOL_MEM_MAX),
-        emitter.row_policy(),
-        Some(config),
-        skip_initial,
-    ));
-
-    let mut resolved = resolve_phase(
-        deferred,
-        &view,
-        &tx,
-        Undecidable::Pending(&mut pending),
-        &mut gate_stats,
-    )
-    .await;
-    gate_stats.pending_relations = pending.len() as u64;
-    gate_stats.pending_multixact = pending.count_for(PendingReason::UnresolvedMultiXact);
-    if resolved.is_ok() {
-        match repair(
-            &pending,
-            &repair_catalog,
-            &repair_skip,
-            &source,
-            start_lsn,
-            &tx,
-        )
-        .await
-        {
-            Ok(r) => {
-                gate_stats.repaired_rows = r.rows;
-                gate_stats.p_hi = r.p_hi;
-                log_repair(&r, gate_stats.pending_multixact);
-            }
-            Err(e) => resolved = Err(format!("{e:#}")),
-        }
-    }
+    let (tx, stages) = sink.spawn(tail.msg_tx.clone(), tail.ack.clone());
+    let resolved = resolve_phase(deferred, &view, &GateOutput::Repair(&tx), &mut gate_stats).await;
     drop(tx);
-    let drained = drain.await.context("visibility gate: drain join")?;
     // Drain tail before surfacing errors
-    let next_seq = match (resolved, drained) {
-        (Ok(()), Ok(o)) => o.next_seq,
+    let next_seq = match (resolved, stages.join().await) {
+        (Ok(()), Ok((repaired, drained))) => {
+            gate_stats.repaired_rows += repaired.rows;
+            gate_stats.p_hi = gate_stats.p_hi.max(repaired.p_hi);
+            drained.next_seq
+        }
         (Err(e), _) | (_, Err(e)) => {
             tail.quiesce().await;
             anyhow::bail!(e);
@@ -309,30 +356,16 @@ pub async fn resolve_greenfield(
     Ok(gate_stats)
 }
 
-/// Log repair convergence frontier
-fn log_repair(r: &RepairStats, multixact_relations: u64) {
-    if r.relations == 0 && r.skipped == 0 {
-        return;
-    }
-    tracing::info!(
-        target: "walshadow::bootstrap",
-        relations = r.relations,
-        rows = r.rows,
-        skipped = r.skipped,
-        multixact_relations,
-        p_hi = r.p_hi,
-        "visibility repair read pending relations through PostgreSQL",
-    );
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::backfill::backup_page_walk::make_rel_named;
+    use crate::backfill::spool::DEFERRED_SPOOL_MEM_MAX;
     use crate::decode::visibility::{
         HEAP_XMAX_COMMITTED, HEAP_XMAX_INVALID, HEAP_XMAX_IS_MULTI, HEAP_XMIN_COMMITTED,
         HEAP_XMIN_INVALID,
     };
+    use crate::decode::visibility::{PgMultiXactAccum, PgXactAccum};
     use ahash::HashSetExt;
     use walrus::pg::walparser::RelFileNode;
 
@@ -383,32 +416,38 @@ mod tests {
     /// let through
     async fn run_stream_phase(
         catalog: &CatalogMap,
-        pending: &mut PendingSet,
         tuples: Vec<BackfillTuple>,
     ) -> (GateStats, Vec<BackfillTuple>) {
         let (tx, mut rx) = mpsc::channel(8);
         let (walk_tx, mut walk_rx) = mpsc::channel(8);
+        // One tuple per slab: exercises the per-tuple verdicts, not batching
         for t in tuples {
-            walk_tx.send(t).await.unwrap();
+            walk_tx.send(vec![t]).await.unwrap();
         }
         drop(walk_tx);
 
         let mut stats = GateStats::default();
         let mut spool = spool_of(Vec::new()).await;
-        stream_phase(&mut walk_rx, &tx, catalog, pending, &mut spool, &mut stats)
-            .await
-            .unwrap();
+        stream_phase(
+            &mut walk_rx,
+            &GateOutput::Rows(&tx),
+            catalog,
+            &mut spool,
+            &mut stats,
+        )
+        .await
+        .unwrap();
         drop(tx);
 
         let mut passed = Vec::new();
-        while let Some(t) = rx.recv().await {
-            passed.push(t);
+        while let Some(slab) = rx.recv().await {
+            passed.extend(slab);
         }
         (stats, passed)
     }
 
     #[tokio::test]
-    async fn repair_requires_a_mapped_external_value() {
+    async fn mapped_external_values_stream_without_marking_relations() {
         use crate::decode::heap_decoder::{ColumnValue, ToastPointer};
         use crate::mapping::{ColumnMapping, TableMapping, TableTarget};
         use crate::schema::RelName;
@@ -454,15 +493,13 @@ mod tests {
             .into_iter()
             .collect::<ahash::HashMap<_, _>>()
             .into();
-            let mut pending = PendingSet::mapped(&catalog, &mapping);
-            assert!(pending.is_empty());
+            let scope = RepairScope::mapped(&catalog, &mapping, |_| true);
             let row = |value, infomask| BackfillTuple {
                 columns: vec![Some(ColumnValue::Int4(1)), Some(value)],
                 ..tuple(100, 0, infomask)
             };
             let (stats, passed) = run_stream_phase(
                 &catalog,
-                &mut pending,
                 vec![
                     row(ColumnValue::Text("inline".into()), HEAP_XMIN_COMMITTED),
                     row(external.clone(), HEAP_XMIN_INVALID),
@@ -471,8 +508,9 @@ mod tests {
             )
             .await;
             assert_eq!(stats.gated, 1);
-            assert_eq!(pending.holds(5, 16400), body_mapped);
-            assert_eq!(passed.len(), if body_mapped { 1 } else { 2 });
+            assert_eq!(passed.len(), 2);
+            assert!(!scope.has_external(&passed[0]));
+            assert_eq!(scope.has_external(&passed[1]), body_mapped);
         }
     }
 
@@ -488,7 +526,6 @@ mod tests {
         // Deleted value, aborted insert, then one that is still live
         let (stats, passed) = run_stream_phase(
             &toast_catalog(16401),
-            &mut PendingSet::empty(),
             vec![
                 chunk(200, HEAP_XMIN_COMMITTED | HEAP_XMAX_COMMITTED),
                 chunk(0, HEAP_XMIN_INVALID),
@@ -504,53 +541,11 @@ mod tests {
         assert_eq!(stats.deferred, 0);
     }
 
-    /// Repair replaces main rows but preserves chunk cache
-    #[tokio::test]
-    async fn pending_relation_drops_its_pages_and_keeps_its_chunks() {
-        let mut catalog = CatalogMap::new();
-        catalog.insert(make_rel_named(
-            16400,
-            16400,
-            16402,
-            RelName::new("public", "t"),
-        ));
-        catalog.insert(make_rel_named(
-            16402,
-            16403,
-            0,
-            RelName::new("pg_toast", "pg_toast_16400"),
-        ));
-        let mut pending = PendingSet::toast_capable(&catalog);
-
-        let live = HEAP_XMIN_COMMITTED | HEAP_XMAX_INVALID;
-        let (stats, passed) = run_stream_phase(
-            &catalog,
-            &mut pending,
-            vec![
-                tuple(100, 0, live),
-                BackfillTuple {
-                    rfn: rfn(16403),
-                    ..tuple(100, 0, live)
-                },
-            ],
-        )
-        .await;
-
-        assert_eq!(stats.pending_discarded, 1, "its main page is dropped");
-        assert_eq!(stats.emitted, 0);
-        assert_eq!(
-            passed.iter().map(|t| t.rfn.rel_node).collect::<Vec<_>>(),
-            [16403],
-            "only its chunk reaches the store",
-        );
-    }
-
     /// Preserve chunks without decisive hint bits
     #[tokio::test]
     async fn undecidable_chunks_still_pass_through() {
         let (stats, passed) = run_stream_phase(
             &toast_catalog(16401),
-            &mut PendingSet::empty(),
             vec![BackfillTuple {
                 rfn: rfn(16401),
                 ..tuple(100, 0, 0)
@@ -564,41 +559,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn greenfield_hands_undecidable_multixact_relation_over() {
+    async fn greenfield_repairs_only_undecidable_tuples() {
         let accum = PgXactAccum::new();
         let patch = PgXactPatch::new();
-        // No collected offsets segment: the mxid is below any known range
         let multi = PgMultiXactAccum::new();
         let view = PgXactView::new(&accum, &patch).with_multixact(&multi);
         let (tx, mut rx) = mpsc::channel(4);
         let mut stats = GateStats::default();
         let spool = spool_of(vec![
+            tuple(100, 0, HEAP_XMIN_COMMITTED),
             tuple(100, 10, HEAP_XMIN_COMMITTED | HEAP_XMAX_IS_MULTI),
             tuple(100, 0, HEAP_XMIN_COMMITTED),
         ])
         .await;
-
-        let mut pending = PendingSet::empty();
-        resolve_phase(
-            spool,
-            &view,
-            &tx,
-            Undecidable::Pending(&mut pending),
-            &mut stats,
-        )
-        .await
-        .unwrap();
+        resolve_phase(spool, &view, &GateOutput::Repair(&tx), &mut stats)
+            .await
+            .unwrap();
         drop(tx);
-
-        assert!(
-            rx.recv().await.is_none(),
-            "an undecidable tuple is never guessed"
-        );
-        assert_eq!(stats.emitted, 0);
-        assert_eq!(stats.pending_discarded, 2);
-        assert_eq!(pending.len(), 1, "its relation goes to the repair path");
-        assert_eq!(pending.count_for(PendingReason::UnresolvedMultiXact), 1);
-        assert!(pending.holds(5, 16400));
+        let visible = rx.recv().await.expect("visible rows");
+        assert!(!visible.unresolved);
+        assert_eq!(visible.rows.len(), 2);
+        let unresolved = rx.recv().await.expect("unresolved row");
+        assert!(unresolved.unresolved);
+        assert_eq!(unresolved.rows.len(), 1);
+        assert_eq!(unresolved.rows[0].xmax, 10);
+        assert!(rx.recv().await.is_none());
+        assert_eq!(stats.emitted, 2);
+        assert_eq!(stats.unresolved, 1);
     }
 
     #[tokio::test]
@@ -616,7 +603,7 @@ mod tests {
         )])
         .await;
 
-        let err = resolve_phase(spool, &view, &tx, Undecidable::Abort, &mut stats)
+        let err = resolve_phase(spool, &view, &GateOutput::Rows(&tx), &mut stats)
             .await
             .unwrap_err();
         assert!(err.contains("pg_multixact"), "{err}");
@@ -628,18 +615,19 @@ mod tests {
     async fn resolve_greenfield_is_a_noop_without_deferrals() {
         let pending = PendingGate {
             deferred: spool_of(Vec::new()).await,
-            catalog: CatalogMap::new(),
-            mapping: crate::mapping::mapping_handle(Default::default()),
-            config: Arc::new(ResolvedConfig::default()),
-            emitter: EmitterConfig::default(),
-            stats: Arc::new(EmitterStats::default()),
-            resolver: ToastResolver::disabled(),
+            sink: GreenfieldSink {
+                source: crate::config::SourceConn::default().to_pg_config(),
+                catalog: CatalogMap::new(),
+                mapping: Default::default(),
+                repair_scope: RepairScope::default(),
+                copy_rate: CopyRate::new(None),
+                config: Arc::new(ResolvedConfig::default()),
+                emitter: EmitterConfig::default(),
+                stats: Arc::new(EmitterStats::default()),
+                resolver: ToastResolver::disabled(),
+                skip_initial: HashSet::new(),
+            },
             oracle: None,
-            skip_initial: HashSet::new(),
-            source: crate::config::SourceConn::default().to_pg_config(),
-            pending: PendingSet::empty(),
-            start_lsn: 0x1000,
-            spill_dir: std::env::temp_dir(),
             stream_stats: GateStats {
                 emitted: 7,
                 ..Default::default()

--- a/src/backfill/visibility_repair.rs
+++ b/src/backfill/visibility_repair.rs
@@ -1,201 +1,175 @@
-//! Replace relations whose backup-page visibility cannot be proven
+//! Repair external values and unresolved visibility through source CTID reads
 //!
-//! Read each pending relation through PostgreSQL `COPY`, emit visible,
-//! detoasted rows at page-walk coverage LSN. Keep chunk pages in mirror for
-//! later WAL rows carrying old external pointers
+//! Preserve chunk mirrors for WAL rows carrying old external pointers
 
 use anyhow::{Context, Result, bail};
 use tokio::sync::mpsc;
 use walrus::pg::replication::conn::PgConfig;
-use walrus::pg::walparser::{Oid, RelFileNode};
+use walrus::pg::walparser::Oid;
 
-use crate::backfill::backfill_bootstrap::seed_in_snapshot;
+use crate::backfill::backfill_bootstrap::seed_relation_from_source;
 use crate::backfill::backup_page_walk::{BackfillTuple, CatalogMap};
-use crate::backfill::copy_backfill::copy_rows_into;
-use crate::decode::heap_decoder::ColumnValue;
-use crate::mapping::MappingSnapshot;
-use crate::pg::current_wal_lsn;
+use crate::backfill::copy_backfill::{CopyRate, copy_selected_rows_into};
+use crate::mapping::{MappingSnapshot, TableMapping};
+use crate::pg::{current_wal_lsn, quote_ident};
 use crate::schema::{RelDescriptor, RelName};
 use crate::source::source_feed::open_sql_client;
-use ahash::{HashMap, HashSet};
+use ahash::HashMap;
 
-/// Reason for authoritative relation read
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PendingReason {
-    /// `xmax` multixact outside backup coverage
-    UnresolvedMultiXact,
-    /// Mapped external value may reference ambiguous chunk generations
-    ExternalToast,
+/// CTIDs per `COPY`, bounding the `ctid = ANY (ARRAY[...])` literal
+const CTID_BATCH: usize = 256;
+
+#[derive(Debug, Default, Clone)]
+pub struct RepairScope {
+    mapped: HashMap<(Oid, Oid), TableMapping>,
 }
 
-/// Relations handed from page walk to repair
-#[derive(Debug, Default)]
-pub struct PendingSet {
-    rels: HashMap<(Oid, Oid), PendingReason>,
-    /// Filenodes repair may read, `None` unrestricted. Greenfield scopes to
-    /// the mapping snapshot: the drain routes by mapping, so reading an
-    /// unmapped relation ships rows it drops
-    scope: Option<HashSet<(Oid, Oid)>>,
-    external: HashMap<(Oid, Oid), Vec<usize>>,
-}
-
-impl PendingSet {
-    /// Empty set for per-table loads without repair
-    pub fn empty() -> Self {
-        Self::default()
-    }
-
-    pub fn mapped(catalog: &CatalogMap, mapping: &MappingSnapshot) -> Self {
-        let mut set = Self::empty();
-        let mut scope = HashSet::default();
-        for desc in catalog.descriptors() {
-            let Some(mapped) = mapping.get(&desc.rel_name) else {
-                continue;
-            };
-            let key = (desc.rfn.db_node, desc.rfn.rel_node);
-            scope.insert(key);
-            if desc.toast_oid == 0 {
-                continue;
-            }
-            let columns: Vec<_> = mapped
-                .columns
-                .iter()
-                .filter_map(|c| {
-                    let attr = desc.attributes.iter().find(|a| a.attnum == c.src_attnum)?;
-                    (attr.type_len == -1 && !attr.dropped)
-                        .then(|| usize::try_from(i32::from(attr.attnum) - 1).ok())
-                        .flatten()
+impl RepairScope {
+    /// Repair reads follow the drain's routes: `walked` narrows them to the
+    /// relations the page walk ships, so a read never lands rows the drain drops
+    pub fn mapped(
+        catalog: &CatalogMap,
+        mapping: &MappingSnapshot,
+        walked: impl Fn(&RelName) -> bool,
+    ) -> Self {
+        Self {
+            mapped: catalog
+                .descriptors()
+                .filter(|d| walked(&d.rel_name))
+                .filter_map(|d| {
+                    mapping
+                        .get(&d.rel_name)
+                        .map(|m| ((d.rfn.db_node, d.rfn.rel_node), m.clone()))
                 })
-                .collect();
-            if !columns.is_empty() {
-                set.external.insert(key, columns);
-            }
+                .collect(),
         }
-        set.scope = Some(scope);
-        set
     }
 
-    pub fn observe_external(&mut self, tuple: &BackfillTuple) -> bool {
-        let key = (tuple.rfn.db_node, tuple.rfn.rel_node);
-        let external = self.external.get(&key).is_some_and(|columns| {
-            columns.iter().any(|&i| {
-                matches!(
-                    tuple.columns.get(i),
-                    Some(Some(ColumnValue::ExternalToast(_)))
-                )
-            })
-        });
-        if external {
-            self.mark(tuple.rfn, PendingReason::ExternalToast);
-        }
-        external
+    fn get(&self, tuple: &BackfillTuple) -> Option<&TableMapping> {
+        self.mapped.get(&(tuple.rfn.db_node, tuple.rfn.rel_node))
     }
 
-    /// Pre-mark relations owning TOAST storage
-    pub fn toast_capable(catalog: &CatalogMap) -> Self {
-        let mut set = Self::default();
-        for desc in catalog.descriptors().filter(|d| d.toast_oid != 0) {
-            set.rels.insert(
-                (desc.rfn.db_node, desc.rfn.rel_node),
-                PendingReason::ExternalToast,
-            );
-        }
-        set
+    pub fn has_external(&self, tuple: &BackfillTuple) -> bool {
+        self.get(tuple)
+            .is_some_and(|m| tuple.has_mapped_external(m))
     }
+}
 
-    /// Restrict repair to `mapped` filenodes, dropping pre-marks outside it
-    pub fn scoped_to(mut self, mapped: HashSet<(Oid, Oid)>) -> Self {
-        self.rels.retain(|k, _| mapped.contains(k));
-        self.external.retain(|k, _| mapped.contains(k));
-        self.scope = Some(mapped);
-        self
-    }
-
-    /// Hand a relation over mid-walk. First reason wins. Out of scope is
-    /// dropped: the tuple was headed for the drain's discard either way
-    pub fn mark(&mut self, rfn: RelFileNode, reason: PendingReason) {
-        let key = (rfn.db_node, rfn.rel_node);
-        if self.scope.as_ref().is_some_and(|s| !s.contains(&key)) {
-            return;
-        }
-        self.rels.entry(key).or_insert(reason);
-    }
-
-    /// Check whether repair replaces relation main pages
-    pub fn holds(&self, db_node: Oid, rel_node: Oid) -> bool {
-        self.rels.contains_key(&(db_node, rel_node))
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.rels.is_empty()
-    }
-
-    pub fn len(&self) -> usize {
-        self.rels.len()
-    }
-
-    pub fn count_for(&self, reason: PendingReason) -> u64 {
-        self.rels.values().filter(|r| **r == reason).count() as u64
-    }
+pub struct RepairBatch {
+    pub rows: Vec<BackfillTuple>,
+    /// Backup SLRUs left visibility undecidable, so a source read replaces
+    /// every in-scope row rather than only the externally toasted ones
+    pub unresolved: bool,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct RepairStats {
-    pub relations: u64,
     pub rows: u64,
-    /// Relations `initial_load = "none"` opted out of
-    pub skipped: u64,
-    /// Source write head after final read
     pub p_hi: u64,
 }
 
-/// Read pending relations through PostgreSQL at `coverage_lsn`
-///
-/// Reject descriptors changed since page walk
-pub async fn repair(
-    pending: &PendingSet,
-    catalog: &CatalogMap,
-    skip_initial: &HashSet<RelName>,
-    source: &PgConfig,
-    coverage_lsn: u64,
-    tx: &mpsc::Sender<BackfillTuple>,
-) -> Result<RepairStats> {
-    let mut stats = RepairStats::default();
-    if pending.is_empty() {
-        return Ok(stats);
-    }
-    let client = open_sql_client(source)
-        .await
-        .context("visibility repair: source sql connect")?;
-    client
-        .batch_execute("SET row_security = off")
-        .await
-        .context("visibility repair: reject row security filtering")?;
-    // Re-read the same seed the walk's catalog came from, so an unchanged
-    // relation compares equal field for field
-    let fresh = seed_in_snapshot(&client)
-        .await
-        .context("visibility repair: re-seed source catalog")?;
+pub struct RowRepair {
+    pub source: PgConfig,
+    pub catalog: CatalogMap,
+    pub scope: RepairScope,
+    pub rate: CopyRate,
+}
 
-    for &(db_node, rel_node) in pending.rels.keys() {
-        let desc = catalog.get(db_node, rel_node).with_context(|| {
-            format!("visibility repair: filenode {db_node}/{rel_node} left the catalog map")
-        })?;
-        if skip_initial.contains(&desc.rel_name) {
-            stats.skipped += 1;
-            continue;
+impl RowRepair {
+    pub async fn run(
+        self,
+        mut rx: mpsc::Receiver<RepairBatch>,
+        tx: mpsc::Sender<Vec<BackfillTuple>>,
+    ) -> Result<RepairStats> {
+        let mut stats = RepairStats::default();
+        let mut connection = None;
+        while let Some(RepairBatch { rows, unresolved }) = rx.recv().await {
+            let mut pass = Vec::new();
+            let mut reads: HashMap<_, Vec<_>> = HashMap::default();
+            // Unresolved rows out of scope get no read and have no route, so
+            // they reach neither branch
+            for t in rows {
+                if self
+                    .scope
+                    .get(&t)
+                    .is_some_and(|m| unresolved || t.has_mapped_external(m))
+                {
+                    reads
+                        .entry((t.rfn.db_node, t.rfn.rel_node, t.source_lsn))
+                        .or_default()
+                        .push((t.blkno, t.offnum));
+                } else if !unresolved {
+                    pass.push(t);
+                }
+            }
+            if !pass.is_empty() {
+                tx.send(pass)
+                    .await
+                    .context("row repair: drain closed early")?;
+            }
+            if reads.is_empty() {
+                continue;
+            }
+            if connection.is_none() {
+                let client = open_sql_client(&self.source)
+                    .await
+                    .context("row repair: source sql connect")?;
+                client.batch_execute("SET row_security = off").await?;
+                connection = Some(client);
+            }
+            let client = connection.as_ref().unwrap();
+            for ((db, rel, lsn), tids) in reads {
+                let desc = self
+                    .catalog
+                    .get(db, rel)
+                    .with_context(|| format!("row repair: unknown filenode {db}/{rel}"))?;
+                stats.rows += copy_locked(client, &desc, lsn, &tx, &tids, &self.rate).await?;
+            }
         }
-        assert_unchanged(&fresh, &desc)?;
-        stats.relations += 1;
-        stats.rows += copy_rows_into(&client, &desc, coverage_lsn, tx)
-            .await
-            .with_context(|| format!("visibility repair: COPY {}", desc.rel_name))?;
+        if let Some(client) = connection {
+            stats.p_hi = current_wal_lsn(&client).await?;
+        }
+        Ok(stats)
     }
-    // Sample after reads to bound every snapshot
-    stats.p_hi = current_wal_lsn(&client)
-        .await
-        .context("visibility repair: source write head")?;
-    Ok(stats)
+}
+
+/// Hold `ACCESS SHARE` across descriptor validation and every `COPY`, so no
+/// rewrite slips between the shape check and the reads it authorises
+async fn copy_locked(
+    client: &tokio_postgres::Client,
+    desc: &RelDescriptor,
+    lsn: u64,
+    tx: &mpsc::Sender<Vec<BackfillTuple>>,
+    tids: &[(u32, u16)],
+    rate: &CopyRate,
+) -> Result<u64> {
+    client.batch_execute("BEGIN").await?;
+    let result: Result<u64> = async {
+        client
+            .batch_execute(&format!(
+                "LOCK TABLE ONLY {}.{} IN ACCESS SHARE MODE",
+                quote_ident(&desc.rel_name.namespace),
+                quote_ident(&desc.rel_name.name),
+            ))
+            .await
+            .with_context(|| format!("row repair: lock {}", desc.rel_name))?;
+        let fresh = seed_relation_from_source(client, desc.oid).await?;
+        assert_unchanged(&fresh, desc)?;
+        let mut rows = 0;
+        // PostgreSQL CTIDs identify physical versions, WAL covers moved or deleted rows
+        for batch in tids.chunks(CTID_BATCH) {
+            rows += copy_selected_rows_into(client, desc, lsn, tx, Some(batch), rate)
+                .await
+                .with_context(|| format!("row repair: COPY {}", desc.rel_name))?;
+        }
+        Ok(rows)
+    }
+    .await;
+    // Release relation lock on both success and failure
+    let released = client.batch_execute("ROLLBACK").await;
+    let rows = result?;
+    released?;
+    Ok(rows)
 }
 
 /// Verify COPY target still matches walked descriptor
@@ -252,90 +226,52 @@ fn shape(d: &RelDescriptor) -> String {
 mod tests {
     use super::*;
     use crate::backfill::backup_page_walk::make_rel_named;
-    use ahash::HashSetExt;
-    use std::sync::Arc;
+    use crate::mapping::TableTarget;
 
-    fn desc(
-        oid: Oid,
-        rel_node: Oid,
-        toast_oid: Oid,
-        namespace: &str,
-        name: &str,
-    ) -> Arc<RelDescriptor> {
-        make_rel_named(oid, rel_node, toast_oid, RelName::new(namespace, name))
-    }
-
-    /// A relation with a toast relation is pending before the walk. Its
-    /// chunk store is not: the mirror is a cache the walk keeps filling
-    #[test]
-    fn toast_capable_scope_takes_the_parent_but_not_its_chunks() {
-        let mut catalog = CatalogMap::new();
-        catalog.insert(desc(16400, 16400, 16402, "public", "with_text"));
-        catalog.insert(desc(16402, 16403, 0, "pg_toast", "pg_toast_16400"));
-        catalog.insert(desc(16500, 16500, 0, "public", "fixed_width"));
-
-        let set = PendingSet::toast_capable(&catalog);
-
-        assert_eq!(set.len(), 1);
-        assert!(set.holds(5, 16400), "parent is pending");
-        assert!(!set.holds(5, 16403), "its chunk filenode still walks");
-        assert!(!set.holds(5, 16500), "a fixed-width relation still walks");
-        assert_eq!(set.count_for(PendingReason::ExternalToast), 1);
-    }
-
-    /// Repair reads the source, so scope follows the drain's routes: an
-    /// unmapped relation's rows would be dropped on arrival
-    #[test]
-    fn scope_drops_unmapped_relations_and_their_later_marks() {
-        let mut catalog = CatalogMap::new();
-        catalog.insert(desc(16400, 16400, 16402, "public", "mapped"));
-        catalog.insert(desc(16500, 16500, 16502, "public", "unmapped"));
-
-        let mut set =
-            PendingSet::toast_capable(&catalog).scoped_to([(5, 16400)].into_iter().collect());
-
-        assert_eq!(set.len(), 1);
-        assert!(set.holds(5, 16400));
-        assert!(!set.holds(5, 16500), "pre-mark outside the mapping drops");
-
-        let unmapped = catalog.get(5, 16500).unwrap();
-        set.mark(unmapped.rfn, PendingReason::UnresolvedMultiXact);
-        assert!(!set.holds(5, 16500), "so does a walk-time mark");
-    }
-
-    /// Marking mid-walk keeps the first reason
-    #[test]
-    fn walk_time_mark_keeps_the_first_reason() {
-        let mut catalog = CatalogMap::new();
-        catalog.insert(desc(16400, 16400, 16402, "public", "t"));
-        let mut set = PendingSet::empty();
-        assert!(!set.holds(5, 16400));
-
-        let parent = catalog.get(5, 16400).unwrap();
-        set.mark(parent.rfn, PendingReason::UnresolvedMultiXact);
-        set.mark(parent.rfn, PendingReason::ExternalToast);
-
-        assert_eq!(set.len(), 1);
-        assert!(set.holds(5, 16400));
-        assert_eq!(set.count_for(PendingReason::UnresolvedMultiXact), 1);
-        assert_eq!(set.count_for(PendingReason::ExternalToast), 0);
-    }
-
-    /// Nothing pending means no source connection at all
     #[tokio::test]
-    async fn repair_without_pending_relations_touches_nothing() {
-        let (tx, _rx) = mpsc::channel(1);
-        let source = crate::config::SourceConn::default().to_pg_config();
-        let stats = repair(
-            &PendingSet::empty(),
-            &CatalogMap::new(),
-            &HashSet::new(),
-            &source,
-            0x1000,
-            &tx,
-        )
+    async fn out_of_scope_rows_never_connect() {
+        let mut catalog = CatalogMap::new();
+        let d = make_rel_named(16400, 16400, 0, RelName::new("public", "t"));
+        catalog.insert(d.clone());
+        let mapping = [(
+            d.rel_name.clone(),
+            TableMapping {
+                target: TableTarget::new("default", "t"),
+                columns: Vec::new(),
+            },
+        )]
+        .into_iter()
+        .collect::<HashMap<_, _>>()
+        .into();
+        let scope = RepairScope::mapped(&catalog, &mapping, |_| false);
+        let (tx, rx) = mpsc::channel(1);
+        tx.send(RepairBatch {
+            rows: vec![BackfillTuple {
+                rfn: d.rfn,
+                xid: 0,
+                xmax: 0,
+                infomask: 0,
+                source_lsn: 0x1000,
+                blkno: 0,
+                offnum: 1,
+                columns: Vec::new(),
+            }],
+            unresolved: true,
+        })
+        .await
+        .unwrap();
+        drop(tx);
+        let (out_tx, mut out_rx) = mpsc::channel(1);
+        let stats = RowRepair {
+            source: crate::config::SourceConn::default().to_pg_config(),
+            catalog,
+            scope,
+            rate: CopyRate::new(None),
+        }
+        .run(rx, out_tx)
         .await
         .unwrap();
         assert_eq!(stats, RepairStats::default());
+        assert!(out_rx.recv().await.is_none());
     }
 }

--- a/src/bin/stream.rs
+++ b/src/bin/stream.rs
@@ -49,11 +49,12 @@ use walrus::pg::replication::base_backup::BaseBackupOpts;
 use walrus::pg::replication::conn::PgConfig;
 use walrus::pg::replication::tls::SslMode;
 use walshadow::backfill::visibility_gate::{
-    GateStats, PendingGate, resolve_greenfield, stream_phase,
+    GateOutput, GateStats, GreenfieldSink, PendingGate, resolve_greenfield, stream_phase,
 };
-use walshadow::backfill::visibility_repair::PendingSet;
+use walshadow::backfill::visibility_repair::RepairScope;
 use walshadow::backfill_bootstrap::{
-    BootstrapConfig, BootstrapOutcome, drain_backfill, seed_in_snapshot, spawn_greenfield_bootstrap,
+    BootstrapConfig, BootstrapOutcome, BootstrapProgress, drain_backfill, seed_in_snapshot,
+    spawn_greenfield_bootstrap,
 };
 use walshadow::backup_source::BackupSource;
 use walshadow::backup_source_direct::DirectSource;
@@ -71,7 +72,7 @@ use walshadow::mapping::{DropTableStrategy, MappingHandle};
 use walshadow::metrics::{MetricsRegistry, MetricsSnapshot, RateEstimator};
 use walshadow::pg::{quote_ident, socket_conninfo};
 use walshadow::pipeline::tail::OwnedTail;
-use walshadow::pipeline::{Fatal, PipelineConfig, TailKind, bootstrap};
+use walshadow::pipeline::{Fatal, PipelineConfig, TailKind};
 use walshadow::pos::{
     Drain, EmitterAck, FilterDispatched, FilterDurable, Floor, Gate, Monotone, Pos, ShadowFlush,
     ShadowReplay, SourceReceived,
@@ -553,11 +554,14 @@ struct Args {
     /// cost matters more than bootstrap latency.
     #[arg(long, default_value_t = true)]
     bootstrap_fast_checkpoint: bool,
-    /// BASE_BACKUP `MAX_RATE` in kB/s for `direct` mode (PG accepts
-    /// 32..1048576). Caps the backup's read bandwidth on the source; the
-    /// window WAL leg keeps the destination converging while it streams
+    /// Cap direct BASE_BACKUP and bootstrap COPY repair separately in KiB/s
+    /// PostgreSQL accepts 32..1048576; window WAL remains unthrottled
     #[arg(long, value_parser = clap::value_parser!(i32).range(32..=1_048_576))]
     bootstrap_max_rate_kib: Option<i32>,
+    /// Wait this many seconds for transactions crossing live bootstrap handoff
+    /// Zero resumes immediately from oldest buffered record
+    #[arg(long, default_value_t = 5)]
+    bootstrap_wind_down_secs: u64,
     /// Fetch the bootstrap WAL window from the `[backup]` bucket instead of
     /// inside `base.tar` (`direct` mode only). Source then needn't retain or
     /// re-ship `[start_lsn, end_lsn]`, which is what fills its disk at high
@@ -964,6 +968,10 @@ async fn run_session(
     );
     let bootstrap_plan = resolve_bootstrap(args, ch_config.as_ref())?;
     let shadow_start = resolve_shadow_start(args, bootstrap_plan.mode)?;
+    let bridge_workers = match shadow_start {
+        ShadowStart::External => 1,
+        _ => bridge_pool_size(ch_config.as_ref()),
+    };
     // Slot before bootstrap
     if let Some(slot) = source_conn.slot.as_deref() {
         feed.ensure_physical_slot(slot)
@@ -971,6 +979,15 @@ async fn run_session(
             .with_context(|| format!("ensure physical replication slot {slot}"))?;
         tracing::info!(target: "walshadow", slot, "physical replication slot ready");
     }
+    // Uptime anchors here, ahead of bootstrap: an initial load is part of the
+    // session, and a `t0` that only starts at the status loop reads as a
+    // counter reset to a scraper watching through it
+    let start_instant = Instant::now();
+    // One emitter-counter handle for both phases. Bootstrap's insert tail and
+    // the streaming pipeline write the same series, so sharing it is what
+    // keeps inserter and TOAST totals from resetting at handoff
+    let emitter_stats = Arc::new(EmitterStats::default());
+    let mut bootstrap_metrics: Option<BootstrapMetrics> = None;
     let bootstrap_handoff: Option<BootstrapHandoff> =
         if matches!(shadow_start, ShadowStart::Bootstrap(_)) {
             if !args.skip_preflight {
@@ -988,11 +1005,22 @@ async fn run_session(
                 .into_result()
                 .context("pre-flight rejected bootstrap")?;
             }
-            Some(
-                run_bootstrap(&cfg, &mut feed, args, &bootstrap_plan, ch_config.clone())
-                    .await
-                    .context("bootstrap")?,
+            let (handoff, stage) = run_bootstrap(
+                &cfg,
+                &mut feed,
+                args,
+                &bootstrap_plan,
+                ch_config.clone(),
+                BootstrapObservers {
+                    metrics: &metrics,
+                    emitter_stats: emitter_stats.clone(),
+                    uptime_from: start_instant,
+                },
             )
+            .await
+            .context("bootstrap")?;
+            bootstrap_metrics = Some(stage);
+            Some(handoff)
         } else {
             None
         };
@@ -1004,7 +1032,12 @@ async fn run_session(
     let shadow_lifecycle: Option<ShadowLifecycle> = match &shadow_start {
         ShadowStart::External => None,
         ShadowStart::Bootstrap(dir) | ShadowStart::Resume(dir) => {
-            let shadow = Arc::new(build_owned_shadow(args, &source_conn.dbname, dir.clone()));
+            let shadow = Arc::new(build_owned_shadow(
+                args,
+                &source_conn.dbname,
+                dir.clone(),
+                bridge_workers,
+            ));
             shadow
                 .write_standby_signal()
                 .context("write standby.signal")?;
@@ -1286,7 +1319,7 @@ async fn run_session(
     let connect_budget = Duration::from_secs(args.shadow_connect_timeout);
     let bridge_path = args.bridge_socket_path();
     let bridge = Arc::new(
-        walshadow::bridge::connect_with_budget(&bridge_path, connect_budget)
+        walshadow::bridge::connect_with_budget(&bridge_path, bridge_workers, connect_budget)
             .await
             .with_context(|| format!("connect bridge at {}", bridge_path.display()))?,
     );
@@ -1294,6 +1327,7 @@ async fn run_session(
     tracing::info!(
         target: "walshadow::bridge",
         socket = %bridge_path.display(),
+        workers = bridge.pool_size(),
         pg_version = info.map(|i| i.pg_version_num).unwrap_or(0),
         in_recovery = info.map(|i| i.in_recovery).unwrap_or(false),
         "bridge connected",
@@ -1623,7 +1657,7 @@ async fn run_session(
         .await
         .context("init DDL applicator")?
         .with_resolver(resolver.clone());
-        let stats = Arc::new(EmitterStats::default());
+        let stats = emitter_stats.clone();
         emitter_stats_handle = Some(stats.clone());
         // Backfiller for `initial_load` opt-ins (COPY / backup-sourced):
         // own source session + CH tail per backfill or pass, spill-dir
@@ -1765,6 +1799,7 @@ async fn run_session(
             addr = %addr,
             decoders,
             inserters,
+            resolvers = bridge.pool_size(),
             "parallel decode+insert pipeline starting",
         );
         PipelineConfig {
@@ -2000,7 +2035,6 @@ async fn run_session(
             .context("resume WAL source")?;
     }
 
-    let start_instant = Instant::now();
     let mut segments_shipped = 0u64;
     let mut prev_dispatched = stream.dispatched_lsn();
     let mut rate_estimator = RateEstimator::default();
@@ -2674,10 +2708,6 @@ async fn run_session(
             drain_resident,
             Some(&pipeline_handle.budget),
             decoder_stats,
-            emitter_stats,
-            oracle_stats,
-            bridge_stats,
-            start_instant.elapsed().as_secs(),
             SourceSwapView {
                 swaps: source_swaps_total,
                 failures: source_swap_failures_total,
@@ -2708,6 +2738,13 @@ async fn run_session(
             &desc_log,
             metrics_resolver.as_deref(),
             metrics_backfiller.as_deref(),
+            StageCounters {
+                emitter: emitter_stats,
+                oracle: [oracle_stats, bootstrap_metrics.as_ref().map(|b| &*b.oracle)],
+                bridge: [bridge_stats, bootstrap_metrics.as_ref().map(|b| &*b.bridge)],
+                bootstrap: bootstrap_metrics.as_ref().map(|b| &b.progress),
+                uptime_secs: start_instant.elapsed().as_secs(),
+            },
         )
         .await;
         if advanced {
@@ -3342,10 +3379,6 @@ async fn populate_metrics(
     drain_resident: DrainResident,
     budget: Option<&walshadow::budget::MemoryBudget>,
     decoder_stats: &walshadow::decoder_sink::DecoderStats,
-    emitter_stats: Option<&walshadow::ch_emitter::EmitterStats>,
-    oracle_stats: Option<&walshadow::oracle::OracleStats>,
-    bridge_stats: Option<&walshadow::bridge::BridgeStats>,
-    uptime_secs: u64,
     source_swap: SourceSwapView,
     timeline_view: TimelineView,
     shadow_view: ShadowMetricsView,
@@ -3354,10 +3387,10 @@ async fn populate_metrics(
     desc_log: &walshadow::desc_log::DescriptorLog,
     config_resolver: Option<&ConfigResolver>,
     backfiller: Option<&walshadow::copy_backfill::CopyBackfiller>,
+    counters: StageCounters<'_>,
 ) {
     use std::collections::BTreeMap;
     use walshadow::record::rmgr_label;
-    let (proc_cpu, proc_rss) = read_process_stats();
     let desc_log_gauges = desc_log.gauges();
     let log_stats = desc_log.stats_handle();
     let mut by_rm = BTreeMap::new();
@@ -3390,12 +3423,6 @@ async fn populate_metrics(
         resident_payload_peak_bytes: budget.map(|b| b.peak_bytes()).unwrap_or(0),
         memory_budget_waits_total: budget.map(|b| b.waits_total()).unwrap_or(0),
         memory_budget_overshoots_total: budget.map(|b| b.overshoots_total()).unwrap_or(0),
-        bootstrap_deferred_bytes: emitter_stats
-            .map(|s| s.bootstrap_deferred_bytes.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        bootstrap_deferred_spool_bytes: emitter_stats
-            .map(|s| s.bootstrap_deferred_spool_bytes.load(Ordering::Relaxed))
-            .unwrap_or(0),
         spill_evictions_total: xact_stats.spill_evictions_total,
         xacts_committed_total: xact_stats.committed_xacts_total,
         xacts_aborted_total: xact_stats.aborted_xacts_total,
@@ -3404,78 +3431,8 @@ async fn populate_metrics(
         decoder_toast_chunks_total: decoder_stats.toast_chunks_buffered.load(Ordering::Relaxed),
         decoder_toast_malformed_total: decoder_stats.toast_chunks_malformed.load(Ordering::Relaxed),
         decoder_toast_deletes_total: decoder_stats.toast_chunk_deletes.load(Ordering::Relaxed),
-        toast_tombstones_stored_total: emitter_stats
-            .map(|s| s.toast_tombstones_stored.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        toast_values_filled_superseded_total: emitter_stats
-            .map(|s| s.toast_values_filled_superseded.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        toast_values_filled_mismatch_total: emitter_stats
-            .map(|s| s.toast_values_filled_mismatch.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        toast_mirror_truncates_total: emitter_stats
-            .map(|s| s.toast_mirror_truncates.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        toast_mirror_retires_total: emitter_stats
-            .map(|s| s.toast_mirror_retires.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        toast_rewrite_barriers_total: emitter_stats
-            .map(|s| s.toast_rewrite_barriers.load(Ordering::Relaxed))
-            .unwrap_or(0),
         toast_stash_buffered_total: decoder_stats.toast_stash_buffered.load(Ordering::Relaxed),
         raw_stash_deferred_total: decoder_stats.raw_stash_deferred.load(Ordering::Relaxed),
-        toast_stash_decoded_total: emitter_stats
-            .map(|s| s.toast_stash_decoded.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        toast_stash_discarded_total: emitter_stats
-            .map(|s| s.toast_stash_discarded.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        toast_stash_in_place_total: emitter_stats
-            .map(|s| s.toast_stash_in_place.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        stash_foreign_db_skipped_total: emitter_stats
-            .map(|s| s.stash_foreign_db_skipped.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        xact_plan_rows: emitter_stats
-            .map(|s| s.plan_rows.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        xact_plan_bytes_by_storage: emitter_stats
-            .map(|s| {
-                [
-                    s.plan_bytes_mem.load(Ordering::Relaxed),
-                    s.plan_bytes_file.load(Ordering::Relaxed),
-                ]
-            })
-            .unwrap_or_default(),
-        xact_plan_failures_by_reason: emitter_stats
-            .map(|s| {
-                [
-                    s.plan_failures_spool.load(Ordering::Relaxed),
-                    s.plan_failures_fail_closed_image_only
-                        .load(Ordering::Relaxed),
-                    s.plan_failures_fail_closed_malformed
-                        .load(Ordering::Relaxed),
-                    s.plan_failures_fail_closed_unsupported_op
-                        .load(Ordering::Relaxed),
-                    s.plan_failures_stash_ambiguous.load(Ordering::Relaxed),
-                    s.plan_failures_incomplete_toast.load(Ordering::Relaxed),
-                    s.plan_failures_missing_stash_resolution
-                        .load(Ordering::Relaxed),
-                    s.plan_failures_detoast.load(Ordering::Relaxed),
-                    s.plan_failures_partial_update.load(Ordering::Relaxed),
-                    s.plan_failures_view.load(Ordering::Relaxed),
-                    s.plan_failures_drain.load(Ordering::Relaxed),
-                ]
-            })
-            .unwrap_or_default(),
-        route_snapshots_by_result: emitter_stats
-            .map(|s| {
-                [
-                    s.route_snapshots_mapped.load(Ordering::Relaxed),
-                    s.route_snapshots_unmapped.load(Ordering::Relaxed),
-                ]
-            })
-            .unwrap_or_default(),
         raw_stash_records_by_kind_op: [
             decoder_stats.raw_stash_dirty_ops.load(),
             decoder_stats.raw_stash_marker_ops.load(),
@@ -3484,72 +3441,10 @@ async fn populate_metrics(
             xact_stats.raw_stash_bytes_mem,
             xact_stats.raw_stash_bytes_spill,
         ],
-        raw_decode_records_by_kind_op: emitter_stats
-            .map(|s| {
-                [
-                    s.raw_decode_toast_ops.load(),
-                    s.raw_decode_ordinary_ops.load(),
-                ]
-            })
-            .unwrap_or_default(),
-        raw_decode_rows_by_op: emitter_stats
-            .map(|s| s.raw_decode_rows_ops.load())
-            .unwrap_or_default(),
         raw_pending_rows: drain_resident.raw_pending_rows,
         raw_pending_bytes: drain_resident.raw_pending_bytes,
-        emitter_rows_total: emitter_stats
-            .map(|s| s.rows_emitted.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        emitter_blocks_total: emitter_stats
-            .map(|s| s.blocks_sent.load(Ordering::Relaxed))
-            .unwrap_or(0),
         pump_queue_depth,
         queue_records_out_total,
-        queue_jobs_out_total: emitter_stats
-            .map(|s| s.queue_jobs_out.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        decode_jobs_in_total: emitter_stats
-            .map(|s| s.decode_jobs_in.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        decode_rows_out_total: emitter_stats
-            .map(|s| s.decode_rows_out.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        insertbatch_rows_in_total: emitter_stats
-            .map(|s| s.insertbatch_rows_in.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        insertbatch_batches_out_total: emitter_stats
-            .map(|s| s.insertbatch_batches_out.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        inserter_batches_in_total: emitter_stats
-            .map(|s| s.inserter_batches_in.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        process_cpu_seconds_total: proc_cpu,
-        process_resident_memory_bytes: proc_rss,
-        emitter_xacts_total: emitter_stats
-            .map(|s| s.xacts_committed.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        emitter_unsupported_relations: emitter_stats
-            .map(|s| s.unsupported_relations.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        emitter_deletes_discarded: emitter_stats
-            .map(|s| s.deletes_discarded.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        oracle_blocks_total: oracle_stats
-            .map(|s| s.blocks.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        oracle_rows_total: oracle_stats
-            .map(|s| s.rows.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        oracle_cells_total: oracle_stats
-            .map(|s| s.cells.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        oracle_conversion_errors_total: oracle_stats
-            .map(|s| s.conversion_errors.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        oracle_errors_total: oracle_stats
-            .map(|s| s.errors.load(Ordering::Relaxed))
-            .unwrap_or(0),
-        uptime_secs,
         source_endpoint_swaps_total: source_swap.swaps,
         source_endpoint_swap_failures_total: source_swap.failures,
         source_endpoint_swap_pending: u64::from(source_swap.pending),
@@ -3622,35 +3517,239 @@ async fn populate_metrics(
         config_replicate_opt_out_total: config_resolver.map(|r| r.opt_out_total()).unwrap_or(0),
         config_backfills_pending: backfiller.map(|b| b.pending_count()).unwrap_or(0),
         config_backfills_pending_by_mode: backfiller.map(|b| b.pending_by_mode()).unwrap_or([0; 3]),
-        bridge_up: bridge_gauge(bridge_stats, |b| &b.up),
-        bridge_requests_by_op: bridge_ops(bridge_stats.map(|b| &b.requests)),
-        bridge_errors_by_op: bridge_ops(bridge_stats.map(|b| &b.errors)),
-        bridge_request_nanos_by_op: bridge_ops(bridge_stats.map(|b| &b.request_nanos)),
-        bridge_reconnects_total: bridge_gauge(bridge_stats, |b| &b.reconnects),
-        bridge_scan_rows_total: bridge_gauge(bridge_stats, |b| &b.scan_rows),
-        bridge_scan_replay_moved_total: bridge_gauge(bridge_stats, |b| &b.scan_replay_moved),
-        bridge_scan_subtrans_mismatch_total: bridge_gauge(bridge_stats, |b| {
-            &b.scan_subtrans_mismatch
-        }),
-        bridge_native_bytes_total: bridge_gauge(bridge_stats, |b| &b.native_bytes),
+        ..stage_gauges(&counters)
     };
     registry.set(snap).await;
 }
 
-/// Zero when bridge stats are unavailable, so series stays present
-fn bridge_gauge(
-    stats: Option<&walshadow::bridge::BridgeStats>,
-    pick: fn(&walshadow::bridge::BridgeStats) -> &AtomicU64,
-) -> u64 {
-    stats.map(|b| pick(b).load(Ordering::Relaxed)).unwrap_or(0)
+/// Counters both phases write. Bootstrap runs its own insert tail and oracle
+/// PG before a status loop exists, so its ticker publishes this group beside
+/// pump progress and the series carry across handoff rather than reading as a
+/// reset: the emitter handle is shared, and the two oracle bridges' cumulative
+/// counters sum into one series
+struct StageCounters<'a> {
+    emitter: Option<&'a walshadow::ch_emitter::EmitterStats>,
+    /// Live first, bootstrap's second. Only one of the pair is ever serving
+    oracle: [Option<&'a walshadow::oracle::OracleStats>; 2],
+    bridge: [Option<&'a walshadow::bridge::BridgeStats>; 2],
+    bootstrap: Option<&'a BootstrapProgress>,
+    uptime_secs: u64,
 }
 
-fn bridge_ops(
-    counters: Option<&[AtomicU64; walshadow::bridge::OP_COUNT]>,
-) -> [u64; walshadow::bridge::OP_COUNT] {
-    counters
-        .map(|a| std::array::from_fn(|i| a[i].load(Ordering::Relaxed)))
-        .unwrap_or_default()
+fn stage_gauges(v: &StageCounters<'_>) -> MetricsSnapshot {
+    let (proc_cpu, proc_rss) = read_process_stats();
+    let emitter_stats = v.emitter;
+    let uptime_secs = v.uptime_secs;
+    let oracle = |pick: fn(&walshadow::oracle::OracleStats) -> &AtomicU64| -> u64 {
+        v.oracle
+            .iter()
+            .flatten()
+            .map(|s| pick(s).load(Ordering::Relaxed))
+            .sum()
+    };
+    let bridge = |pick: fn(&walshadow::bridge::BridgeStats) -> &AtomicU64| -> u64 {
+        v.bridge
+            .iter()
+            .flatten()
+            .map(|s| pick(s).load(Ordering::Relaxed))
+            .sum()
+    };
+    let bridge_ops = |pick: fn(
+        &walshadow::bridge::BridgeStats,
+    ) -> &[AtomicU64; walshadow::bridge::OP_COUNT]|
+     -> [u64; walshadow::bridge::OP_COUNT] {
+        std::array::from_fn(|i| {
+            v.bridge
+                .iter()
+                .flatten()
+                .map(|s| pick(s)[i].load(Ordering::Relaxed))
+                .sum()
+        })
+    };
+    MetricsSnapshot {
+        bootstrap_deferred_bytes: emitter_stats
+            .map(|s| s.bootstrap_deferred_bytes.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        bootstrap_deferred_spool_bytes: emitter_stats
+            .map(|s| s.bootstrap_deferred_spool_bytes.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        toast_tombstones_stored_total: emitter_stats
+            .map(|s| s.toast_tombstones_stored.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        toast_values_filled_superseded_total: emitter_stats
+            .map(|s| s.toast_values_filled_superseded.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        toast_values_filled_mismatch_total: emitter_stats
+            .map(|s| s.toast_values_filled_mismatch.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        toast_mirror_truncates_total: emitter_stats
+            .map(|s| s.toast_mirror_truncates.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        toast_mirror_retires_total: emitter_stats
+            .map(|s| s.toast_mirror_retires.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        toast_rewrite_barriers_total: emitter_stats
+            .map(|s| s.toast_rewrite_barriers.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        toast_stash_decoded_total: emitter_stats
+            .map(|s| s.toast_stash_decoded.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        toast_stash_discarded_total: emitter_stats
+            .map(|s| s.toast_stash_discarded.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        toast_stash_in_place_total: emitter_stats
+            .map(|s| s.toast_stash_in_place.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        stash_foreign_db_skipped_total: emitter_stats
+            .map(|s| s.stash_foreign_db_skipped.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        xact_plan_rows: emitter_stats
+            .map(|s| s.plan_rows.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        xact_plan_bytes_by_storage: emitter_stats
+            .map(|s| {
+                [
+                    s.plan_bytes_mem.load(Ordering::Relaxed),
+                    s.plan_bytes_file.load(Ordering::Relaxed),
+                ]
+            })
+            .unwrap_or_default(),
+        xact_plan_failures_by_reason: emitter_stats
+            .map(|s| {
+                [
+                    s.plan_failures_spool.load(Ordering::Relaxed),
+                    s.plan_failures_fail_closed_image_only
+                        .load(Ordering::Relaxed),
+                    s.plan_failures_fail_closed_malformed
+                        .load(Ordering::Relaxed),
+                    s.plan_failures_fail_closed_unsupported_op
+                        .load(Ordering::Relaxed),
+                    s.plan_failures_stash_ambiguous.load(Ordering::Relaxed),
+                    s.plan_failures_incomplete_toast.load(Ordering::Relaxed),
+                    s.plan_failures_missing_stash_resolution
+                        .load(Ordering::Relaxed),
+                    s.plan_failures_detoast.load(Ordering::Relaxed),
+                    s.plan_failures_partial_update.load(Ordering::Relaxed),
+                    s.plan_failures_view.load(Ordering::Relaxed),
+                    s.plan_failures_drain.load(Ordering::Relaxed),
+                ]
+            })
+            .unwrap_or_default(),
+        route_snapshots_by_result: emitter_stats
+            .map(|s| {
+                [
+                    s.route_snapshots_mapped.load(Ordering::Relaxed),
+                    s.route_snapshots_unmapped.load(Ordering::Relaxed),
+                ]
+            })
+            .unwrap_or_default(),
+        raw_decode_records_by_kind_op: emitter_stats
+            .map(|s| {
+                [
+                    s.raw_decode_toast_ops.load(),
+                    s.raw_decode_ordinary_ops.load(),
+                ]
+            })
+            .unwrap_or_default(),
+        raw_decode_rows_by_op: emitter_stats
+            .map(|s| s.raw_decode_rows_ops.load())
+            .unwrap_or_default(),
+        emitter_rows_total: emitter_stats
+            .map(|s| s.rows_emitted.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        emitter_blocks_total: emitter_stats
+            .map(|s| s.blocks_sent.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        queue_jobs_out_total: emitter_stats
+            .map(|s| s.queue_jobs_out.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        decode_jobs_in_total: emitter_stats
+            .map(|s| s.decode_jobs_in.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        decode_rows_out_total: emitter_stats
+            .map(|s| s.decode_rows_out.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        insertbatch_rows_in_total: emitter_stats
+            .map(|s| s.insertbatch_rows_in.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        insertbatch_batches_out_total: emitter_stats
+            .map(|s| s.insertbatch_batches_out.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        inserter_batches_in_total: emitter_stats
+            .map(|s| s.inserter_batches_in.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        inserter_ch_seconds_total: emitter_stats
+            .map(|s| s.inserter_ch_nanos.load(Ordering::Relaxed) as f64 / 1e9)
+            .unwrap_or(0.0),
+        inserter_encode_seconds_total: emitter_stats
+            .map(|s| s.inserter_encode_nanos.load(Ordering::Relaxed) as f64 / 1e9)
+            .unwrap_or(0.0),
+        oracle_resolve_seconds_total: emitter_stats
+            .map(|s| s.oracle_resolve_nanos.load(Ordering::Relaxed) as f64 / 1e9)
+            .unwrap_or(0.0),
+        process_cpu_seconds_total: proc_cpu,
+        process_resident_memory_bytes: proc_rss,
+        emitter_xacts_total: emitter_stats
+            .map(|s| s.xacts_committed.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        emitter_unsupported_relations: emitter_stats
+            .map(|s| s.unsupported_relations.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        emitter_deletes_discarded: emitter_stats
+            .map(|s| s.deletes_discarded.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        oracle_local_columns_total: emitter_stats
+            .map(|s| s.oracle_local_columns.load(Ordering::Relaxed))
+            .unwrap_or(0),
+        oracle_blocks_total: oracle(|s| &s.blocks),
+        oracle_rows_total: oracle(|s| &s.rows),
+        oracle_cells_total: oracle(|s| &s.cells),
+        oracle_conversion_errors_total: oracle(|s| &s.conversion_errors),
+        oracle_errors_total: oracle(|s| &s.errors),
+        uptime_secs,
+        // Gauge, so it answers off whichever bridge is serving: bootstrap's
+        // oracle socket is gone by the time the live bridge dials
+        bridge_up: v
+            .bridge
+            .iter()
+            .flatten()
+            .next()
+            .map_or(0, |b| b.up.load(Ordering::Relaxed)),
+        bridge_requests_by_op: bridge_ops(|b| &b.requests),
+        bridge_errors_by_op: bridge_ops(|b| &b.errors),
+        bridge_request_nanos_by_op: bridge_ops(|b| &b.request_nanos),
+        bridge_lock_wait_nanos_by_op: bridge_ops(|b| &b.lock_wait_nanos),
+        bridge_service_nanos_by_op: bridge_ops(|b| &b.service_nanos),
+        bridge_request_bytes_by_op: bridge_ops(|b| &b.request_bytes),
+        bridge_response_bytes_by_op: bridge_ops(|b| &b.response_bytes),
+        bridge_reconnects_total: bridge(|b| &b.reconnects),
+        bridge_scan_rows_total: bridge(|b| &b.scan_rows),
+        bridge_scan_replay_moved_total: bridge(|b| &b.scan_replay_moved),
+        bridge_scan_subtrans_mismatch_total: bridge(|b| &b.scan_subtrans_mismatch),
+        bridge_native_bytes_total: bridge(|b| &b.native_bytes),
+        ..bootstrap_gauges(v.bootstrap)
+    }
+}
+
+/// Bootstrap stage attribution, frozen at its final values once the pump
+/// returns. Rendered for the whole session so a slow initial load stays
+/// attributable after the fact
+fn bootstrap_gauges(progress: Option<&BootstrapProgress>) -> MetricsSnapshot {
+    let Some(p) = progress else {
+        return MetricsSnapshot::default();
+    };
+    let ld = |a: &AtomicU64| a.load(Ordering::Relaxed);
+    MetricsSnapshot {
+        bootstrap_bytes_tapped: ld(&p.pump.bytes_tapped),
+        bootstrap_pages_walked: ld(&p.page_walk.pages_walked),
+        bootstrap_tuples_emitted: ld(&p.page_walk.tuples_emitted),
+        bootstrap_files_walked: ld(&p.page_walk.files_walked),
+        bootstrap_files_skipped_unmapped: ld(&p.page_walk.files_skipped_unmapped),
+        bootstrap_decode_seconds: ld(&p.page_walk.decode_nanos) as f64 / 1e9,
+        bootstrap_tap_seconds: ld(&p.pump.sink_chunk_nanos) as f64 / 1e9,
+        bootstrap_channel_block_seconds: ld(&p.page_walk.channel_block_nanos) as f64 / 1e9,
+        ..MetricsSnapshot::default()
+    }
 }
 
 /// Retry transient source failures, stop when source reports missing WAL.
@@ -4209,8 +4308,15 @@ async fn run_bootstrap(
     args: &Args,
     plan: &BootstrapPlan,
     ch_config: Option<EmitterConfig>,
-) -> Result<BootstrapHandoff> {
+    observers: BootstrapObservers<'_>,
+) -> Result<(BootstrapHandoff, BootstrapMetrics)> {
+    let BootstrapObservers {
+        metrics,
+        emitter_stats,
+        uptime_from,
+    } = observers;
     let timing = walshadow::ops::stages::BOOTSTRAP.start();
+    let bridge_workers = bridge_pool_size(ch_config.as_ref());
     let shadow_data_dir = args
         .bootstrap_shadow_data_dir
         .clone()
@@ -4319,7 +4425,9 @@ async fn run_bootstrap(
     // Build the toast resolver up front, sharing its counters with the
     // bootstrap tail. The store-toast flag tells the page walk whether to
     // decode pg_toast_* pages.
-    let bootstrap_stats = Arc::new(EmitterStats::default());
+    // Counters are the daemon's, not this phase's: the streaming pipeline
+    // keeps adding to them, so a load's insert cost survives handoff
+    let bootstrap_stats = emitter_stats;
     // Leaf-only pool for the bootstrap tail: caps each value (V3) and
     // bounds decoded rows in flight to insert ack; no admission stage
     let resolver = if let Some(cfg) = &ch_config {
@@ -4331,12 +4439,14 @@ async fn run_bootstrap(
     };
     let store_toast = resolver.stores_chunks();
 
-    let (ch_target, walk_skip) = match ch_config {
+    let ch_target = match ch_config {
         Some(emitter_cfg) => {
             let (mapping, resolved) = bootstrap_build_mapping(&emitter_cfg, &drain_catalog, args)
                 .await
                 .context("bootstrap: build mapping")?;
-            let routed = mapping.snapshot().await;
+            // `initial_load = "none"` (table override, else namespace) opts a
+            // relation out of the greenfield snapshot: create it + stream CDC,
+            // but don't page-walk its existing rows.
             let skip_initial: HashSet<_> = drain_catalog
                 .descriptors()
                 .filter_map(|d| {
@@ -4359,67 +4469,39 @@ async fn run_bootstrap(
                     none.then(|| rn.clone())
                 })
                 .collect();
-            let mapped: HashSet<_> = drain_catalog
-                .descriptors()
-                .filter(|d| routed.contains_key(&d.rel_name) && !skip_initial.contains(&d.rel_name))
-                .map(|d| (d.rfn.db_node, d.rfn.rel_node))
-                .collect();
-            let pending = PendingSet::mapped(&drain_catalog, &routed).scoped_to(mapped.clone());
-            let skip = drain_catalog
-                .descriptors()
-                .map(|d| (d.rfn.db_node, d.rfn.rel_node))
-                .filter(|&(db, rel)| {
-                    !drain_catalog.is_toast(db, rel) && !mapped.contains(&(db, rel))
-                })
-                .collect();
-            (
-                Some((emitter_cfg, mapping, resolved, pending, skip_initial)),
-                skip,
-            )
+            Some((emitter_cfg, mapping, resolved, skip_initial))
         }
-        None => (None, HashSet::default()),
+        None => None,
     };
 
-    prepare_bootstrap_dir(&shadow_data_dir)
-        .await
-        .context("prepare shadow data dir for bootstrap")?;
+    // Decline unmapped relations at `begin` so their pages never decode.
+    // Metrics-only (no CH) has no mapping to filter against, so it walks all
+    let (tap_filenodes, needs_oracle, repair_scope, routes) = match &ch_target {
+        Some((_, mapping, resolved, skip_initial)) => {
+            let routed = mapping.snapshot().await;
+            let is_routed = |rn: &RelName| routed.contains_key(rn);
+            let walked = |rn: &RelName| is_routed(rn) && !skip_initial.contains(rn);
+            let scope = RepairScope::mapped(&drain_catalog, &routed, walked);
+            (
+                walshadow::backfill_bootstrap::tap_filenode_set(&drain_catalog, is_routed, walked)
+                    .map(Arc::new),
+                walshadow::backfill::bootstrap_oracle::needs_oracle(
+                    &drain_catalog,
+                    &routed,
+                    &resolved.column_rules,
+                ),
+                scope,
+                routed,
+            )
+        }
+        None => (None, false, RepairScope::default(), Default::default()),
+    };
 
-    // Sample window floor before BASE_BACKUP
-    let source_ident = feed
-        .identify_system()
-        .await
-        .context("bootstrap: sample source write head for the window leg")?;
-    let source_major = (feed.server_version_num() / 10000) as u32;
-
-    let cfg = BootstrapConfig::new(shadow_data_dir.clone())
-        .with_skip_filenodes(walk_skip)
-        .with_catalog_filenodes(catalog_filenodes);
-    let (rx, pump) = spawn_greenfield_bootstrap(cfg, source, catalog_map, store_toast);
-
-    // Keep oracle alive through live or file window replay
-    let mut bootstrap_oracle: Option<walshadow::backfill::bootstrap_oracle::BootstrapOracle> = None;
-    let mut window_cfg: Option<walshadow::backfill::bootstrap_window::WindowLegConfig> = None;
-    // Overlay window transaction outcomes on backup pg_xact
-    let window_patch = Arc::new(std::sync::Mutex::new(PgXactPatch::new()));
-    // Metrics-only mode has no pending gate
-    let mut pending_gate: Option<PendingGate> = None;
-    // Preserve live failure if file fallback also fails
-    let mut window_leg_error: Option<anyhow::Error> = None;
-    let window_scratch = args.spill_dir.join("bootstrap_window");
-    tokio::fs::remove_dir_all(&window_scratch).await.ok();
-
-    let (shipped, outcome, mut window) = if let Some(target) = ch_target {
-        let (emitter_cfg, mapping, resolved, mut pending, skip_initial) = target;
-        // Route bootstrap rows through the shared insert tail. Bootstrap
-        // is the easy case: every row op=Insert at _lsn = start_lsn, no
-        // aborts / TRUNCATE / DDL. Keep operator's flush_timeout; tail
-        // defaults 0 to its own partial-flush deadline.
-        let addr = format!("{}:{}", emitter_cfg.host, emitter_cfg.port);
-        let stats = bootstrap_stats.clone();
-        // Window leg shares the tail's fatal, so a CH outage stops both
-        let fatal = Fatal::new();
-        let inserter_pool_size = emitter_cfg.inserter_pool_size;
-
+    // Off the backup window: provisioning is an initdb + pg_dump + apply +
+    // restart, and doing it after `BASE_BACKUP` opens parks a live backup
+    // through all of it — in object-store mode against walrus's 60 s request
+    // cap
+    let bootstrap_oracle = if needs_oracle {
         let source_conninfo = format!(
             "host={} port={} user={} dbname={} sslmode={}",
             src_cfg.host,
@@ -4432,26 +4514,99 @@ async fn run_bootstrap(
                 "prefer"
             },
         );
-        if walshadow::backfill::bootstrap_oracle::needs_oracle(
-            &drain_catalog,
-            &mapping.snapshot().await,
-            &resolved.column_rules,
-        ) {
-            bootstrap_oracle = Some(
-                walshadow::backfill::bootstrap_oracle::BootstrapOracle::provision(
-                    args.spill_dir.join("bootstrap_oracle"),
-                    source_conninfo,
-                    src_cfg.password.clone(),
-                    args.bridge_lib_dir.clone(),
-                    Duration::from_secs(args.shadow_connect_timeout),
-                )
-                .await
-                .context(
-                    "bootstrap oracle: greenfield needs it to convert oracle columns; \
-                     refusing to load empty columns",
-                )?,
-            );
+        Some(
+            walshadow::backfill::bootstrap_oracle::BootstrapOracle::provision(
+                args.spill_dir.join("bootstrap_oracle"),
+                source_conninfo,
+                src_cfg.password.clone(),
+                args.bridge_lib_dir.clone(),
+                bridge_workers,
+                Duration::from_secs(args.shadow_connect_timeout),
+            )
+            .await
+            .context(
+                "bootstrap oracle: greenfield needs it to resolve tier-3 types; \
+                 refusing to load empty columns",
+            )?,
+        )
+    } else {
+        None
+    };
+    let oracle = bootstrap_oracle.as_ref().map(|o| o.oracle());
+
+    prepare_bootstrap_dir(&shadow_data_dir)
+        .await
+        .context("prepare shadow data dir for bootstrap")?;
+
+    // Sample window floor before BASE_BACKUP
+    let source_ident = feed
+        .identify_system()
+        .await
+        .context("bootstrap: sample source write head for the window leg")?;
+    let source_major = (feed.server_version_num() / 10000) as u32;
+
+    let mut cfg =
+        BootstrapConfig::new(shadow_data_dir.clone()).with_catalog_filenodes(catalog_filenodes);
+    if let Some(set) = tap_filenodes {
+        cfg = cfg.with_tap_filenodes(set);
+    }
+    let progress = cfg.progress.clone();
+    // Only writer of the registry until the status loop starts. Publishing the
+    // whole stage group is what makes oracle-versus-ClickHouse attribution
+    // answerable during an initial load, rather than page decode alone
+    let oracle_stats = oracle.as_ref().map(|o| o.stats.clone()).unwrap_or_default();
+    let bridge_stats = bootstrap_oracle
+        .as_ref()
+        .map(|o| o.bridge_stats())
+        .unwrap_or_default();
+    let ticker = tokio_util::task::AbortOnDropHandle::new(tokio::spawn({
+        let metrics = metrics.clone();
+        let progress = progress.clone();
+        let stats = bootstrap_stats.clone();
+        let oracle_stats = oracle_stats.clone();
+        let bridge_stats = bridge_stats.clone();
+        async move {
+            let mut tick = tokio::time::interval(Duration::from_secs(5));
+            loop {
+                tick.tick().await;
+                metrics
+                    .set(stage_gauges(&StageCounters {
+                        emitter: Some(&stats),
+                        oracle: [None, Some(&oracle_stats)],
+                        bridge: [None, Some(&bridge_stats)],
+                        bootstrap: Some(&progress),
+                        uptime_secs: uptime_from.elapsed().as_secs(),
+                    }))
+                    .await;
+            }
         }
+    }));
+    let (rx, pump) = spawn_greenfield_bootstrap(cfg, source, catalog_map, store_toast);
+    let pump = tokio_util::task::AbortOnDropHandle::new(pump);
+
+    let mut window_cfg: Option<walshadow::backfill::bootstrap_window::WindowLegConfig> = None;
+    // Overlay window transaction outcomes on backup pg_xact
+    let window_patch = Arc::new(std::sync::Mutex::new(PgXactPatch::new()));
+    // Metrics-only mode has no pending gate
+    let mut pending_gate: Option<PendingGate> = None;
+    let copy_rate =
+        walshadow::copy_backfill::CopyRate::new(args.bootstrap_max_rate_kib.map(|n| n as u32));
+    // Preserve live failure if file fallback also fails
+    let mut window_leg_error: Option<anyhow::Error> = None;
+    let window_scratch = args.spill_dir.join("bootstrap_window");
+    tokio::fs::remove_dir_all(&window_scratch).await.ok();
+
+    let (shipped, outcome, mut window) = if let Some(target) = ch_target {
+        let (emitter_cfg, mapping, resolved, skip_initial) = target;
+        // Route bootstrap rows through the shared insert tail. Bootstrap
+        // is the easy case: every row op=Insert at _lsn = start_lsn, no
+        // aborts / TRUNCATE / DDL. Keep operator's flush_timeout; tail
+        // defaults 0 to its own partial-flush deadline.
+        let addr = format!("{}:{}", emitter_cfg.host, emitter_cfg.port);
+        let stats = bootstrap_stats.clone();
+        // Window leg shares the tail's fatal, so a CH outage stops both
+        let fatal = Fatal::new();
+        let inserter_pool_size = emitter_cfg.inserter_pool_size;
 
         // Throwaway watermark: durability proof is `wait_through(K)`, resume
         // LSN is carried via the WAL pipeline's emitter_ack seed (see `run`),
@@ -4462,7 +4617,7 @@ async fn run_bootstrap(
             stats.clone(),
             fatal.clone(),
             None,
-            bootstrap_oracle.as_ref().map(|o| o.oracle()),
+            oracle.clone(),
             "bootstrap",
         )
         .await
@@ -4482,7 +4637,7 @@ async fn run_bootstrap(
                 config: resolved.clone(),
                 stats: stats.clone(),
                 resolver: resolver.clone(),
-                oracle: bootstrap_oracle.as_ref().map(|o| o.oracle()),
+                oracle: oracle.clone(),
                 fatal: fatal.clone(),
                 scratch_dir: window_scratch.clone(),
                 patch: window_patch.clone(),
@@ -4490,18 +4645,32 @@ async fn run_bootstrap(
                 pg_major: source_major,
                 system_id: source_ident.sysid.clone(),
                 timeline: source_ident.timeline,
+                wind_down: Duration::from_secs(args.bootstrap_wind_down_secs),
             }
         });
         let live_cfg = window_cfg.clone().filter(|_| plan.live_window_leg(args));
 
+        // No source-PG overlay during greenfield bootstrap, and the same
+        // mapping snapshot the CREATEs above rendered from: per-relation
+        // system column names have to match what CH now holds
+        let sink = GreenfieldSink {
+            source: src_cfg.clone(),
+            catalog: drain_catalog.clone(),
+            mapping: routes,
+            repair_scope,
+            copy_rate,
+            config: resolved.clone(),
+            emitter: emitter_cfg.clone(),
+            stats: stats.clone(),
+            resolver: resolver.clone(),
+            skip_initial,
+        };
+
         // Gate page tuples, defer unknowns until transaction logs land
         let gate_spool_path = args.spill_dir.join("bootstrap_gate_deferred.bin");
         tokio::fs::remove_file(&gate_spool_path).await.ok();
-        let (gated_tx, gated_rx) =
-            tokio::sync::mpsc::channel::<walshadow::backup_page_walk::BackfillTuple>(
-                walshadow::backup_page_walk::BOOTSTRAP_TUPLE_CHANNEL_CAP,
-            );
-        let gate = tokio::spawn({
+        let (gated_tx, stages) = sink.spawn(tail.msg_tx.clone(), tail.ack.clone());
+        let gate = tokio_util::task::AbortOnDropHandle::new(tokio::spawn({
             let catalog = drain_catalog.clone();
             let mut rx = rx;
             let mut spool = walshadow::spool::DeferredSpool::new(
@@ -4512,38 +4681,16 @@ async fn run_bootstrap(
                 let mut gate_stats = GateStats::default();
                 stream_phase(
                     &mut rx,
-                    &gated_tx,
+                    &GateOutput::Repair(&gated_tx),
                     &catalog,
-                    &mut pending,
                     &mut spool,
                     &mut gate_stats,
                 )
                 .await
-                .map(|()| (gate_stats, spool, pending))
+                .map(|()| (gate_stats, spool))
             }
-        });
+        }));
 
-        let deferred_path = args.spill_dir.join("bootstrap_deferred.bin");
-        tokio::fs::remove_file(&deferred_path).await.ok();
-        let drain = tokio::spawn(bootstrap::drain(
-            gated_rx,
-            drain_catalog.clone(),
-            mapping.clone(),
-            tail.msg_tx.clone(),
-            tail.ack.clone(),
-            stats.clone(),
-            resolver.clone(),
-            walshadow::spool::DeferredSpool::new(
-                deferred_path,
-                walshadow::spool::DEFERRED_SPOOL_MEM_MAX,
-            ),
-            emitter_cfg.row_policy(),
-            // No source-PG overlay during greenfield bootstrap, but the same
-            // snapshot the CREATEs above rendered from: per-relation system
-            // column names have to match what CH now holds
-            Some(resolved.clone()),
-            skip_initial.clone(),
-        ));
         // Borrow feed until stop watch publishes end_lsn or zero
         let (stop_tx, stop_rx) = tokio::sync::watch::channel(None);
         // Keep sender alive while leg winds down
@@ -4570,34 +4717,44 @@ async fn run_bootstrap(
                 None => Ok(None),
             }
         };
-        let (gate_res, drain_res, pump_res, leg_res) =
-            tokio::join!(gate, drain, pump_then_stop, leg_fut);
-        let (gate_stats, gate_spool, pending) = gate_res
-            .context("bootstrap gate join")?
-            .map_err(|e| anyhow::anyhow!("bootstrap gate: {e}"))?;
-        let drain_outcome = drain_res
-            .context("bootstrap drain join")?
-            .map_err(|e| anyhow::anyhow!("bootstrap drain: {e}"))?;
-        let outcome: BootstrapOutcome = pump_res
-            .context("bootstrap pump join")?
-            .context("bootstrap pump")?;
-        // Retry failed live read from landed WAL
-        let window = match leg_res {
-            Ok(w) => {
-                if w.is_some() {
-                    window_cfg = None;
+        let (gate_res, stage_res, pump_res, leg_res) =
+            tokio::join!(gate, stages.join(), pump_then_stop, leg_fut);
+        let prepared = (|| -> Result<_> {
+            let (repair_stats, drain_outcome) = stage_res.map_err(|e| anyhow::anyhow!(e))?;
+            let (mut gate_stats, gate_spool) = gate_res
+                .context("bootstrap gate join")?
+                .map_err(|e| anyhow::anyhow!("bootstrap gate: {e}"))?;
+            gate_stats.repaired_rows += repair_stats.rows;
+            gate_stats.p_hi = gate_stats.p_hi.max(repair_stats.p_hi);
+            let outcome: BootstrapOutcome = pump_res
+                .context("bootstrap pump join")?
+                .context("bootstrap pump")?;
+            // Retry failed live read from landed WAL
+            let window = match leg_res {
+                Ok(w) => {
+                    if w.is_some() {
+                        window_cfg = None;
+                    }
+                    w
                 }
-                w
-            }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "walshadow::bootstrap",
+                        error = %format!("{e:#}"),
+                        "live backup-window leg failed; replaying the window from the \
+                         WAL the backup landed",
+                    );
+                    window_leg_error = Some(e);
+                    None
+                }
+            };
+            Ok((gate_stats, gate_spool, drain_outcome, outcome, window))
+        })();
+        let (gate_stats, gate_spool, drain_outcome, outcome, window) = match prepared {
+            Ok(prepared) => prepared,
             Err(e) => {
-                tracing::warn!(
-                    target: "walshadow::bootstrap",
-                    error = %format!("{e:#}"),
-                    "live backup-window leg failed; replaying the window from the \
-                     WAL the backup landed",
-                );
-                window_leg_error = Some(e);
-                None
+                tail.quiesce().await;
+                return Err(e);
             }
         };
         let k = drain_outcome.next_seq;
@@ -4613,18 +4770,8 @@ async fn run_bootstrap(
         );
         pending_gate = Some(PendingGate {
             deferred: gate_spool,
-            pending,
-            catalog: drain_catalog,
-            mapping,
-            config: resolved,
-            emitter: emitter_cfg,
-            stats,
-            resolver: resolver.clone(),
-            oracle: bootstrap_oracle.as_ref().map(|o| o.oracle()),
-            skip_initial,
-            source: src_cfg.clone(),
-            start_lsn: outcome.start.start_lsn,
-            spill_dir: args.spill_dir.clone(),
+            sink,
+            oracle: oracle.clone(),
             stream_stats: gate_stats,
         });
         (drain_outcome.rows_routed, outcome, window)
@@ -4670,14 +4817,27 @@ async fn run_bootstrap(
         start_lsn = format_pg_lsn(outcome.start.start_lsn).to_string(),
         end_lsn = format_pg_lsn(outcome.end.end_lsn).to_string(),
         timeline = outcome.start.timeline,
-        kept_files = outcome.disk.kept_files,
-        skipped_denylist = outcome.disk.skipped_denylist,
-        files_walked = outcome.page_walk.files_walked,
-        files_skipped_by_caller = outcome.page_walk.files_skipped_by_caller,
-        tuples_emitted = outcome.page_walk.tuples_emitted,
+        kept_files = outcome.disk.kept_files.load(Ordering::Relaxed),
+        skipped_denylist = outcome.disk.skipped_denylist.load(Ordering::Relaxed),
+        files_walked = outcome.page_walk.files_walked.load(Ordering::Relaxed),
+        tuples_emitted = outcome.page_walk.tuples_emitted.load(Ordering::Relaxed),
         drained = shipped,
         "bootstrap landed",
     );
+    // Stage attribution: which of tap, decode or emitter drain owned the
+    // wall clock. Sum exceeds elapsed under source parallelism
+    tracing::info!(
+        target: "walshadow::bootstrap",
+        elapsed_secs = timing.elapsed().as_secs_f64(),
+        bytes_tapped = outcome.pump.bytes_tapped.load(Ordering::Relaxed),
+        pages_walked = outcome.page_walk.pages_walked.load(Ordering::Relaxed),
+        tap_secs = outcome.pump.sink_chunk_nanos.load(Ordering::Relaxed) as f64 / 1e9,
+        decode_secs = outcome.page_walk.decode_nanos.load(Ordering::Relaxed) as f64 / 1e9,
+        channel_block_secs = outcome.page_walk.channel_block_nanos.load(Ordering::Relaxed) as f64 / 1e9,
+        files_skipped_unmapped = outcome.page_walk.files_skipped_unmapped.load(Ordering::Relaxed),
+        "bootstrap stage timings",
+    );
+    ticker.abort();
 
     if let Some((settings, storage)) = wal_hydrate {
         fetch_wal_into_pg_wal(
@@ -4766,9 +4926,7 @@ async fn run_bootstrap(
             deferred = gate.deferred,
             multixact_emitted = gate.multixact_emitted,
             chunks_gated = gate.chunks_gated,
-            pending_relations = gate.pending_relations,
-            pending_multixact = gate.pending_multixact,
-            pending_discarded = gate.pending_discarded,
+            unresolved = gate.unresolved,
             repaired_rows = gate.repaired_rows,
             p_hi = gate.p_hi,
             patch_xacts = patch.len(),
@@ -4793,10 +4951,35 @@ async fn run_bootstrap(
         .context("clear completed bootstrap marker")?;
 
     timing.finish();
-    Ok(BootstrapHandoff {
-        end_lsn: outcome.end.end_lsn,
-        open_floor,
-    })
+    Ok((
+        BootstrapHandoff {
+            end_lsn: outcome.end.end_lsn,
+            open_floor,
+        },
+        BootstrapMetrics {
+            progress,
+            oracle: oracle_stats,
+            bridge: bridge_stats,
+        },
+    ))
+}
+
+/// Registry the bootstrap ticker writes, and the handles it publishes there.
+/// Both outlive bootstrap: the daemon's `t0` and the emitter counters the
+/// streaming pipeline goes on adding to
+struct BootstrapObservers<'a> {
+    metrics: &'a MetricsRegistry,
+    emitter_stats: Arc<EmitterStats>,
+    uptime_from: Instant,
+}
+
+/// What bootstrap leaves behind for the status loop to keep publishing. The
+/// oracle handles outlive their throwaway PG, so its request cost stays on
+/// the same series the live bridge then adds to
+struct BootstrapMetrics {
+    progress: BootstrapProgress,
+    oracle: Arc<walshadow::oracle::OracleStats>,
+    bridge: Arc<walshadow::bridge::BridgeStats>,
 }
 
 /// Bootstrap-to-pump handoff
@@ -4959,7 +5142,16 @@ async fn prepare_bootstrap_dir(dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn build_owned_shadow(args: &Args, dbname: &str, data_dir: PathBuf) -> Shadow {
+/// Inserter count is the demand on the oracle: one bridge worker and one
+/// resolver per inserter is what keeps a batch resolving while the others
+/// insert
+fn bridge_pool_size(ch_config: Option<&EmitterConfig>) -> usize {
+    ch_config
+        .map_or(1, |cfg| cfg.inserter_pool_size)
+        .clamp(1, walshadow::bridge::MAX_BRIDGE_WORKERS)
+}
+
+fn build_owned_shadow(args: &Args, dbname: &str, data_dir: PathBuf, workers: usize) -> Shadow {
     let mut cfg = ShadowConfig::new(data_dir, args.out_dir.clone());
     cfg.port = args.shadow_port;
     cfg.socket_dir = args.shadow_socket_dir.clone();
@@ -4971,6 +5163,7 @@ fn build_owned_shadow(args: &Args, dbname: &str, data_dir: PathBuf) -> Shadow {
     let mut bridge = walshadow::shadow::BridgeConf::in_dir(&cfg.socket_dir);
     bridge.socket_path = args.bridge_socket_path();
     bridge.library_dir = args.bridge_lib_dir.clone();
+    bridge.workers = workers;
     cfg.bridge = Some(bridge);
     Shadow::new(cfg)
 }
@@ -5287,6 +5480,68 @@ mod tests {
         Args::parse_from(base.iter().copied().chain(argv.iter().copied()))
     }
 
+    #[test]
+    fn stage_gauges_folds_bootstrap_oracle_into_the_live_series() {
+        use walshadow::bridge::{BridgeStats, OP_LABELS};
+        use walshadow::oracle::OracleStats;
+        let encode = OP_LABELS
+            .iter()
+            .position(|l| *l == "encode_native")
+            .expect("op label");
+        let bump = |s: &BridgeStats, n: u64| {
+            s.up.store(1, Ordering::Relaxed);
+            s.requests[encode].fetch_add(n, Ordering::Relaxed);
+            s.native_bytes.fetch_add(n, Ordering::Relaxed);
+        };
+        let (live_bridge, boot_bridge) = (BridgeStats::default(), BridgeStats::default());
+        bump(&live_bridge, 2);
+        bump(&boot_bridge, 5);
+        live_bridge.up.store(0, Ordering::Relaxed);
+        let (live_oracle, boot_oracle) = (OracleStats::default(), OracleStats::default());
+        live_oracle.rows.fetch_add(3, Ordering::Relaxed);
+        boot_oracle.rows.fetch_add(7, Ordering::Relaxed);
+
+        let snap = stage_gauges(&StageCounters {
+            emitter: None,
+            oracle: [Some(&live_oracle), Some(&boot_oracle)],
+            bridge: [Some(&live_bridge), Some(&boot_bridge)],
+            bootstrap: None,
+            uptime_secs: 11,
+        });
+        assert_eq!(snap.oracle_rows_total, 10);
+        assert_eq!(snap.bridge_native_bytes_total, 7);
+        assert_eq!(
+            snap.bridge_requests_by_op[encode], 7,
+            "both bridges' requests land on one series"
+        );
+        // Live bridge owns the gauge once it exists, whatever bootstrap left
+        assert_eq!(snap.bridge_up, 0);
+        assert_eq!(snap.uptime_secs, 11);
+
+        let boot_only = stage_gauges(&StageCounters {
+            emitter: None,
+            oracle: [None, Some(&boot_oracle)],
+            bridge: [None, Some(&boot_bridge)],
+            bootstrap: None,
+            uptime_secs: 11,
+        });
+        assert_eq!(boot_only.oracle_rows_total, 7);
+        assert_eq!(boot_only.bridge_up, 1, "bootstrap's bridge answers alone");
+    }
+
+    #[test]
+    fn bootstrap_wind_down_accepts_override_and_zero() {
+        assert_eq!(args_from(&[]).bootstrap_wind_down_secs, 5);
+        assert_eq!(
+            args_from(&["--bootstrap-wind-down-secs", "60"]).bootstrap_wind_down_secs,
+            60
+        );
+        assert_eq!(
+            args_from(&["--bootstrap-wind-down-secs", "0"]).bootstrap_wind_down_secs,
+            0
+        );
+    }
+
     #[tokio::test]
     async fn archive_fetch_reads_exact_segment() {
         let tmp = tempfile::tempdir().unwrap();
@@ -5417,6 +5672,34 @@ mod tests {
             args_from(&["--bridge-socket", "/tmp/custom.sock"]).bridge_socket_path(),
             PathBuf::from("/tmp/custom.sock")
         );
+    }
+
+    #[test]
+    fn owned_shadow_sizes_bridge_from_inserter_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let args = args_from(&[]);
+        for (toml, workers, slots) in [
+            (None, 1, 2),
+            (Some("[ch]"), 3, 4),
+            (Some("[ch]\ninserter_pool_size = 5"), 5, 6),
+            (Some("[ch]\ninserter_pool_size = 16"), 8, 9),
+        ] {
+            let config = toml.map(|t| EmitterConfig::from_toml_str(t).unwrap());
+            let shadow = build_owned_shadow(
+                &args,
+                "postgres",
+                tmp.path().to_path_buf(),
+                bridge_pool_size(config.as_ref()),
+            );
+            let floor = walshadow::shadow::SourceGucFloor {
+                max_worker_processes: 1,
+                ..Default::default()
+            };
+            shadow.materialize_conf(&floor, None).unwrap();
+            let conf = std::fs::read_to_string(tmp.path().join("postgresql.conf")).unwrap();
+            assert!(conf.contains(&format!("walshadow.bridge_workers = {workers}\n")));
+            assert!(conf.contains(&format!("max_worker_processes = {slots}\n")));
+        }
     }
 
     #[test]

--- a/src/catalog/shadow.rs
+++ b/src/catalog/shadow.rs
@@ -70,6 +70,10 @@ pub struct BridgeConf {
     /// Bounds a catalog lock the worker cannot get, which would otherwise hang
     /// against recovery
     pub lock_timeout: Duration,
+    /// `walshadow.bridge_workers`. Each worker serves one request at a time,
+    /// so this is how many oracle round trips can be in flight. Worker 0
+    /// keeps `socket_path`; worker `i` listens on `socket_path.i`
+    pub workers: usize,
 }
 
 impl BridgeConf {
@@ -80,6 +84,7 @@ impl BridgeConf {
             library_dir: None,
             io_timeout: Duration::from_secs(30),
             lock_timeout: Duration::from_secs(1),
+            workers: 1,
         }
     }
 
@@ -100,11 +105,14 @@ impl BridgeConf {
             "walshadow.socket_path = '{}'\n\
              walshadow.database = '{}'\n\
              walshadow.io_timeout_ms = {}\n\
-             walshadow.lock_timeout_ms = {}\n",
+             walshadow.lock_timeout_ms = {}\n\
+             walshadow.bridge_workers = {}\n",
             quote_path(&self.socket_path),
             quote(dbname),
             self.io_timeout.as_millis(),
             self.lock_timeout.as_millis(),
+            self.workers
+                .clamp(1, crate::ops::bridge::MAX_BRIDGE_WORKERS),
         ));
         out
     }
@@ -352,10 +360,11 @@ impl Shadow {
             sock = self.config.socket_str(),
             port = self.config.port,
             max_connections = floor.max_connections,
-            // Bridge takes a slot. Over the floor rather than under it: PG only
-            // LOGs "too many background workers" and drops the registration
-            max_worker_processes =
-                floor.max_worker_processes + u32::from(self.config.bridge.is_some()),
+            // PG only logs excess workers and drops their registration
+            max_worker_processes = floor.max_worker_processes
+                + self.config.bridge.as_ref().map_or(0, |b| {
+                    b.workers.clamp(1, crate::ops::bridge::MAX_BRIDGE_WORKERS) as u32
+                }),
             max_wal_senders = floor.max_wal_senders,
             max_prepared_transactions = floor.max_prepared_transactions,
             max_locks_per_transaction = floor.max_locks_per_transaction,

--- a/src/emit/ch_emitter.rs
+++ b/src/emit/ch_emitter.rs
@@ -1349,7 +1349,11 @@ pub(crate) fn fresh_buffers(plan: &TablePlan) -> Result<Vec<ColumnBuf>, EmitterE
             ColumnEncoding::Oracle {
                 source_type_oid,
                 source_typmod,
-            } => ColumnBuf::Oracle(OracleColumnBuf::new(source_type_oid, source_typmod)),
+            } => ColumnBuf::Oracle(OracleColumnBuf::new(
+                source_type_oid,
+                source_typmod,
+                &c.type_repr,
+            )),
         });
     }
     buffers.push(ColumnBuf::Fixed {
@@ -1426,15 +1430,23 @@ impl TableEncoder {
         let mut cells = std::mem::take(&mut self.oracle_cells);
         cells.clear();
         let mut row_oracle_bytes = 0usize;
+        // Literals bound for a String target never reach the request, so they
+        // owe it nothing until a cell needing conversion strands them
+        let mut stranded_bytes = 0usize;
         for (i, col) in mapping.columns.iter().enumerate() {
             if let ColumnBuf::Oracle(o) = &self.buffers[i] {
                 let cell = oracle_cell(value_of(col), o.source_type_oid)
                     .map_err(|e| name_column(e, &col.target_name))?;
-                row_oracle_bytes += cell.wire_bytes();
+                if !o.resolves_locally(&cell) {
+                    row_oracle_bytes += cell.wire_bytes();
+                    stranded_bytes += o.stranded_bytes();
+                }
                 cells.push(cell);
             }
         }
-        if self.rows > 0 && self.oracle_bytes + row_oracle_bytes > ORACLE_BATCH_SEAL_BYTES {
+        if self.rows > 0
+            && self.oracle_bytes + row_oracle_bytes + stranded_bytes > ORACLE_BATCH_SEAL_BYTES
+        {
             cells.clear();
             self.oracle_cells = cells;
             return Ok(Append::Full);
@@ -1467,7 +1479,7 @@ impl TableEncoder {
         }
         cells.clear();
         self.oracle_cells = cells;
-        self.oracle_bytes += row_oracle_bytes;
+        self.oracle_bytes += row_oracle_bytes + stranded_bytes;
         // Synthetic columns: lsn, xid, commit_ts (unix micros), delete marker
         let off = mapping.columns.len();
         push_fixed(&mut self.buffers[off], &decoded.source_lsn.to_le_bytes())?;
@@ -1495,7 +1507,36 @@ fn name_column(mut e: EmitterError, target: &str) -> EmitterError {
     e
 }
 
-/// Build stable leaves before roots borrow them
+/// PostgreSQL returns literal String cells unchanged
+pub(crate) fn literal_column(
+    buf: &OracleColumnBuf,
+    target_type: &str,
+    n_rows: usize,
+) -> Option<ColumnBuf> {
+    if !buf.resolves_batch_locally(n_rows) {
+        return None;
+    }
+    let offsets = Vec::with_capacity(n_rows);
+    let data = Vec::new();
+    let mut local = if target_type == "Nullable(String)" {
+        ColumnBuf::NullableString {
+            offsets,
+            data,
+            null_map: Vec::with_capacity(n_rows),
+        }
+    } else {
+        ColumnBuf::String { offsets, data }
+    };
+    for cell in buf.cells() {
+        if let OracleCell::Literal(bytes) = cell {
+            local.append_string_bytes(bytes).ok()?;
+        } else {
+            local.append_default();
+        }
+    }
+    Some(local)
+}
+
 pub(crate) fn build_leaf(
     buf: &ColumnBuf,
     n_rows: usize,
@@ -2001,6 +2042,19 @@ crate::atomic_stats! {
         pub insertbatch_rows_in,
         pub insertbatch_batches_out,
         pub inserter_batches_in,
+        /// Inserter time inside the INSERT round trip (`send_query` through
+        /// `EndOfStream`), retries included. Against `inserter_pool_size ×
+        /// elapsed` this is CH-side utilization
+        pub inserter_ch_nanos,
+        /// Inserter time rebuilding the Native block over the batch's slabs
+        pub inserter_encode_nanos,
+        /// Resolver time inside the oracle round trip, retries included.
+        /// Overlaps the inserters' ClickHouse time, so against
+        /// `inserter_ch_nanos` it says which stage is the limiter
+        pub oracle_resolve_nanos,
+        /// Oracle-routed columns the daemon built itself: rendered cells
+        /// against a `String` target, which PG would hand straight back
+        pub oracle_local_columns,
     }
 }
 
@@ -2381,6 +2435,94 @@ mod tests {
             let ast = TypeAst::parse(name, alloc).expect("parses");
             assert_eq!(ast.view().elem_size(), 0, "{name}");
         }
+    }
+
+    #[test]
+    fn literal_column_requires_string_target_and_rendered_cells() {
+        let mut buf = OracleColumnBuf::new(0, -1, "String");
+        buf.push(OracleCell::Literal(b"a".to_vec()));
+        buf.push(OracleCell::Default);
+        match literal_column(&buf, "String", 2) {
+            Some(ColumnBuf::String { offsets, data }) => {
+                assert_eq!(data, b"a");
+                assert_eq!(offsets, [1, 1]);
+            }
+            other => panic!("got {other:?}"),
+        }
+        for reject in ["Array(String)", "LowCardinality(String)", "JSON", "Int32"] {
+            let mut buf = OracleColumnBuf::new(0, -1, reject);
+            buf.push(OracleCell::Literal(b"a".to_vec()));
+            buf.push(OracleCell::Default);
+            assert!(
+                literal_column(&buf, reject, 2).is_none(),
+                "{reject} needs the worker",
+            );
+        }
+        // Cell count must match the batch, else offsets would not
+        assert!(literal_column(&buf, "String", 3).is_none());
+        for cell in [
+            OracleCell::DiskRaw(b"a".to_vec()),
+            OracleCell::TextInput(b"a".to_vec()),
+        ] {
+            let mut buf = OracleColumnBuf::new(0, -1, "String");
+            buf.push(OracleCell::Literal(b"a".to_vec()));
+            buf.push(cell);
+            for target in ["String", "Nullable(String)"] {
+                assert!(literal_column(&buf, target, 2).is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn literal_string_cells_stay_off_the_oracle_batch_estimate() {
+        let alloc = Allocator::stdlib();
+        let mut rel = mk_rel();
+        // Source type the local matrix misses, so `name` plans as an oracle
+        // column while its String target still renders literals in-daemon
+        rel.attributes[1].type_oid = 17_000;
+        let m = mk_mapping();
+        let plan = TablePlan::build(
+            alloc,
+            &rel,
+            &m,
+            &ColumnRules::default(),
+            &SystemColumns::default(),
+        )
+        .unwrap();
+        assert!(matches!(
+            plan.columns[1].encoding,
+            ColumnEncoding::Oracle { .. }
+        ));
+        let mut enc = TableEncoder::new(plan).unwrap();
+        let overhead = enc.oracle_bytes;
+        let big = "x".repeat(ORACLE_BATCH_SEAL_BYTES * 3 / 5);
+        for id in 1..=2 {
+            assert_eq!(
+                enc.append_row(&committed(id, Some(&big)), &m, OP_INSERT)
+                    .unwrap(),
+                Append::Done,
+                "literal rows do not seal",
+            );
+        }
+        assert_eq!(
+            enc.oracle_bytes, overhead,
+            "literals owe the request nothing"
+        );
+        // A cell needing conversion sends the column whole, so the literals
+        // it strands seal the batch rather than overrun the frame cap
+        let mut json_row = committed(3, None);
+        json_row.decoded.new.as_mut().expect("insert tuple").columns[1] =
+            Some(ColumnValue::Json("{}".into()));
+        assert_eq!(
+            enc.append_row(&json_row, &m, OP_INSERT).unwrap(),
+            Append::Full
+        );
+        let (buffers, rows) = enc.take_block().unwrap();
+        assert_eq!(rows, 2);
+        let ColumnBuf::Oracle(o) = &buffers[1] else {
+            panic!("oracle column")
+        };
+        assert!(literal_column(o, "Nullable(String)", rows).is_some());
     }
 
     #[test]

--- a/src/emit/pipeline/bootstrap.rs
+++ b/src/emit/pipeline/bootstrap.rs
@@ -15,9 +15,10 @@ use crate::config::ResolvedConfig;
 use crate::decode::heap_decoder::{ColumnValue, ToastPointer};
 use crate::emit::ch_emitter::EmitterStats;
 use crate::emit::pipeline::ack::AckHandle;
-use crate::emit::pipeline::batcher::{BatcherMsg, RoutedRow};
+use crate::emit::pipeline::batcher::{BatcherMsg, RoutedRow, RowChunk};
+use crate::emit::pipeline::decode::DECODE_CHUNK_BYTES;
 use crate::emit::route::{RouteSnapshot, RowPolicy, freeze_routes};
-use crate::mapping::{MappingHandle, TableMapping};
+use crate::mapping::{MappingSnapshot, TableMapping};
 use crate::ops::oracle::render_ext_columns;
 use crate::schema::{RelDescriptor, RelName};
 use crate::toast::{
@@ -25,6 +26,11 @@ use crate::toast::{
     detoasted_value, finish_value, pointer_extsize,
 };
 use ahash::HashSet;
+
+/// Rows per `BatcherMsg::Rows` from the bootstrap drain. Fixed rather than
+/// config-driven: bootstrap rows are uniform inserts, and the byte trigger
+/// covers the fat-row case
+const DRAIN_CHUNK_ROWS: usize = 1024;
 
 /// Completion frontier for `FlushAll` and resume advance
 #[derive(Debug, Clone, Copy, Default)]
@@ -34,108 +40,113 @@ pub struct BootstrapDrainOutcome {
     pub rows_routed: u64,
 }
 
-/// Drain page-walk tuples into shared insert tail. `deferred` spools
-/// referrers waiting for later `pg_toast_*` files; at replay the
-/// descriptor and mapping re-resolve from frozen per-pass snapshots
+/// Drain baseline tuples into shared insert tail
+///
+/// `None` requires repaired input, `Some` permits per-table backup referrers
+/// to wait for later TOAST files
 #[allow(clippy::too_many_arguments)]
 pub async fn drain(
-    mut rx: mpsc::Receiver<BackfillTuple>,
+    mut rx: mpsc::Receiver<Vec<BackfillTuple>>,
     catalog: CatalogMap,
-    mapping_handle: MappingHandle,
+    mapping: MappingSnapshot,
     msg_tx: mpsc::Sender<BatcherMsg>,
     ack: AckHandle,
     stats: Arc<EmitterStats>,
     resolver: ToastResolver,
-    mut deferred: DeferredSpool,
+    mut deferred: Option<DeferredSpool>,
     row_policy: RowPolicy,
     config: Option<Arc<ResolvedConfig>>,
     skip_initial: HashSet<RelName>,
 ) -> Result<BootstrapDrainOutcome, String> {
     // Routes frozen once per pass from the caller's config snapshot
-    let routes = freeze_routes(
-        &mapping_handle.snapshot().await,
-        config.as_deref(),
-        &row_policy,
-    );
+    let routes = freeze_routes(&mapping, config.as_deref(), &row_policy);
     let mut next_seq = 0u64;
     let mut rows_routed = 0u64;
     let mut open: Option<(walrus::pg::walparser::RelFileNode, u64, u64)> = None;
     let mut chunk_batch: Vec<ToastRow> = Vec::new();
     let mut chunk_batch_bytes = 0usize;
     let mut start_lsn = 0u64;
-    while let Some(tuple) = rx.recv().await {
-        let rfn = tuple.rfn;
-        let source_lsn = tuple.source_lsn;
-        start_lsn = source_lsn;
+    // Rows coalesce into `BatcherMsg::Rows` on the same dual trigger the
+    // decode pool uses, so a walk slab costs one channel hop, not one per row
+    let mut out = RowBuf::default();
+    while let Some(slab) = rx.recv().await {
+        for tuple in slab {
+            let rfn = tuple.rfn;
+            let source_lsn = tuple.source_lsn;
+            start_lsn = source_lsn;
 
-        let same = matches!(&open, Some((r, _, _)) if *r == rfn);
-        let seq = if same {
-            open.as_ref().expect("same implies open").1
-        } else {
-            if let Some((_, prev_seq, prev_rows)) = open.take() {
-                ack.placed(prev_seq, prev_rows);
-            }
-            let s = next_seq;
-            next_seq += 1;
-            ack.register(s, source_lsn);
-            open = Some((rfn, s, 0));
-            s
-        };
-
-        let Some(rel) = catalog.get(rfn.db_node, rfn.rel_node) else {
-            stats.unsupported_relations.fetch_add(1, Ordering::Relaxed);
-            continue;
-        };
-
-        if skip_initial.contains(&rel.rel_name) {
-            continue;
-        }
-
-        if catalog.is_toast(rfn.db_node, rfn.rel_node) {
-            if let Some(row) = row_from_columns(tuple, rel.oid) {
-                chunk_batch_bytes += row.chunk_data.len();
-                chunk_batch.push(row);
-                if chunk_batch.len() >= CHUNK_PUT_BATCH || chunk_batch_bytes >= CHUNK_PUT_BYTES {
-                    flush_chunks(&resolver, &mut chunk_batch).await?;
-                    chunk_batch_bytes = 0;
+            let same = matches!(&open, Some((r, _, _)) if *r == rfn);
+            let seq = if same {
+                open.as_ref().expect("same implies open").1
+            } else {
+                if let Some((_, prev_seq, prev_rows)) = open.take() {
+                    // Every row of the closing seq on the channel before its
+                    // expected count is published
+                    out.flush(&msg_tx).await?;
+                    ack.placed(prev_seq, prev_rows);
                 }
-            }
-            continue;
-        }
+                let s = next_seq;
+                next_seq += 1;
+                ack.register(s, source_lsn);
+                open = Some((rfn, s, 0));
+                s
+            };
 
-        let Some(route) = routes.get(&rel.rel_name).cloned() else {
-            stats.unsupported_relations.fetch_add(1, Ordering::Relaxed);
-            continue;
-        };
+            let Some(rel) = catalog.get(rfn.db_node, rfn.rel_node) else {
+                stats.unsupported_relations.fetch_add(1, Ordering::Relaxed);
+                continue;
+            };
 
-        if has_mapped_external_toast(&tuple, &route.mapping) {
-            if resolver.stores_chunks() {
-                deferred
-                    .push(tuple)
-                    .await
-                    .map_err(|e| format!("bootstrap: deferred spool: {e}"))?;
-                stats
-                    .bootstrap_deferred_bytes
-                    .store(deferred.resident_bytes() as u64, Ordering::Relaxed);
-                stats
-                    .bootstrap_deferred_spool_bytes
-                    .store(deferred.spooled_bytes(), Ordering::Relaxed);
+            if skip_initial.contains(&rel.rel_name) {
                 continue;
             }
-            let mut tuple = tuple;
-            let permit = resolve_or_fill_toast(&mut tuple, &rel, &route.mapping, &resolver).await?;
-            render_ext_columns(&rel.attributes, &mut tuple.columns);
-            route_row(&msg_tx, seq, rel, route, tuple, permit).await?;
-            bump(&mut open, &mut rows_routed);
-            continue;
-        }
 
-        let mut tuple = tuple;
-        render_ext_columns(&rel.attributes, &mut tuple.columns);
-        route_row(&msg_tx, seq, rel, route, tuple, None).await?;
-        bump(&mut open, &mut rows_routed);
+            if catalog.is_toast(rfn.db_node, rfn.rel_node) {
+                if let Some(row) = row_from_columns(tuple, rel.oid) {
+                    chunk_batch_bytes += row.chunk_data.len();
+                    chunk_batch.push(row);
+                    if chunk_batch.len() >= CHUNK_PUT_BATCH || chunk_batch_bytes >= CHUNK_PUT_BYTES
+                    {
+                        flush_chunks(&resolver, &mut chunk_batch).await?;
+                        chunk_batch_bytes = 0;
+                    }
+                }
+                continue;
+            }
+
+            let Some(route) = routes.get(&rel.rel_name).cloned() else {
+                stats.unsupported_relations.fetch_add(1, Ordering::Relaxed);
+                continue;
+            };
+
+            let mut tuple = tuple;
+            let mut permit = None;
+            if tuple.has_mapped_external(&route.mapping) {
+                let deferred = deferred.as_mut().ok_or_else(|| {
+                    format!("bootstrap: unrepaired external value in {}", rel.rel_name)
+                })?;
+                if resolver.stores_chunks() {
+                    deferred
+                        .push(tuple)
+                        .await
+                        .map_err(|e| format!("bootstrap: deferred spool: {e}"))?;
+                    stats
+                        .bootstrap_deferred_bytes
+                        .store(deferred.resident_bytes() as u64, Ordering::Relaxed);
+                    stats
+                        .bootstrap_deferred_spool_bytes
+                        .store(deferred.spooled_bytes(), Ordering::Relaxed);
+                    continue;
+                }
+                permit = resolve_or_fill_toast(&mut tuple, &rel, &route.mapping, &resolver).await?;
+            }
+            render_ext_columns(&rel.attributes, &mut tuple.columns);
+            out.push(&msg_tx, seq, rel, route, tuple, permit).await?;
+            bump(&mut open, &mut rows_routed);
+        }
     }
 
+    out.flush(&msg_tx).await?;
     if let Some((_, seq, rows)) = open.take() {
         ack.placed(seq, rows);
     }
@@ -144,7 +155,7 @@ pub async fn drain(
         flush_chunks(&resolver, &mut chunk_batch).await?;
     }
 
-    if deferred.records() > 0 {
+    if let Some(deferred) = deferred.filter(|s| s.records() > 0) {
         tracing::info!(
             target: "walshadow::bootstrap",
             deferred = deferred.records(),
@@ -174,10 +185,11 @@ pub async fn drain(
             };
             let permit = resolve_or_fill_toast(&mut tuple, &rel, &route.mapping, &resolver).await?;
             render_ext_columns(&rel.attributes, &mut tuple.columns);
-            route_row(&msg_tx, seq, rel, route, tuple, permit).await?;
+            out.push(&msg_tx, seq, rel, route, tuple, permit).await?;
             placed += 1;
             rows_routed += 1;
         }
+        out.flush(&msg_tx).await?;
         replay
             .finish()
             .await
@@ -202,37 +214,57 @@ fn bump(open: &mut Option<(walrus::pg::walparser::RelFileNode, u64, u64)>, rows_
     *rows_routed += 1;
 }
 
-async fn route_row(
-    msg_tx: &mpsc::Sender<BatcherMsg>,
-    seq: u64,
-    rel: Arc<RelDescriptor>,
-    route: Arc<RouteSnapshot>,
-    tuple: BackfillTuple,
-    value_permit: Option<crate::budget::MemoryPermit>,
-) -> Result<(), String> {
-    let committed = tuple.into_committed_insert();
-    msg_tx
-        .send(BatcherMsg::Row(RoutedRow {
+/// Coalesces routed rows into one `BatcherMsg::Rows` per
+/// [`DECODE_CHUNK_BYTES`]-shaped trigger, the same amortization the streaming
+/// decode pool gets. Rows of different seqs may share a chunk; the batcher
+/// routes each independently
+#[derive(Default)]
+struct RowBuf {
+    rows: Vec<RoutedRow>,
+    bytes: usize,
+}
+
+impl RowBuf {
+    async fn push(
+        &mut self,
+        msg_tx: &mpsc::Sender<BatcherMsg>,
+        seq: u64,
+        rel: Arc<RelDescriptor>,
+        route: Arc<RouteSnapshot>,
+        tuple: BackfillTuple,
+        value_permit: Option<crate::budget::MemoryPermit>,
+    ) -> Result<(), String> {
+        let committed = tuple.into_committed_insert();
+        self.bytes += committed.decoded.approx_bytes();
+        self.rows.push(RoutedRow {
             seq,
             rel,
             route,
             committed,
             value_permit: value_permit.map(Arc::new),
-        }))
-        .await
-        .map_err(|_| "bootstrap: batcher channel closed".to_string())
+        });
+        if self.rows.len() >= DRAIN_CHUNK_ROWS || self.bytes >= DECODE_CHUNK_BYTES {
+            self.flush(msg_tx).await?;
+        }
+        Ok(())
+    }
+
+    async fn flush(&mut self, msg_tx: &mpsc::Sender<BatcherMsg>) -> Result<(), String> {
+        if self.rows.is_empty() {
+            return Ok(());
+        }
+        self.bytes = 0;
+        msg_tx
+            .send(BatcherMsg::Rows(RowChunk {
+                rows: std::mem::take(&mut self.rows),
+                permit: None,
+            }))
+            .await
+            .map_err(|_| "bootstrap: batcher channel closed".to_string())
+    }
 }
 
 /// Check only columns routed to ClickHouse
-fn has_mapped_external_toast(tuple: &BackfillTuple, mapping: &TableMapping) -> bool {
-    mapping.columns.iter().any(|c| {
-        usize::try_from(c.src_attnum as i32 - 1)
-            .ok()
-            .and_then(|idx| tuple.columns.get(idx))
-            .is_some_and(|col| matches!(col, Some(ColumnValue::ExternalToast(_))))
-    })
-}
-
 /// Resolve mapped TOAST pointers or fill in disabled mode. Value cap
 /// checked before any fetch; the returned leaf permit is shrunk to the
 /// retained decoded bytes and rides the routed row to insert ack
@@ -337,6 +369,21 @@ fn row_from_columns(mut tuple: BackfillTuple, toast_relid: u32) -> Option<ToastR
 
 #[cfg(test)]
 mod tests {
+    /// Flatten the drain's coalesced `Rows` chunks back to a row list
+    async fn collect_rows(rx: &mut mpsc::Receiver<BatcherMsg>) -> Vec<RoutedRow> {
+        let mut rows = Vec::new();
+        while let Some(msg) = rx.recv().await {
+            match msg {
+                BatcherMsg::Rows(chunk) => rows.extend(chunk.rows),
+                BatcherMsg::Row(r) => rows.push(r),
+                BatcherMsg::FlushAll(reply) => {
+                    let _ = reply.send(());
+                }
+            }
+        }
+        rows
+    }
+
     use super::*;
     use crate::backfill::spool::DEFERRED_SPOOL_MEM_MAX;
     use crate::mapping::{ColumnMapping, TableMapping, TableTarget};
@@ -530,6 +577,41 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn repaired_input_rejects_external_pointers() {
+        let mut catalog = CatalogMap::new();
+        catalog.insert(rel(16400));
+        let mapping = Arc::new(
+            [(RelName::new("public", "t16400"), mapping_for(16400))]
+                .into_iter()
+                .collect(),
+        );
+        let (ack, collector) = ack::spawn(Arc::new(crate::pos::Monotone::new(0)));
+        let (msg_tx, _msg_rx) = mpsc::channel(1);
+        let (tx, rx) = mpsc::channel(1);
+        tx.send(vec![bytea_toast_tuple(16400, 16401, 7)])
+            .await
+            .unwrap();
+        drop(tx);
+        let err = drain(
+            rx,
+            catalog,
+            mapping,
+            msg_tx,
+            ack,
+            Arc::new(EmitterStats::default()),
+            ToastResolver::disabled(),
+            None,
+            Default::default(),
+            None,
+            HashSet::new(),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("unrepaired external value"), "{err}");
+        collector.await.unwrap();
+    }
+
     /// Two rels, contiguous rows each: one seq per rfn, every row routed,
     /// each seq placed with its exact count.
     #[tokio::test]
@@ -540,18 +622,18 @@ mod tests {
         let mut tables = HashMap::new();
         tables.insert(RelName::new("public", "t16400"), mapping_for(16400));
         tables.insert(RelName::new("public", "t16401"), mapping_for(16401));
-        let mapping = crate::mapping::mapping_handle(tables);
+        let mapping = Arc::new(tables);
 
         let emitter_ack = Arc::new(crate::pos::Monotone::new(0));
         let (ack, collector) = ack::spawn(emitter_ack);
         let (msg_tx, mut msg_rx) = mpsc::channel::<BatcherMsg>(64);
-        let (tup_tx, tup_rx) = mpsc::channel::<BackfillTuple>(64);
+        let (tup_tx, tup_rx) = mpsc::channel::<Vec<BackfillTuple>>(64);
 
         for id in 0..3 {
-            tup_tx.send(tuple(16400, id)).await.unwrap();
+            tup_tx.send(vec![tuple(16400, id)]).await.unwrap();
         }
         for id in 0..2 {
-            tup_tx.send(tuple(16401, id)).await.unwrap();
+            tup_tx.send(vec![tuple(16401, id)]).await.unwrap();
         }
         drop(tup_tx);
 
@@ -564,14 +646,14 @@ mod tests {
             ack.clone(),
             stats.clone(),
             ToastResolver::disabled(),
-            mem_spool(),
+            Some(mem_spool()),
             Default::default(),
             None,
             HashSet::new(),
         ));
 
         let mut by_seq: HashMap<u64, u64> = HashMap::new();
-        while let Some(BatcherMsg::Row(r)) = msg_rx.recv().await {
+        for r in collect_rows(&mut msg_rx).await {
             *by_seq.entry(r.seq).or_default() += 1;
         }
         let outcome = drain_task.await.unwrap().unwrap();
@@ -595,17 +677,17 @@ mod tests {
         catalog.insert(rel(16401)); // resolvable but unmapped
         let mut tables = HashMap::new();
         tables.insert(RelName::new("public", "t16400"), mapping_for(16400));
-        let mapping = crate::mapping::mapping_handle(tables);
+        let mapping = Arc::new(tables);
 
         let emitter_ack = Arc::new(crate::pos::Monotone::new(0));
         let (ack, collector) = ack::spawn(emitter_ack);
         let (msg_tx, mut msg_rx) = mpsc::channel::<BatcherMsg>(64);
-        let (tup_tx, tup_rx) = mpsc::channel::<BackfillTuple>(64);
+        let (tup_tx, tup_rx) = mpsc::channel::<Vec<BackfillTuple>>(64);
 
         // 16400, 16401(unmapped), 16400 → seqs 0,1,2; only 0 and 2 route
-        tup_tx.send(tuple(16400, 1)).await.unwrap();
-        tup_tx.send(tuple(16401, 9)).await.unwrap();
-        tup_tx.send(tuple(16400, 2)).await.unwrap();
+        tup_tx.send(vec![tuple(16400, 1)]).await.unwrap();
+        tup_tx.send(vec![tuple(16401, 9)]).await.unwrap();
+        tup_tx.send(vec![tuple(16400, 2)]).await.unwrap();
         drop(tup_tx);
 
         let stats = Arc::new(EmitterStats::default());
@@ -617,16 +699,17 @@ mod tests {
             ack.clone(),
             stats.clone(),
             ToastResolver::disabled(),
-            mem_spool(),
+            Some(mem_spool()),
             Default::default(),
             None,
             HashSet::new(),
         ));
 
-        let mut seqs: Vec<u64> = Vec::new();
-        while let Some(BatcherMsg::Row(r)) = msg_rx.recv().await {
-            seqs.push(r.seq);
-        }
+        let seqs: Vec<u64> = collect_rows(&mut msg_rx)
+            .await
+            .iter()
+            .map(|r| r.seq)
+            .collect();
         let outcome = drain_task.await.unwrap().unwrap();
         assert_eq!(outcome.next_seq, 3, "three distinct rfn runs");
         assert_eq!(outcome.rows_routed, 2, "unmapped rel routed nothing");
@@ -644,15 +727,15 @@ mod tests {
         catalog.insert(bytea_rel(16400));
         let mut tables = HashMap::new();
         tables.insert(RelName::new("public", "t16400"), bytea_mapping_for(16400));
-        let mapping = crate::mapping::mapping_handle(tables);
+        let mapping = Arc::new(tables);
 
         let emitter_ack = Arc::new(crate::pos::Monotone::new(0));
         let (ack, collector) = ack::spawn(emitter_ack);
         let (msg_tx, mut msg_rx) = mpsc::channel::<BatcherMsg>(64);
-        let (tup_tx, tup_rx) = mpsc::channel::<BackfillTuple>(64);
+        let (tup_tx, tup_rx) = mpsc::channel::<Vec<BackfillTuple>>(64);
 
         tup_tx
-            .send(bytea_toast_tuple(16400, 16500, 1))
+            .send(vec![bytea_toast_tuple(16400, 16500, 1)])
             .await
             .unwrap();
         drop(tup_tx);
@@ -667,16 +750,13 @@ mod tests {
             ack.clone(),
             stats.clone(),
             resolver,
-            mem_spool(),
+            Some(mem_spool()),
             Default::default(),
             None,
             HashSet::new(),
         ));
 
-        let mut rows = Vec::new();
-        while let Some(BatcherMsg::Row(r)) = msg_rx.recv().await {
-            rows.push(r);
-        }
+        let rows = collect_rows(&mut msg_rx).await;
         let outcome = drain_task.await.unwrap().unwrap();
         assert_eq!(outcome.next_seq, 1);
         assert_eq!(outcome.rows_routed, 1);
@@ -703,21 +783,21 @@ mod tests {
         catalog.insert(toast_rel(16500));
         let mut tables = HashMap::new();
         tables.insert(RelName::new("public", "t16400"), bytea_mapping_for(16400));
-        let mapping = crate::mapping::mapping_handle(tables);
+        let mapping = Arc::new(tables);
 
         let emitter_ack = Arc::new(crate::pos::Monotone::new(0));
         let (ack, collector) = ack::spawn(emitter_ack);
         let (msg_tx, mut msg_rx) = mpsc::channel::<BatcherMsg>(64);
-        let (tup_tx, tup_rx) = mpsc::channel::<BackfillTuple>(64);
+        let (tup_tx, tup_rx) = mpsc::channel::<Vec<BackfillTuple>>(64);
         let spool_tmp = tempfile::tempdir().unwrap();
 
         // toast chunk first (its own zero-row seq), then the referring main row
         tup_tx
-            .send(toast_chunk_tuple(16500, 1, 0, b"hello"))
+            .send(vec![toast_chunk_tuple(16500, 1, 0, b"hello")])
             .await
             .unwrap();
         tup_tx
-            .send(bytea_toast_tuple(16400, 16500, 1))
+            .send(vec![bytea_toast_tuple(16400, 16500, 1)])
             .await
             .unwrap();
         drop(tup_tx);
@@ -733,16 +813,16 @@ mod tests {
             stats.clone(),
             ToastResolver::with_store(store, stats.clone()),
             // Threshold 0: deferred referrer rides a real spool file
-            DeferredSpool::new(spool_tmp.path().join("bootstrap_deferred.bin"), 0),
+            Some(DeferredSpool::new(
+                spool_tmp.path().join("bootstrap_deferred.bin"),
+                0,
+            )),
             Default::default(),
             None,
             HashSet::new(),
         ));
 
-        let mut rows = Vec::new();
-        while let Some(BatcherMsg::Row(r)) = msg_rx.recv().await {
-            rows.push(r);
-        }
+        let rows = collect_rows(&mut msg_rx).await;
         let outcome = drain_task.await.unwrap().unwrap();
         assert_eq!(outcome.next_seq, 3, "toast seq, main seq, deferred seq");
         assert_eq!(outcome.rows_routed, 1);
@@ -756,29 +836,28 @@ mod tests {
         collector.await.unwrap();
     }
 
-    /// SIGHUP unmapping between defer and replay: the deferred row lands
-    /// under the mapping captured at defer, not the live handle — one
-    /// relation's initial load keeps one target shape
+    /// Referrer deferred past the walk still routes under the pass's frozen
+    /// mapping — one relation's initial load keeps one target shape
     #[tokio::test]
-    async fn deferred_replay_uses_mapping_frozen_at_defer() {
+    async fn deferred_replay_routes_referrer() {
         let mut catalog = CatalogMap::new();
         catalog.insert(bytea_rel(16400));
         catalog.insert(toast_rel(16500));
         let mut tables = HashMap::new();
         tables.insert(RelName::new("public", "t16400"), bytea_mapping_for(16400));
-        let mapping = crate::mapping::mapping_handle(tables);
+        let mapping = Arc::new(tables);
 
         let emitter_ack = Arc::new(crate::pos::Monotone::new(0));
         let (ack, collector) = ack::spawn(emitter_ack);
         let (msg_tx, mut msg_rx) = mpsc::channel::<BatcherMsg>(64);
-        let (tup_tx, tup_rx) = mpsc::channel::<BackfillTuple>(64);
+        let (tup_tx, tup_rx) = mpsc::channel::<Vec<BackfillTuple>>(64);
 
         tup_tx
-            .send(toast_chunk_tuple(16500, 1, 0, b"hello"))
+            .send(vec![toast_chunk_tuple(16500, 1, 0, b"hello")])
             .await
             .unwrap();
         tup_tx
-            .send(bytea_toast_tuple(16400, 16500, 1))
+            .send(vec![bytea_toast_tuple(16400, 16500, 1)])
             .await
             .unwrap();
 
@@ -787,31 +866,21 @@ mod tests {
         let drain_task = tokio::spawn(drain(
             tup_rx,
             catalog,
-            mapping.clone(),
+            mapping,
             msg_tx,
             ack.clone(),
             stats.clone(),
             ToastResolver::with_store(store, stats.clone()),
-            mem_spool(),
+            Some(mem_spool()),
             Default::default(),
             None,
             HashSet::new(),
         ));
-        // Wait for the referrer to defer, then unmap before walk EOF
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-        while stats.bootstrap_deferred_bytes.load(Ordering::Relaxed) == 0 {
-            assert!(std::time::Instant::now() < deadline, "referrer deferred");
-            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
-        }
-        mapping.mutate(|m| Arc::make_mut(m).clear()).await;
         drop(tup_tx);
 
-        let mut rows = Vec::new();
-        while let Some(BatcherMsg::Row(r)) = msg_rx.recv().await {
-            rows.push(r);
-        }
+        let rows = collect_rows(&mut msg_rx).await;
         let outcome = drain_task.await.unwrap().unwrap();
-        assert_eq!(outcome.rows_routed, 1, "unmapping must not drop the row");
+        assert_eq!(outcome.rows_routed, 1);
         assert_eq!(rows.len(), 1);
         let cols = &rows[0].committed.decoded.new.as_ref().unwrap().columns;
         assert_eq!(cols[0], Some(ColumnValue::Bytea(b"hello".to_vec())));

--- a/src/emit/pipeline/inserter.rs
+++ b/src/emit/pipeline/inserter.rs
@@ -12,7 +12,6 @@
 //! dedups by `_lsn`). Retry-exhaustion is fatal: the watermark can't advance
 //! without this batch.
 
-use backon::Retryable;
 use clickhouse_c::{Allocator, BlockBuilder, ColumnBuilder, TypeAst};
 use tokio::task::JoinHandle;
 
@@ -21,8 +20,8 @@ use crate::config::ResolvedConfig;
 use crate::emit::ch_emitter::{ColumnBuf, EmitterConfig, EmitterStats, build_leaf, build_root};
 use crate::emit::pipeline::Fatal;
 use crate::emit::pipeline::ack::AckHandle;
-use crate::emit::pipeline::batcher::{BatchMeta, InsertBatch};
-use crate::ops::oracle::{Oracle, OracleBlock, OracleError, OracleRequestColumn};
+use crate::emit::pipeline::batcher::BatchMeta;
+use crate::emit::pipeline::resolver::ResolvedBatch;
 use crate::schema::RelName;
 use ahash::{HashMap, HashMapExt};
 use std::sync::Arc;
@@ -43,7 +42,6 @@ struct Inserter {
     /// compression are re-read at each batch boundary (a compression change
     /// reconnects, since the codec is fixed at connect).
     config_rx: Option<watch::Receiver<Arc<ResolvedConfig>>>,
-    oracle: Option<Arc<Oracle>>,
 }
 
 impl Inserter {
@@ -81,6 +79,7 @@ impl Inserter {
         bb: &BlockBuilder<'_>,
     ) -> Result<(), EmitterError> {
         let insert_timeout = self.config.insert_timeout;
+        let started = std::time::Instant::now();
         let result = self
             .client
             .retry(
@@ -105,11 +104,16 @@ impl Inserter {
         self.stats
             .reconnects
             .fetch_add(self.client.take_dials(), Ordering::Relaxed);
+        if result.is_ok() {
+            self.stats
+                .inserter_ch_nanos
+                .fetch_add(started.elapsed().as_nanos() as u64, Ordering::Relaxed);
+        }
         result
     }
 
-    async fn run(mut self, rx: async_channel::Receiver<InsertBatch>, fatal: Fatal) {
-        while let Ok(batch) = rx.recv().await {
+    async fn run(mut self, rx: async_channel::Receiver<ResolvedBatch>, fatal: Fatal) {
+        while let Ok(ResolvedBatch { batch, resolved }) = rx.recv().await {
             // Live emitter knobs (overlay active): pick up the retry budget and
             // compression. A compression change needs a fresh client — the codec
             // is fixed at connect — reconnected here at a batch boundary, never
@@ -173,19 +177,7 @@ impl Inserter {
                 .remove(&batch.meta.table_key)
                 .expect("ensure_asts inserted");
             let result = 'send: {
-                // Keep resolved block alive across every INSERT retry
-                let resolved = match resolve_oracle_with_retry(
-                    self.oracle.clone(),
-                    self.alloc,
-                    &batch,
-                    &self.config.retry,
-                    &self.stats,
-                )
-                .await
-                {
-                    Ok(v) => v,
-                    Err(e) => break 'send Err(e),
-                };
+                let encode_started = std::time::Instant::now();
                 let leaves: Vec<Option<ColumnBuilder<'_>>> = match batch
                     .buffers
                     .iter()
@@ -232,6 +224,10 @@ impl Inserter {
                                 .map_err(Into::into)
                         }
                     });
+                self.stats.inserter_encode_nanos.fetch_add(
+                    encode_started.elapsed().as_nanos() as u64,
+                    Ordering::Relaxed,
+                );
                 match appended {
                     Ok(()) => self.send_with_retry(&batch.meta.insert_sql, &bb).await,
                     Err(e) => Err(e),
@@ -259,68 +255,15 @@ impl Inserter {
     }
 }
 
-/// Retry transport failures only
-async fn resolve_oracle_with_retry(
-    oracle: Option<Arc<Oracle>>,
-    alloc: Allocator,
-    batch: &InsertBatch,
-    retry: &crate::emit::ch_emitter::RetryConfig,
-    stats: &EmitterStats,
-) -> Result<Option<OracleBlock>, EmitterError> {
-    (|| resolve_oracle(oracle.clone(), alloc, batch))
-        .retry(retry.backoff())
-        .when(OracleError::retryable)
-        .notify(|_, _| {
-            stats.retries_attempted.fetch_add(1, Ordering::Relaxed);
-        })
-        .await
-        .map_err(|e| EmitterError::Type(e.to_string()))
-}
-
-async fn resolve_oracle(
-    oracle: Option<Arc<Oracle>>,
-    alloc: Allocator,
-    batch: &InsertBatch,
-) -> Result<Option<OracleBlock>, OracleError> {
-    let columns: Vec<OracleRequestColumn<'_>> = batch
-        .buffers
-        .iter()
-        .enumerate()
-        .filter_map(|(i, buf)| match buf {
-            ColumnBuf::Oracle(o) => Some(OracleRequestColumn {
-                ordinal: i as u32,
-                name: &batch.meta.columns[i].name,
-                target_type: &batch.meta.columns[i].type_repr,
-                buf: o,
-            }),
-            _ => None,
-        })
-        .collect();
-    if columns.is_empty() {
-        return Ok(None);
-    }
-    let oracle = oracle.ok_or_else(|| {
-        OracleError::Absent(format!(
-            "{} needs the shadow oracle, which this pipeline has none of",
-            batch.meta.table_key
-        ))
-    })?;
-    oracle
-        .encode_batch(&columns, batch.n_rows, alloc)
-        .await
-        .map(Some)
-}
-
 pub(crate) struct PoolOptions {
     pub config_rx: Option<watch::Receiver<Arc<ResolvedConfig>>>,
-    pub oracle: Option<Arc<Oracle>>,
 }
 
 /// Connect `n` inserters and spawn drain loops
 pub(crate) async fn spawn_pool(
     n: usize,
     config: &EmitterConfig,
-    rx: async_channel::Receiver<InsertBatch>,
+    rx: async_channel::Receiver<ResolvedBatch>,
     ack: AckHandle,
     stats: Arc<EmitterStats>,
     fatal: Fatal,
@@ -336,7 +279,6 @@ pub(crate) async fn spawn_pool(
             ack: ack.clone(),
             stats: stats.clone(),
             config_rx: options.config_rx.clone(),
-            oracle: options.oracle.clone(),
         };
         let rx = rx.clone();
         let fatal = fatal.clone();
@@ -367,7 +309,6 @@ mod tests {
                 ack,
                 stats: stats.clone(),
                 config_rx: None,
-                oracle: None,
             };
             let ast = TypeAst::parse("UInt8", inserter.alloc).unwrap();
             let column = ColumnBuilder::fixed(&[42], 1, 1).unwrap();

--- a/src/emit/pipeline/mod.rs
+++ b/src/emit/pipeline/mod.rs
@@ -18,6 +18,7 @@ pub mod inserter;
 pub mod plan_spool;
 pub mod planner;
 pub mod reorder;
+pub mod resolver;
 pub mod tail;
 
 use std::sync::Arc;

--- a/src/emit/pipeline/resolver.rs
+++ b/src/emit/pipeline/resolver.rs
@@ -1,0 +1,357 @@
+//! Oracle resolve, off the inserters' critical path.
+//!
+//! An inserter that resolves its own batch leaves its ClickHouse connection
+//! idle for the whole round trip, and the oracle idle for the whole INSERT:
+//! throughput is `1 / (T_oracle + T_ch / P)` where it could be
+//! `1 / max(T_oracle / W, T_ch / P)`. This stage sits between batcher and
+//! inserter pool so the two overlap, `W` wide to match the bridge — that is
+//! how many requests the shadow answers at once.
+//!
+//! Costs one extra resident batch per inserter, which is what a queue deep
+//! enough to keep every inserter fed takes.
+//!
+//! A batch with no oracle column crosses unchanged, without touching the
+//! bridge.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use backon::Retryable;
+use clickhouse_c::Allocator;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+use crate::ch::EmitterError;
+use crate::config::ResolvedConfig;
+use crate::emit::ch_emitter::{ColumnBuf, EmitterStats, RetryConfig, literal_column};
+use crate::emit::pipeline::Fatal;
+use crate::emit::pipeline::batcher::InsertBatch;
+use crate::ops::oracle::{Oracle, OracleBlock, OracleError, OracleRequestColumn};
+
+pub(crate) struct ResolvedBatch {
+    pub batch: InsertBatch,
+    pub resolved: Option<OracleBlock>,
+}
+
+/// `None` oracle resolves nothing, which a pipeline with no oracle column
+/// and a pipeline that has one but no shadow both look like; the second
+/// fails at its first oracle batch
+#[derive(Clone)]
+pub(crate) struct ResolverOptions {
+    pub oracle: Option<Arc<Oracle>>,
+    /// Boot budget for oracle transport retries, re-read from `config_rx`
+    pub retry: RetryConfig,
+    pub stats: Arc<EmitterStats>,
+    pub fatal: Fatal,
+    pub config_rx: Option<watch::Receiver<Arc<ResolvedConfig>>>,
+}
+
+/// Spawn `n` resolvers over the shared batch queue. Drops the sender it was
+/// handed, so the inserters' queue closes once every resolver exits
+pub(crate) fn spawn_pool(
+    n: usize,
+    rx: async_channel::Receiver<InsertBatch>,
+    tx: async_channel::Sender<ResolvedBatch>,
+    opts: ResolverOptions,
+) -> Vec<JoinHandle<()>> {
+    (0..n.max(1))
+        .map(|_| tokio::spawn(run(rx.clone(), tx.clone(), opts.clone())))
+        .collect()
+}
+
+async fn run(
+    rx: async_channel::Receiver<InsertBatch>,
+    tx: async_channel::Sender<ResolvedBatch>,
+    opts: ResolverOptions,
+) {
+    let ResolverOptions {
+        oracle,
+        mut retry,
+        stats,
+        fatal,
+        config_rx,
+    } = opts;
+    let alloc = Allocator::global(&mimalloc::MiMalloc);
+    while let Ok(mut batch) = rx.recv().await {
+        if let Some(rx) = config_rx.as_ref() {
+            retry.max_attempts = rx.borrow().retry_max_attempts;
+        }
+        resolve_local_columns(&mut batch, &stats);
+        let started = std::time::Instant::now();
+        let resolved = match resolve_oracle_with_retry(&oracle, alloc, &batch, &retry, &stats).await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                // Seq stays unacknowledged, so a restart replays it
+                fatal.set(format!("oracle resolve: {e}"));
+                return;
+            }
+        };
+        stats
+            .oracle_resolve_nanos
+            .fetch_add(started.elapsed().as_nanos() as u64, Ordering::Relaxed);
+        if tx.send(ResolvedBatch { batch, resolved }).await.is_err() {
+            return;
+        }
+    }
+}
+
+fn resolve_local_columns(batch: &mut InsertBatch, stats: &EmitterStats) {
+    let mut n = 0;
+    for (buf, column) in batch.buffers.iter_mut().zip(&batch.meta.columns) {
+        if let ColumnBuf::Oracle(o) = buf
+            && let Some(local) = literal_column(o, &column.type_repr, batch.n_rows)
+        {
+            *buf = local;
+            n += 1;
+        }
+    }
+    if n > 0 {
+        stats.oracle_local_columns.fetch_add(n, Ordering::Relaxed);
+    }
+}
+
+/// Retry transport failures only
+async fn resolve_oracle_with_retry(
+    oracle: &Option<Arc<Oracle>>,
+    alloc: Allocator,
+    batch: &InsertBatch,
+    retry: &RetryConfig,
+    stats: &EmitterStats,
+) -> Result<Option<OracleBlock>, EmitterError> {
+    (|| resolve_oracle(oracle, alloc, batch))
+        .retry(retry.backoff())
+        .when(OracleError::retryable)
+        .notify(|_, _| {
+            stats.retries_attempted.fetch_add(1, Ordering::Relaxed);
+        })
+        .await
+        .map_err(|e| EmitterError::Type(e.to_string()))
+}
+
+async fn resolve_oracle(
+    oracle: &Option<Arc<Oracle>>,
+    alloc: Allocator,
+    batch: &InsertBatch,
+) -> Result<Option<OracleBlock>, OracleError> {
+    let columns: Vec<OracleRequestColumn<'_>> = batch
+        .buffers
+        .iter()
+        .enumerate()
+        .filter_map(|(i, buf)| match buf {
+            ColumnBuf::Oracle(o) => Some(OracleRequestColumn {
+                ordinal: i as u32,
+                name: &batch.meta.columns[i].name,
+                target_type: &batch.meta.columns[i].type_repr,
+                buf: o,
+            }),
+            _ => None,
+        })
+        .collect();
+    if columns.is_empty() {
+        return Ok(None);
+    }
+    let oracle = oracle.as_ref().ok_or_else(|| {
+        OracleError::Absent(format!(
+            "{} needs the shadow oracle, which this pipeline has none of",
+            batch.meta.table_key
+        ))
+    })?;
+    oracle
+        .encode_batch(&columns, batch.n_rows, alloc)
+        .await
+        .map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decode::heap_decoder::{
+        ColumnValue, CommittedTuple, DecodedHeap, DecodedTuple, HeapOp,
+    };
+    use crate::emit::pipeline::batcher::{BatcherConfig, BatcherMsg, RoutedRow};
+    use crate::emit::route::RouteSnapshot;
+    use crate::mapping::{ColumnMapping, TableMapping, TableTarget};
+    use crate::schema::{RelAttr, RelDescriptor, RelName, ReplIdent};
+    use std::time::Duration;
+    use tokio::sync::{mpsc, oneshot};
+    use walrus::pg::walparser::RelFileNode;
+
+    /// An oracle-routed column the local matrix does not cover, rendered by
+    /// the daemon: the shape a PostGIS 2-D point takes
+    const GEOM_OID: u32 = 999_999;
+
+    fn wkt_row(seq: u64, text: Option<&str>) -> RoutedRow {
+        let rel = Arc::new(RelDescriptor {
+            rfn: RelFileNode {
+                spc_node: 1663,
+                db_node: 5,
+                rel_node: 16385,
+            },
+            oid: 16385,
+            toast_oid: 0,
+            namespace_oid: 2200,
+            rel_name: RelName::new("public", "g"),
+            kind: 'r',
+            persistence: 'p',
+            replident: ReplIdent::Default { pk_attnums: None },
+            attributes: vec![RelAttr {
+                attnum: 1,
+                name: "geom".into(),
+                type_oid: GEOM_OID,
+                typmod: -1,
+                not_null: false,
+                dropped: false,
+                type_name: "geometry".into(),
+                type_byval: false,
+                type_len: -1,
+                type_align: 'i',
+                type_storage: 'x',
+                missing_default: None,
+            }],
+        });
+        let route = RouteSnapshot::freeze(
+            Arc::new(TableMapping {
+                target: TableTarget::new("default", "g"),
+                columns: vec![ColumnMapping {
+                    src_attnum: 1,
+                    target_name: "geom".into(),
+                    target_type: "Nullable(String)".into(),
+                }],
+            }),
+            Arc::default(),
+            Default::default(),
+        );
+        RoutedRow {
+            seq,
+            rel,
+            route,
+            committed: CommittedTuple {
+                decoded: DecodedHeap {
+                    rfn: RelFileNode {
+                        spc_node: 1663,
+                        db_node: 5,
+                        rel_node: 16385,
+                    },
+                    xid: 7,
+                    source_lsn: 0x1000 + seq,
+                    op: HeapOp::Insert,
+                    new: Some(DecodedTuple {
+                        columns: vec![text.map(|t| ColumnValue::Text(t.into()))],
+                        partial: false,
+                    }),
+                    old: None,
+                },
+                commit_ts: 0,
+                commit_lsn: (seq + 1) * 100,
+            },
+            value_permit: None,
+        }
+    }
+
+    /// One batch of the rows, sealed through the real batcher: `InsertBatch`
+    /// is only reachable that way, and its cell tags are what the encoder
+    /// chose rather than what a test asserted
+    async fn seal(rows: Vec<RoutedRow>) -> InsertBatch {
+        let (msg_tx, msg_rx) = mpsc::channel(64);
+        let (batches_tx, batches_rx) = async_channel::bounded(64);
+        let fatal = Fatal::new();
+        let handle = crate::emit::pipeline::batcher::spawn(
+            msg_rx,
+            batches_tx,
+            BatcherConfig {
+                row_budget: 1_000,
+                byte_budget: 1 << 30,
+                flush_timeout: Duration::from_secs(3600),
+            },
+            Allocator::stdlib(),
+            fatal.clone(),
+            Arc::new(EmitterStats::default()),
+            None,
+        );
+        for r in rows {
+            msg_tx.send(BatcherMsg::Row(r)).await.expect("send row");
+        }
+        let (reply_tx, reply_rx) = oneshot::channel();
+        msg_tx
+            .send(BatcherMsg::FlushAll(reply_tx))
+            .await
+            .expect("send flush");
+        reply_rx.await.expect("flush ack");
+        let batch = batches_rx.recv().await.expect("one batch");
+        drop(msg_tx);
+        handle.await.expect("batcher task");
+        assert!(fatal.message().is_none());
+        batch
+    }
+
+    /// Cells the daemon rendered against a `String` target never reach the
+    /// bridge: the same batch resolves with no oracle at all, and fails
+    /// without the local path
+    #[tokio::test]
+    async fn rendered_cells_against_a_string_target_stay_local() {
+        let mut batch = seal(vec![
+            wkt_row(0, Some("POINT(1 2)")),
+            wkt_row(0, None),
+            wkt_row(0, Some("")),
+            wkt_row(0, Some("POINT(3 4)")),
+        ])
+        .await;
+        assert!(
+            matches!(batch.buffers[0], ColumnBuf::Oracle(_)),
+            "premise: an uncovered source type routes to the oracle",
+        );
+
+        let alloc = Allocator::stdlib();
+        assert!(matches!(
+            resolve_oracle(&None, alloc, &batch).await,
+            Err(OracleError::Absent(_)),
+        ));
+        let stats = EmitterStats::default();
+        resolve_local_columns(&mut batch, &stats);
+        assert_eq!(stats.oracle_local_columns.load(Ordering::Relaxed), 1);
+        let ColumnBuf::NullableString {
+            offsets,
+            data,
+            null_map,
+        } = &batch.buffers[0]
+        else {
+            panic!("column not built locally: {:?}", batch.buffers[0]);
+        };
+        assert_eq!(data, b"POINT(1 2)POINT(3 4)");
+        assert_eq!(offsets, &[10, 10, 10, 20]);
+        assert_eq!(null_map, &[0, 1, 0, 0]);
+
+        assert!(
+            resolve_oracle(&None, alloc, &batch)
+                .await
+                .expect("no request to make")
+                .is_none(),
+        );
+        resolve_local_columns(&mut batch, &stats);
+        assert_eq!(stats.oracle_local_columns.load(Ordering::Relaxed), 1);
+    }
+
+    /// A cell PG must convert keeps the whole column in the request, even
+    /// when its neighbours are rendered
+    #[tokio::test]
+    async fn one_unrendered_cell_keeps_the_column_remote() {
+        let mut rows = vec![wkt_row(0, Some("POINT(1 2)"))];
+        let mut raw = wkt_row(0, None);
+        raw.committed.decoded.new.as_mut().unwrap().columns[0] = Some(ColumnValue::Unsupported {
+            type_oid: GEOM_OID,
+            raw: vec![1, 2, 3],
+        });
+        rows.push(raw);
+        let mut batch = seal(rows).await;
+
+        let stats = EmitterStats::default();
+        resolve_local_columns(&mut batch, &stats);
+        assert!(matches!(batch.buffers[0], ColumnBuf::Oracle(_)));
+        assert_eq!(stats.oracle_local_columns.load(Ordering::Relaxed), 0);
+        assert!(matches!(
+            resolve_oracle(&None, Allocator::stdlib(), &batch).await,
+            Err(OracleError::Absent(_)),
+        ));
+    }
+}

--- a/src/emit/pipeline/tail.rs
+++ b/src/emit/pipeline/tail.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use clickhouse_c::Allocator;
 use tokio::sync::{mpsc, oneshot, watch};
-use tokio::task::JoinHandle;
+use tokio_util::task::AbortOnDropHandle;
 
 use crate::ch::EmitterError;
 use crate::config::ResolvedConfig;
@@ -23,15 +23,17 @@ use crate::emit::ch_emitter::{EmitterConfig, EmitterStats};
 use crate::emit::pipeline::ack::{self, AckHandle};
 use crate::emit::pipeline::batcher::{self, BatcherConfig, BatcherMsg, InsertBatch};
 use crate::emit::pipeline::inserter;
+use crate::emit::pipeline::resolver::{self, ResolvedBatch};
 use crate::emit::pipeline::{DEFAULT_PIPELINE_FLUSH, Fatal};
 use crate::pos::{EmitterAck, Monotone};
 use ahash::{HashMap, HashMapExt};
 
 /// Spawned tail stages; holding this keeps the tasks owned by the caller.
 pub struct TailParts {
-    collector: JoinHandle<()>,
-    batcher: JoinHandle<()>,
-    inserters: Vec<JoinHandle<()>>,
+    collector: AbortOnDropHandle<()>,
+    batcher: AbortOnDropHandle<()>,
+    resolvers: Vec<AbortOnDropHandle<()>>,
+    inserters: Vec<AbortOnDropHandle<()>>,
 }
 
 impl TailParts {
@@ -40,6 +42,9 @@ impl TailParts {
     /// channel close and this hangs.
     pub async fn join(self) {
         let _ = self.batcher.await;
+        for h in self.resolvers {
+            let _ = h.await;
+        }
         for h in self.inserters {
             let _ = h.await;
         }
@@ -102,8 +107,6 @@ pub struct OwnedTail {
 }
 
 impl OwnedTail {
-    /// Bounded legs pass `inserter_pool_size = 1`: they replay serially, and
-    /// the batcher's queue already overlaps insert with decode
     pub async fn spawn(
         emitter: &EmitterConfig,
         inserter_pool_size: usize,
@@ -185,6 +188,7 @@ pub fn spawn_null(
     emitter_ack: Arc<Monotone<EmitterAck>>,
 ) -> (mpsc::Sender<BatcherMsg>, AckHandle, TailParts) {
     let (ack, collector) = ack::spawn(emitter_ack);
+    let collector = AbortOnDropHandle::new(collector);
     let (msg_tx, mut msg_rx) = mpsc::channel::<BatcherMsg>(256);
     let swallow_ack = ack.clone();
     let batcher = tokio::spawn(async move {
@@ -209,7 +213,8 @@ pub fn spawn_null(
         ack,
         TailParts {
             collector,
-            batcher,
+            batcher: AbortOnDropHandle::new(batcher),
+            resolvers: Vec::new(),
             inserters: Vec::new(),
         },
     )
@@ -230,25 +235,42 @@ pub async fn spawn_with_config(
     let n = inserter_pool_size.max(1);
 
     let (ack, collector) = ack::spawn(emitter_ack);
+    let collector = AbortOnDropHandle::new(collector);
 
     // Rows and FlushAll share one FIFO channel so a flush can't overtake rows
     // enqueued before it
     let (msg_tx, msg_rx) = mpsc::channel::<BatcherMsg>(256);
     let (batches_tx, batches_rx) = async_channel::bounded::<InsertBatch>((n * 2).max(4));
+    // One resolved batch per inserter is what keeps every one of them fed
+    let (resolved_tx, resolved_rx) = async_channel::bounded::<ResolvedBatch>(n);
 
     let inserters = inserter::spawn_pool(
         n,
         emitter,
-        batches_rx,
+        resolved_rx,
         ack.clone(),
         stats.clone(),
         fatal.clone(),
         inserter::PoolOptions {
             config_rx: config_rx.clone(),
-            oracle,
         },
     )
     .await?;
+
+    // As wide as the bridge: a narrower pool leaves shadow workers idle, a
+    // wider one only queues on their sockets
+    let resolvers = resolver::spawn_pool(
+        oracle.as_ref().map_or(1, |o| o.concurrency()),
+        batches_rx,
+        resolved_tx,
+        resolver::ResolverOptions {
+            oracle,
+            retry: emitter.retry.clone(),
+            stats: stats.clone(),
+            fatal: fatal.clone(),
+            config_rx: config_rx.clone(),
+        },
+    );
 
     // Boot fallback for the batcher; the live path re-reads from `config_rx`.
     let flush_timeout = if emitter.flush_timeout.is_zero() {
@@ -275,8 +297,24 @@ pub async fn spawn_with_config(
         ack,
         TailParts {
             collector,
-            batcher,
-            inserters,
+            batcher: AbortOnDropHandle::new(batcher),
+            resolvers: resolvers.into_iter().map(AbortOnDropHandle::new).collect(),
+            inserters: inserters.into_iter().map(AbortOnDropHandle::new).collect(),
         },
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn dropped_tail_closes_workers_with_live_producers() {
+        let (tx, ack, parts) = spawn_null(Arc::new(Monotone::new(0)));
+        drop(parts);
+        tokio::time::timeout(std::time::Duration::from_secs(1), tx.closed())
+            .await
+            .unwrap();
+        drop(ack);
+    }
 }

--- a/src/ops/bridge.rs
+++ b/src/ops/bridge.rs
@@ -10,7 +10,7 @@
 
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -27,11 +27,17 @@ pub const PROJECTION_VERSION: u32 = 1;
 
 /// Match `WS_MAX_REQUEST_BYTES`
 pub const MAX_REQUEST_BYTES: usize = 256 * 1024 * 1024;
+/// `len: u32be` then `op: u8`. Request builders reserve this much leading
+/// room so the bridge patches the prefix in place and one `write_all` ships
+/// the frame, rather than reallocating and copying the whole payload
+pub const FRAME_PREFIX_BYTES: usize = 5;
 /// Whole-catalog `pg_type` text output is the largest response in practice
 const MAX_RESPONSE_BYTES: usize = 256 * 1024 * 1024;
 /// Matches `WS_MAX_SCAN_OIDS`. A longer list is the caller's to chunk, since
 /// only the caller knows whether the chunks share a replay position
 pub const MAX_SCAN_OIDS: usize = 65536;
+/// Matches `WS_MAX_WORKERS`, the ceiling on `walshadow.bridge_workers`
+pub const MAX_BRIDGE_WORKERS: usize = 8;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
@@ -49,6 +55,13 @@ impl Op {
     /// Index into the per-op stat arrays, parallel to [`OP_LABELS`]
     fn slot(self) -> usize {
         self as usize - 1
+    }
+
+    /// Catalog reads pin to worker 0. `SCAN` answers off a replay position
+    /// it reports back, and `HELLO` establishes the identity every other
+    /// worker is then checked against, so neither may drift between sockets
+    fn pinned(self) -> bool {
+        matches!(self, Op::Hello | Op::Scan)
     }
 }
 
@@ -132,13 +145,74 @@ pub struct Hello {
     pub in_recovery: bool,
 }
 
-/// Own response frame backing borrowed Native block
-#[derive(Clone, Debug)]
-pub struct NativeResponse {
-    frame: Vec<u8>,
+/// Response body a worker answered with, on loan from the bridge's pool.
+/// Parsers borrow it, then it goes back on drop
+#[derive(Debug)]
+pub struct Response<'a> {
+    body: Vec<u8>,
+    len: usize,
+    pool: &'a BufPool,
 }
 
-impl NativeResponse {
+impl std::ops::Deref for Response<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.body[..self.len]
+    }
+}
+
+impl Drop for Response<'_> {
+    fn drop(&mut self) {
+        self.pool.give(std::mem::take(&mut self.body));
+    }
+}
+
+/// Response bodies return here instead of to the allocator. A 32 MiB
+/// `ENCODE_NATIVE` answer otherwise costs a fresh mapping plus a full zeroing
+/// pass per batch, and the daemon asks for one such answer per sealed block.
+/// A pooled body keeps its length, so only the bytes a longer answer adds
+/// ever get zeroed
+#[derive(Debug)]
+struct BufPool {
+    free: std::sync::Mutex<Vec<Vec<u8>>>,
+    /// One body per worker in flight, so a deeper free list only holds
+    /// peak-sized allocations nothing is going to claim
+    cap: usize,
+}
+
+impl BufPool {
+    fn new(cap: usize) -> Self {
+        Self {
+            free: std::sync::Mutex::new(Vec::new()),
+            cap,
+        }
+    }
+
+    fn take(&self) -> Vec<u8> {
+        self.lock().pop().unwrap_or_default()
+    }
+
+    fn give(&self, buf: Vec<u8>) {
+        let mut free = self.lock();
+        if free.len() < self.cap {
+            free.push(buf);
+        }
+    }
+
+    /// Held across `pop`/`push` only, so a panicking caller cannot poison it
+    fn lock(&self) -> std::sync::MutexGuard<'_, Vec<Vec<u8>>> {
+        self.free.lock().expect("bridge response pool")
+    }
+}
+
+/// Native block, borrowed out of the response body it arrived in
+#[derive(Debug)]
+pub struct NativeResponse<'a> {
+    frame: Response<'a>,
+}
+
+impl NativeResponse<'_> {
     pub fn bytes(&self) -> &[u8] {
         &self.frame[1..]
     }
@@ -170,10 +244,20 @@ crate::atomic_stats! {
         /// reads answer these off SQL instead; overlay reads fail
         pub scan_replay_moved,
         pub native_bytes,
+        /// Bridge sockets the pool holds, one per shadow-side worker
+        pub pool_size,
         /// Per-op, indexed by [`OP_LABELS`]
         pub requests: [AtomicU64; OP_COUNT],
         pub errors: [AtomicU64; OP_COUNT],
         pub request_nanos: [AtomicU64; OP_COUNT],
+        /// Queued behind another caller's request on the one socket. Against
+        /// `service_nanos` this is what says whether the worker is the
+        /// limiter or the funnel in front of it is
+        pub lock_wait_nanos: [AtomicU64; OP_COUNT],
+        /// Wire time with the socket held: worker conversion plus transfer
+        pub service_nanos: [AtomicU64; OP_COUNT],
+        pub request_bytes: [AtomicU64; OP_COUNT],
+        pub response_bytes: [AtomicU64; OP_COUNT],
     }
 }
 
@@ -203,12 +287,25 @@ impl BridgeStats {
     }
 }
 
+/// One shadow-side worker's socket. A worker serves one request at a time,
+/// so the mutex is the worker, not an artefact of sharing
 #[derive(Debug)]
-pub struct Bridge {
+struct Slot {
     path: PathBuf,
     conn: Mutex<Option<UnixStream>>,
-    /// Set by the first successful `HELLO`; later dials must match it
+}
+
+#[derive(Debug)]
+pub struct Bridge {
+    /// Slot 0 is `walshadow.socket_path`, slot `i` is `socket_path.i`.
+    /// Stateless ops round-robin; [`Op::pinned`] ops stay on slot 0
+    slots: Vec<Slot>,
+    next: AtomicUsize,
+    /// Set by the first successful `HELLO`; later dials, on any slot, must
+    /// match it. A worker that came back a different build means a mixed
+    /// install and must fail closed
     info: OnceLock<Hello>,
+    bufs: BufPool,
     pub stats: Arc<BridgeStats>,
 }
 
@@ -217,19 +314,55 @@ impl Bridge {
     /// mismatch is refused rather than negotiated: the daemon would misparse
     /// the projections
     pub async fn connect(path: impl AsRef<Path>) -> Result<Self, BridgeError> {
+        Self::connect_pooled(path, 1).await
+    }
+
+    /// One socket per shadow-side worker, matching
+    /// `walshadow.bridge_workers`. Every slot must answer: a pool short of
+    /// the configured width is a half-started shadow, and silently running
+    /// narrower would hide it
+    pub async fn connect_pooled(
+        path: impl AsRef<Path>,
+        workers: usize,
+    ) -> Result<Self, BridgeError> {
+        let base = path.as_ref();
+        let slots: Vec<Slot> = (0..workers.clamp(1, MAX_BRIDGE_WORKERS))
+            .map(|i| Slot {
+                path: if i == 0 {
+                    base.to_owned()
+                } else {
+                    PathBuf::from(format!("{}.{i}", base.display()))
+                },
+                conn: Mutex::new(None),
+            })
+            .collect();
         let bridge = Self {
-            path: path.as_ref().to_owned(),
-            conn: Mutex::new(None),
+            bufs: BufPool::new(slots.len()),
+            slots,
+            next: AtomicUsize::new(0),
             info: OnceLock::new(),
             stats: Arc::new(BridgeStats::default()),
         };
-        let stream = bridge.dial().await?;
-        *bridge.conn.lock().await = Some(stream);
+        // Slot 0 first, so its HELLO is the identity the rest are checked
+        // against rather than whichever worker happened to answer first
+        for slot in &bridge.slots {
+            let stream = bridge.dial(slot).await?;
+            *slot.conn.lock().await = Some(stream);
+        }
+        bridge
+            .stats
+            .pool_size
+            .store(bridge.slots.len() as u64, Ordering::Relaxed);
         Ok(bridge)
     }
 
+    /// `walshadow.socket_path`, ie slot 0
     pub fn path(&self) -> &Path {
-        &self.path
+        &self.slots[0].path
+    }
+
+    pub fn pool_size(&self) -> usize {
+        self.slots.len()
     }
 
     /// `None` before the first successful `HELLO`, which [`connect`](Self::connect)
@@ -244,13 +377,14 @@ impl Bridge {
 
     /// `pg_last_wal_replay_lsn` by shared-memory read, one round trip
     pub async fn replay_lsn(&self) -> Result<u64, BridgeError> {
-        let body = self.call(Op::ReplayLsn, &[]).await?;
+        let body = self.call(Op::ReplayLsn, request_frame(0)).await?;
         Cursor::at(&body, 1).u64()
     }
 
-    /// Return response remainder as one locally framed Native block
-    pub async fn encode_native(&self, payload: &[u8]) -> Result<NativeResponse, BridgeError> {
-        let frame = self.call(Op::EncodeNative, payload).await?;
+    /// Return response remainder as one locally framed Native block.
+    /// `frame` carries [`FRAME_PREFIX_BYTES`] of unwritten leading room
+    pub async fn encode_native(&self, frame: Vec<u8>) -> Result<NativeResponse<'_>, BridgeError> {
+        let frame = self.call(Op::EncodeNative, frame).await?;
         self.stats
             .native_bytes
             .fetch_add((frame.len() - 1) as u64, Ordering::Relaxed);
@@ -288,16 +422,16 @@ impl Bridge {
         oids: &[u32],
         boundary: u64,
     ) -> Result<ScanResult, BridgeError> {
-        let mut payload = Vec::with_capacity(17 + oids.len() * 4);
-        payload.push(cat as u8);
-        payload.extend_from_slice(&top_xid.to_be_bytes());
-        payload.extend_from_slice(&boundary.to_be_bytes());
-        payload.extend_from_slice(&(oids.len() as u32).to_be_bytes());
+        let mut frame = request_frame(17 + oids.len() * 4);
+        frame.push(cat as u8);
+        frame.extend_from_slice(&top_xid.to_be_bytes());
+        frame.extend_from_slice(&boundary.to_be_bytes());
+        frame.extend_from_slice(&(oids.len() as u32).to_be_bytes());
         for oid in oids {
-            payload.extend_from_slice(&oid.to_be_bytes());
+            frame.extend_from_slice(&oid.to_be_bytes());
         }
 
-        let body = self.call(Op::Scan, &payload).await?;
+        let body = self.call(Op::Scan, frame).await?;
         let mut c = Cursor::at(&body, 1);
         let replay_lsn_start = c.u64()?;
         let replay_lsn_end = c.u64()?;
@@ -387,14 +521,18 @@ impl Bridge {
 
     /// Fresh socket plus `HELLO`. Takes no connection lock, so
     /// [`call`](Self::call) may hold one across it
-    async fn dial(&self) -> Result<UnixStream, BridgeError> {
-        let mut stream = UnixStream::connect(&self.path).await?;
+    async fn dial(&self, slot: &Slot) -> Result<UnixStream, BridgeError> {
+        let mut stream = UnixStream::connect(&slot.path).await?;
+        widen_sockbufs(&stream);
         let started = Instant::now();
-        let res = round_trip(&mut stream, Op::Hello, &[]).await;
+        let mut hello = request_frame(0);
+        patch_frame(&mut hello, Op::Hello);
+        let mut body = Vec::new();
+        let res = round_trip(&mut stream, &hello, &mut body).await;
         self.record(Op::Hello, started, &res);
-        let body = res?;
+        let len = res?;
 
-        let mut c = Cursor::at(&body, 1);
+        let mut c = Cursor::at(&body[..len], 1);
         let info = Hello {
             proto: c.u32()?,
             projection: c.u32()?,
@@ -420,11 +558,13 @@ impl Bridge {
         Ok(stream)
     }
 
-    async fn call(&self, op: Op, payload: &[u8]) -> Result<Vec<u8>, BridgeError> {
+    /// `frame` carries [`FRAME_PREFIX_BYTES`] of unwritten leading room,
+    /// patched here rather than copied into a second buffer
+    async fn call(&self, op: Op, mut frame: Vec<u8>) -> Result<Response<'_>, BridgeError> {
         let started = Instant::now();
         // Refuse before the socket sees it: the worker answers a frame this
         // size by closing, and a healthy connection must not pay for that
-        let len = payload.len() + 1;
+        let len = frame.len() - FRAME_PREFIX_BYTES + 1;
         if len > MAX_REQUEST_BYTES {
             let res = Err(BridgeError::RequestTooLarge {
                 len,
@@ -433,9 +573,19 @@ impl Bridge {
             self.record(op, started, &res);
             return res;
         }
-        let mut guard = self.conn.lock().await;
+        patch_frame(&mut frame, op);
+        let stat = op.slot();
+        self.stats.request_bytes[stat].fetch_add(frame.len() as u64, Ordering::Relaxed);
+        let slot = self.pick(op);
+        let mut body = self.bufs.take();
+        let mut guard = slot.conn.lock().await;
+        let held = Instant::now();
+        self.stats.lock_wait_nanos[stat].fetch_add(
+            held.duration_since(started).as_nanos() as u64,
+            Ordering::Relaxed,
+        );
         let mut res = match guard.as_mut() {
-            Some(stream) => round_trip(stream, op, payload).await,
+            Some(stream) => round_trip(stream, &frame, &mut body).await,
             None => Err(BridgeError::Io(io::Error::new(
                 io::ErrorKind::NotConnected,
                 "bridge disconnected",
@@ -446,9 +596,9 @@ impl Bridge {
         if is_transport_error(&res) {
             *guard = None;
             self.stats.reconnects.fetch_add(1, Ordering::Relaxed);
-            match self.dial().await {
+            match self.dial(slot).await {
                 Ok(mut stream) => {
-                    res = round_trip(&mut stream, op, payload).await;
+                    res = round_trip(&mut stream, &frame, &mut body).await;
                     if !is_transport_error(&res) {
                         *guard = Some(stream);
                     }
@@ -457,11 +607,37 @@ impl Bridge {
             }
         }
         drop(guard);
+        self.stats.service_nanos[stat]
+            .fetch_add(held.elapsed().as_nanos() as u64, Ordering::Relaxed);
+        if let Ok(len) = &res {
+            self.stats.response_bytes[stat].fetch_add(*len as u64, Ordering::Relaxed);
+        }
         self.record(op, started, &res);
-        res
+        match res {
+            Ok(len) => Ok(Response {
+                body,
+                len,
+                pool: &self.bufs,
+            }),
+            Err(e) => {
+                self.bufs.give(body);
+                Err(e)
+            }
+        }
     }
 
-    fn record(&self, op: Op, started: Instant, res: &Result<Vec<u8>, BridgeError>) {
+    /// Round-robin over the pool, except for ops pinned to worker 0.
+    /// `ENCODE_NATIVE` is stateless and read-only, so any worker answers any
+    /// request
+    fn pick(&self, op: Op) -> &Slot {
+        if op.pinned() || self.slots.len() == 1 {
+            return &self.slots[0];
+        }
+        let i = self.next.fetch_add(1, Ordering::Relaxed) % self.slots.len();
+        &self.slots[i]
+    }
+
+    fn record<T>(&self, op: Op, started: Instant, res: &Result<T, BridgeError>) {
         let slot = op.slot();
         self.stats.requests[slot].fetch_add(1, Ordering::Relaxed);
         self.stats.request_nanos[slot]
@@ -479,23 +655,60 @@ impl Bridge {
     }
 }
 
-fn is_transport_error(res: &Result<Vec<u8>, BridgeError>) -> bool {
+fn is_transport_error<T>(res: &Result<T, BridgeError>) -> bool {
     matches!(res, Err(e) if e.is_transport())
 }
 
+/// Matches `WS_SOCKBUF_BYTES` in `pgext/worker.c`. A multi-megabyte frame
+/// against default socket buffers costs hundreds of `EAGAIN` round trips
+/// on each side, so both ends ask for a wide window
+const SOCKBUF_BYTES: libc::c_int = 4 * 1024 * 1024;
+
+/// Advisory: a kernel that refuses leaves the default, which only costs
+/// more wakeups. The worker widens its own end on accept
+fn widen_sockbufs(stream: &UnixStream) {
+    use std::os::fd::AsRawFd;
+    let fd = stream.as_raw_fd();
+    let want = SOCKBUF_BYTES;
+    for opt in [libc::SO_RCVBUF, libc::SO_SNDBUF] {
+        // SAFETY: `fd` is owned by `stream` and outlives the call; `want` is
+        // a live `c_int` of the length passed
+        unsafe {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                opt,
+                (&raw const want).cast(),
+                std::mem::size_of_val(&want) as libc::socklen_t,
+            );
+        }
+    }
+}
+
+/// Leading room for the length + opcode prefix, unwritten until the bridge
+/// knows both
+pub fn request_frame(payload_capacity: usize) -> Vec<u8> {
+    let mut v = Vec::with_capacity(FRAME_PREFIX_BYTES + payload_capacity);
+    v.resize(FRAME_PREFIX_BYTES, 0);
+    v
+}
+
+fn patch_frame(frame: &mut [u8], op: Op) {
+    let len = (frame.len() - FRAME_PREFIX_BYTES + 1) as u32;
+    frame[..4].copy_from_slice(&len.to_be_bytes());
+    frame[4] = op as u8;
+}
+
+/// One write: a peer that dribbles a partial frame is what the worker's
+/// io_timeout_ms exists to bound, and the daemon must not be that peer
+/// Answer lands in `body`, whose length is the high-water mark of every
+/// answer that buffer has carried; the returned count is this one's
 async fn round_trip(
     stream: &mut UnixStream,
-    op: Op,
-    payload: &[u8],
-) -> Result<Vec<u8>, BridgeError> {
-    let len = payload.len() + 1;
-    // One write: a peer that dribbles a partial frame is what the worker's
-    // io_timeout_ms exists to bound, and the daemon must not be that peer
-    let mut frame = Vec::with_capacity(4 + len);
-    frame.extend_from_slice(&(len as u32).to_be_bytes());
-    frame.push(op as u8);
-    frame.extend_from_slice(payload);
-    stream.write_all(&frame).await?;
+    frame: &[u8],
+    body: &mut Vec<u8>,
+) -> Result<usize, BridgeError> {
+    stream.write_all(frame).await?;
     stream.flush().await?;
 
     let mut hdr = [0u8; 4];
@@ -506,12 +719,15 @@ async fn round_trip(
             "response frame of {len} bytes"
         )));
     }
-    let mut body = vec![0u8; len];
-    stream.read_exact(&mut body).await?;
+    if body.len() < len {
+        body.resize(len, 0);
+    }
+    let body = &mut body[..len];
+    stream.read_exact(body).await?;
 
     match body[0] {
-        0 => Ok(body),
-        1 => Err(BridgeError::Remote(Cursor::at(&body, 1).lenstr()?)),
+        0 => Ok(len),
+        1 => Err(BridgeError::Remote(Cursor::at(body, 1).lenstr()?)),
         s => Err(BridgeError::Protocol(format!("response status {s}"))),
     }
 }
@@ -519,9 +735,13 @@ async fn round_trip(
 /// Connect with a wall-clock budget while shadow reaches consistency.
 /// Matches catalog's
 /// [`with_transient_retry`](crate::catalog::shadow_catalog::with_transient_retry) shape
-pub async fn connect_with_budget(path: &Path, budget: Duration) -> Result<Bridge, BridgeError> {
+pub async fn connect_with_budget(
+    path: &Path,
+    workers: usize,
+    budget: Duration,
+) -> Result<Bridge, BridgeError> {
     let deadline = tokio::time::Instant::now() + budget;
-    (|| Bridge::connect(path))
+    (|| Bridge::connect_pooled(path, workers))
         .retry(
             ExponentialBuilder::default()
                 .with_min_delay(Duration::from_millis(100))
@@ -968,12 +1188,36 @@ mod tests {
         ]);
 
         let bridge = Bridge::connect(&path).await.unwrap();
-        let out = bridge.encode_native(&[0u8; 8]).await.unwrap();
+        let mut req = request_frame(8);
+        req.extend_from_slice(&[0u8; 8]);
+        let out = bridge.encode_native(req).await.unwrap();
         assert_eq!(out.bytes(), &native[..]);
         assert_eq!(
             bridge.stats.native_bytes.load(Ordering::Relaxed),
             native.len() as u64
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pooled_body_carries_a_shorter_answer_after_a_longer_one() {
+        let long = vec![b'L'; 4096];
+        let short = vec![b'S'; 7];
+        let framed = |payload: &[u8]| {
+            let mut b = vec![0u8];
+            b.extend_from_slice(payload);
+            b
+        };
+        let (_tmp, path) = spawn_worker(vec![
+            Some(hello_body(PROTO_VERSION, PROJECTION_VERSION)),
+            Some(framed(&long)),
+            Some(framed(&short)),
+        ]);
+
+        let bridge = Bridge::connect(&path).await.unwrap();
+        for want in [&long, &short] {
+            let out = bridge.encode_native(request_frame(0)).await.unwrap();
+            assert_eq!(out.bytes(), &want[..], "answer of {} bytes", want.len());
+        }
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1062,8 +1306,9 @@ mod tests {
         let (_tmp, path) = spawn_worker(vec![Some(hello_body(PROTO_VERSION, PROJECTION_VERSION))]);
 
         let bridge = Bridge::connect(&path).await.unwrap();
-        let huge = vec![0u8; MAX_REQUEST_BYTES];
-        let err = bridge.encode_native(&huge).await.unwrap_err();
+        let mut huge = request_frame(MAX_REQUEST_BYTES);
+        huge.resize(FRAME_PREFIX_BYTES + MAX_REQUEST_BYTES, 0);
+        let err = bridge.encode_native(huge).await.unwrap_err();
         assert!(
             matches!(err, BridgeError::RequestTooLarge { .. }),
             "got {err:?}"

--- a/src/ops/metrics.rs
+++ b/src/ops/metrics.rs
@@ -78,6 +78,16 @@ pub struct MetricsSnapshot {
     pub bootstrap_deferred_bytes: u64,
     /// Encoded bytes in the bootstrap TOAST-deferred spool file
     pub bootstrap_deferred_spool_bytes: u64,
+    /// Bootstrap pump stage attribution. Live while a greenfield bootstrap
+    /// runs, then frozen at its final values for the rest of the session
+    pub bootstrap_bytes_tapped: u64,
+    pub bootstrap_pages_walked: u64,
+    pub bootstrap_tuples_emitted: u64,
+    pub bootstrap_files_walked: u64,
+    pub bootstrap_files_skipped_unmapped: u64,
+    pub bootstrap_decode_seconds: f64,
+    pub bootstrap_tap_seconds: f64,
+    pub bootstrap_channel_block_seconds: f64,
     pub spill_evictions_total: u64,
     pub xacts_committed_total: u64,
     pub xacts_aborted_total: u64,
@@ -150,8 +160,12 @@ pub struct MetricsSnapshot {
     pub insertbatch_rows_in_total: u64,
     pub insertbatch_batches_out_total: u64,
     pub inserter_batches_in_total: u64,
+    pub inserter_ch_seconds_total: f64,
+    pub inserter_encode_seconds_total: f64,
+    pub oracle_resolve_seconds_total: f64,
     pub process_cpu_seconds_total: f64,
     pub process_resident_memory_bytes: u64,
+    pub oracle_local_columns_total: u64,
     pub oracle_blocks_total: u64,
     pub oracle_rows_total: u64,
     pub oracle_cells_total: u64,
@@ -165,6 +179,12 @@ pub struct MetricsSnapshot {
     pub bridge_requests_by_op: [u64; 4],
     pub bridge_errors_by_op: [u64; 4],
     pub bridge_request_nanos_by_op: [u64; 4],
+    /// Queued behind another caller on the single bridge socket
+    pub bridge_lock_wait_nanos_by_op: [u64; 4],
+    /// Wire time with the socket held
+    pub bridge_service_nanos_by_op: [u64; 4],
+    pub bridge_request_bytes_by_op: [u64; 4],
+    pub bridge_response_bytes_by_op: [u64; 4],
     pub bridge_reconnects_total: u64,
     pub bridge_scan_rows_total: u64,
     pub bridge_scan_subtrans_mismatch_total: u64,
@@ -574,6 +594,36 @@ pub fn render(snap: &MetricsSnapshot) -> String {
             snap.bootstrap_deferred_spool_bytes,
         ),
         (
+            "walshadow_bootstrap_bytes_tapped_total",
+            "Backup body bytes the bootstrap pump handed to the page-walk sink.",
+            "counter",
+            snap.bootstrap_bytes_tapped,
+        ),
+        (
+            "walshadow_bootstrap_pages_walked_total",
+            "8 KiB heap pages the bootstrap walk framed.",
+            "counter",
+            snap.bootstrap_pages_walked,
+        ),
+        (
+            "walshadow_bootstrap_tuples_emitted_total",
+            "Live tuples the bootstrap walk decoded off backup pages.",
+            "counter",
+            snap.bootstrap_tuples_emitted,
+        ),
+        (
+            "walshadow_bootstrap_files_walked_total",
+            "User-heap segments the bootstrap walk decoded.",
+            "counter",
+            snap.bootstrap_files_walked,
+        ),
+        (
+            "walshadow_bootstrap_files_skipped_unmapped_total",
+            "User-heap segments declined at begin because no mapped relation owns them; their bytes drain unread.",
+            "counter",
+            snap.bootstrap_files_skipped_unmapped,
+        ),
+        (
             "walshadow_spill_evictions_total",
             "Total evictions in→spill since daemon start.",
             "counter",
@@ -783,6 +833,12 @@ pub fn render(snap: &MetricsSnapshot) -> String {
             "Resident set size of the walshadow process (VmRSS).",
             "gauge",
             snap.process_resident_memory_bytes,
+        ),
+        (
+            "walshadow_oracle_local_columns_total",
+            "Oracle-routed columns the daemon built itself: already-rendered cells against a String target, which PG would hand straight back.",
+            "counter",
+            snap.oracle_local_columns_total,
         ),
         (
             "walshadow_oracle_blocks_total",
@@ -1278,12 +1334,47 @@ pub fn render(snap: &MetricsSnapshot) -> String {
         for (op, v) in OP_LABELS.iter().zip(snap.bridge_errors_by_op) {
             writeln!(s, "{name}{{op=\"{op}\"}} {v}").unwrap();
         }
-        let name = "walshadow_bridge_request_seconds_total";
-        writeln!(s, "# HELP {name} Wall time spent in bridge round trips.").unwrap();
-        writeln!(s, "# TYPE {name} counter").unwrap();
-        for (op, v) in OP_LABELS.iter().zip(snap.bridge_request_nanos_by_op) {
-            let secs = v as f64 / 1e9;
-            writeln!(s, "{name}{{op=\"{op}\"}} {secs}").unwrap();
+        for (name, help, nanos) in [
+            (
+                "walshadow_bridge_request_seconds_total",
+                "Wall time spent in bridge round trips.",
+                snap.bridge_request_nanos_by_op,
+            ),
+            (
+                "walshadow_bridge_lock_wait_seconds_total",
+                "Wall time bridge callers spent queued for the socket. Against bridge_service_seconds this says whether the worker or the funnel in front of it is the limiter.",
+                snap.bridge_lock_wait_nanos_by_op,
+            ),
+            (
+                "walshadow_bridge_service_seconds_total",
+                "Wall time on the wire with the bridge socket held: worker conversion plus transfer.",
+                snap.bridge_service_nanos_by_op,
+            ),
+        ] {
+            writeln!(s, "# HELP {name} {help}").unwrap();
+            writeln!(s, "# TYPE {name} counter").unwrap();
+            for (op, v) in OP_LABELS.iter().zip(nanos) {
+                let secs = v as f64 / 1e9;
+                writeln!(s, "{name}{{op=\"{op}\"}} {secs}").unwrap();
+            }
+        }
+        for (name, help, bytes) in [
+            (
+                "walshadow_bridge_request_bytes_total",
+                "Request frame bytes written to the bridge socket.",
+                snap.bridge_request_bytes_by_op,
+            ),
+            (
+                "walshadow_bridge_response_bytes_total",
+                "Response frame bytes read back off the bridge socket.",
+                snap.bridge_response_bytes_by_op,
+            ),
+        ] {
+            writeln!(s, "# HELP {name} {help}").unwrap();
+            writeln!(s, "# TYPE {name} counter").unwrap();
+            for (op, v) in OP_LABELS.iter().zip(bytes) {
+                writeln!(s, "{name}{{op=\"{op}\"}} {v}").unwrap();
+            }
         }
     }
 
@@ -1338,6 +1429,43 @@ pub fn render(snap: &MetricsSnapshot) -> String {
     .unwrap();
     writeln!(s, "# TYPE {name} counter").unwrap();
     writeln!(s, "{name} {:.3}", snap.desc_capture_seconds_total).unwrap();
+
+    for (name, help, secs) in [
+        (
+            "walshadow_bootstrap_decode_seconds_total",
+            "Cumulative CPU inside the bootstrap page walk, tuple decode included.",
+            snap.bootstrap_decode_seconds,
+        ),
+        (
+            "walshadow_bootstrap_tap_seconds_total",
+            "Cumulative time bootstrap tap readers spent inside the sink: page framing, decode, channel send. Against bootstrap_decode_seconds this is the tap's own overhead.",
+            snap.bootstrap_tap_seconds,
+        ),
+        (
+            "walshadow_bootstrap_channel_block_seconds_total",
+            "Cumulative time the bootstrap walk spent waiting for a free tuple-channel slot, i.e. emitter drain time seen by the walk.",
+            snap.bootstrap_channel_block_seconds,
+        ),
+        (
+            "walshadow_inserter_ch_seconds_total",
+            "Cumulative inserter time inside the ClickHouse INSERT round trip. Against inserter_pool_size x uptime this is CH-side utilization.",
+            snap.inserter_ch_seconds_total,
+        ),
+        (
+            "walshadow_inserter_encode_seconds_total",
+            "Cumulative inserter time rebuilding the Native block over a batch's owned slabs.",
+            snap.inserter_encode_seconds_total,
+        ),
+        (
+            "walshadow_oracle_resolve_seconds_total",
+            "Cumulative resolver time inside the oracle round trip. Overlaps inserter_ch_seconds_total, so the larger of the two is the tail's limiter.",
+            snap.oracle_resolve_seconds_total,
+        ),
+    ] {
+        writeln!(s, "# HELP {name} {help}").unwrap();
+        writeln!(s, "# TYPE {name} counter").unwrap();
+        writeln!(s, "{name} {secs:.3}").unwrap();
+    }
 
     // Process CPU as a float counter (seconds); rate() ≈ cores in use.
     let name = "walshadow_process_cpu_seconds_total";
@@ -1470,6 +1598,37 @@ mod tests {
         }
         assert!(body.contains("walshadow_route_snapshots_total{result=\"mapped\"} 7"));
         assert!(body.contains("walshadow_route_snapshots_total{result=\"unmapped\"} 8"));
+    }
+
+    /// Bootstrap stage attribution reaches `/metrics`. `BootstrapOutcome`
+    /// counters used to stop at a log line, which is what made a slow
+    /// initial load unattributable
+    #[test]
+    fn render_exposes_bootstrap_stage_attribution() {
+        let snap = MetricsSnapshot {
+            bootstrap_bytes_tapped: 1 << 30,
+            bootstrap_pages_walked: 131_072,
+            bootstrap_files_skipped_unmapped: 297,
+            bootstrap_decode_seconds: 12.5,
+            bootstrap_channel_block_seconds: 3.25,
+            bootstrap_tap_seconds: 0.0,
+            inserter_ch_seconds_total: 41.5,
+            oracle_resolve_seconds_total: 8.25,
+            ..MetricsSnapshot::default()
+        };
+        let body = render(&snap);
+        for want in [
+            "walshadow_bootstrap_bytes_tapped_total 1073741824",
+            "walshadow_bootstrap_pages_walked_total 131072",
+            "walshadow_bootstrap_files_skipped_unmapped_total 297",
+            "walshadow_bootstrap_decode_seconds_total 12.500",
+            "walshadow_bootstrap_channel_block_seconds_total 3.250",
+            "walshadow_bootstrap_tap_seconds_total 0.000",
+            "walshadow_inserter_ch_seconds_total 41.500",
+            "walshadow_oracle_resolve_seconds_total 8.250",
+        ] {
+            assert!(body.contains(want), "missing {want}");
+        }
     }
 
     /// Prometheus rejects a family declared twice; `descriptor_ambiguous_total`

--- a/src/ops/oracle.rs
+++ b/src/ops/oracle.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use clickhouse_c::{Allocator, Block, BlockOpts, BlockReader, Column, SliceIo};
 
 use crate::decode::heap_decoder::ColumnValue;
-use crate::ops::bridge::{Bridge, BridgeError, MAX_REQUEST_BYTES};
+use crate::ops::bridge::{Bridge, BridgeError, MAX_REQUEST_BYTES, request_frame};
 use crate::schema::RelAttr;
 
 /// Cell tags, matching `WS_CELL_*` in `pgext/walshadow.h`
@@ -71,21 +71,61 @@ pub struct OracleColumnBuf {
     pub source_typmod: i32,
     cells: Vec<OracleCell>,
     wire_bytes: usize,
+    /// PostgreSQL hands a String target its literal back unchanged, so such
+    /// a column resolves in the daemon while every cell is one
+    string_target: bool,
+    /// Cells no local conversion covers. One is enough to send the whole
+    /// column, literals included
+    remote_cells: usize,
+    /// Wire cost of the literals held so far, owed to the request estimate
+    /// the moment a cell strands them
+    literal_bytes: usize,
 }
 
 impl OracleColumnBuf {
-    pub fn new(source_type_oid: u32, source_typmod: i32) -> Self {
+    pub fn new(source_type_oid: u32, source_typmod: i32, target_type: &str) -> Self {
         Self {
             source_type_oid,
             source_typmod,
             cells: Vec::new(),
             wire_bytes: 0,
+            string_target: matches!(target_type, "String" | "Nullable(String)"),
+            remote_cells: 0,
+            literal_bytes: 0,
         }
     }
 
     pub fn push(&mut self, cell: OracleCell) {
-        self.wire_bytes += cell.wire_bytes();
+        let bytes = cell.wire_bytes();
+        self.wire_bytes += bytes;
+        if self.resolves_locally(&cell) {
+            self.literal_bytes += bytes;
+        } else {
+            self.remote_cells += 1;
+        }
         self.cells.push(cell);
+    }
+
+    /// Whether appending `cell` keeps the column off the request
+    pub fn resolves_locally(&self, cell: &OracleCell) -> bool {
+        self.string_target
+            && self.remote_cells == 0
+            && matches!(cell, OracleCell::Literal(_) | OracleCell::Default)
+    }
+
+    /// Literal bytes a remote cell would drag onto the request, since the
+    /// column then travels whole
+    pub fn stranded_bytes(&self) -> usize {
+        if self.remote_cells == 0 {
+            self.literal_bytes
+        } else {
+            0
+        }
+    }
+
+    /// Column carries `n_rows` cells the daemon can render itself
+    pub fn resolves_batch_locally(&self, n_rows: usize) -> bool {
+        self.string_target && self.remote_cells == 0 && self.cells.len() == n_rows
     }
 
     pub fn cells(&self) -> &[OracleCell] {
@@ -141,6 +181,18 @@ impl Oracle {
         }
     }
 
+    /// Requests the shadow answers at once, ie the bridge's pool width. One
+    /// worker serves one request per loop iteration
+    pub fn concurrency(&self) -> usize {
+        self.bridge.pool_size()
+    }
+
+    /// Round-trip cost of resolution: the request bytes and worker service
+    /// time behind [`OracleStats`]
+    pub fn bridge_stats(&self) -> Arc<crate::ops::bridge::BridgeStats> {
+        self.bridge.stats.clone()
+    }
+
     pub async fn encode_batch(
         &self,
         columns: &[OracleRequestColumn<'_>],
@@ -158,8 +210,11 @@ impl Oracle {
                 )));
             }
         }
-        let payload = encode_request(columns, n_rows);
-        let response = match self.bridge.encode_native(&payload).await {
+        let response = match self
+            .bridge
+            .encode_native(encode_request(columns, n_rows))
+            .await
+        {
             Ok(r) => r,
             Err(e) => {
                 if matches!(e, BridgeError::Remote(_)) {
@@ -201,13 +256,16 @@ pub const ORACLE_BATCH_SEAL_BYTES: usize = 32 << 20;
 
 const _: () = assert!(ORACLE_BATCH_SEAL_BYTES <= MAX_REQUEST_BYTES);
 
-/// Encode all column metadata before row-major cells
+/// Encode all column metadata before row-major cells, past the bridge's
+/// unwritten frame prefix. Seal bytes reach 32 MiB, so building into the
+/// frame rather than into a payload the bridge then copies saves one
+/// allocation and one memcpy of the whole request
 fn encode_request(columns: &[OracleRequestColumn<'_>], n_rows: usize) -> Vec<u8> {
     let size: usize = columns
         .iter()
         .map(|c| request_column_bytes(c.name, c.target_type) + c.buf.approx_size())
         .sum();
-    let mut out = Vec::with_capacity(8 + size);
+    let mut out = request_frame(8 + size);
     out.extend_from_slice(&(n_rows as u32).to_be_bytes());
     out.extend_from_slice(&(columns.len() as u32).to_be_bytes());
     for c in columns {
@@ -364,6 +422,7 @@ impl OracleStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ops::bridge::FRAME_PREFIX_BYTES;
 
     fn col<'a>(
         ordinal: u32,
@@ -381,16 +440,16 @@ mod tests {
 
     #[test]
     fn request_frames_metadata_then_row_major_cells() {
-        let mut a = OracleColumnBuf::new(1007, -1);
+        let mut a = OracleColumnBuf::new(1007, -1, "Array(Int32)");
         a.push(OracleCell::DiskRaw(vec![9, 9]));
         a.push(OracleCell::Default);
-        let mut b = OracleColumnBuf::new(3802, -1);
+        let mut b = OracleColumnBuf::new(3802, -1, "JSON");
         b.push(OracleCell::Literal(b"x".to_vec()));
         b.push(OracleCell::TextInput(b"{}".to_vec()));
         let cols = [col(0, "t", "Array(Int32)", &a), col(3, "j", "JSON", &b)];
 
         let out = encode_request(&cols, 2);
-        let mut c = 0;
+        let mut c = FRAME_PREFIX_BYTES;
         let u32_at = |c: &mut usize| {
             let v = u32::from_be_bytes(out[*c..*c + 4].try_into().unwrap());
             *c += 4;
@@ -434,12 +493,12 @@ mod tests {
 
     #[test]
     fn request_column_bytes_matches_framed_size() {
-        let mut buf = OracleColumnBuf::new(114, -1);
+        let mut buf = OracleColumnBuf::new(114, -1, "Nullable(JSON)");
         buf.push(OracleCell::Default);
         buf.push(OracleCell::DiskRaw(vec![1, 2, 3]));
         let cols = [col(7, "payload", "Nullable(JSON)", &buf)];
         assert_eq!(
-            encode_request(&cols, 2).len() + 1, // opcode the bridge prepends
+            encode_request(&cols, 2).len() + 1 - FRAME_PREFIX_BYTES,
             REQUEST_FRAME_BYTES
                 + request_column_bytes("payload", "Nullable(JSON)")
                 + buf.approx_size()

--- a/src/ops/stages.rs
+++ b/src/ops/stages.rs
@@ -4,7 +4,7 @@ use std::fmt::Write;
 use std::future::Future;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 pub struct Stage {
     name: &'static str,
@@ -51,6 +51,10 @@ pub struct Timer<'a> {
 }
 
 impl Timer<'_> {
+    pub fn elapsed(&self) -> Duration {
+        self.started.elapsed()
+    }
+
     pub fn finish(mut self) {
         self.completed = true;
     }

--- a/src/toast/resolver.rs
+++ b/src/toast/resolver.rs
@@ -572,7 +572,7 @@ impl ClickHouseChunkStore {
         )
     }
 
-    /// Prune candidates, then break reused-generation ties by TID
+    /// Break equal-version ties deterministically; TID order cannot identify newer generations
     fn fetch_sql(&self, toast_relid: u32, value_id: u32, max_lsn: u64) -> String {
         let table = self.toast_table(toast_relid);
         format!(

--- a/tests/backfill_staging_e2e.rs
+++ b/tests/backfill_staging_e2e.rs
@@ -57,6 +57,7 @@ impl Fixture {
         let bridge = Arc::new(
             walshadow::bridge::connect_with_budget(
                 &source.config().socket_dir.join("walshadow-bridge.sock"),
+                1,
                 Duration::from_secs(20),
             )
             .await

--- a/tests/bootstrap_crossing_xact_ch.rs
+++ b/tests/bootstrap_crossing_xact_ch.rs
@@ -57,7 +57,12 @@ async fn crossing_transaction(with_slot: bool) {
     .expect("write ch-config");
 
     let daemon = fx::DaemonRun::prepare(tmp.path(), slot.metrics).expect("daemon layout");
-    let mut args = vec!["--bootstrap-max-rate-kib", MAX_RATE_KIB];
+    let mut args = vec![
+        "--bootstrap-max-rate-kib",
+        MAX_RATE_KIB,
+        "--bootstrap-wind-down-secs",
+        "0",
+    ];
     if with_slot {
         args.extend(["--slot", "walshadow_crossing"]);
     }

--- a/tests/bootstrap_direct_e2e.rs
+++ b/tests/bootstrap_direct_e2e.rs
@@ -181,12 +181,23 @@ async fn direct_source_self_hosted_via_replication_protocol() {
 
     // DiskLanderSink coverage
     assert!(
-        outcome.disk.kept_files > 100,
+        outcome
+            .disk
+            .kept_files
+            .load(std::sync::atomic::Ordering::Relaxed)
+            > 100,
         "expected >100 catalog files landed, got {}",
-        outcome.disk.kept_files,
+        outcome
+            .disk
+            .kept_files
+            .load(std::sync::atomic::Ordering::Relaxed),
     );
     assert!(
-        outcome.disk.skipped_denylist > 0,
+        outcome
+            .disk
+            .skipped_denylist
+            .load(std::sync::atomic::Ordering::Relaxed)
+            > 0,
         "no denylist files skipped — expected at least one under pg_replslot/ or pg_stat_tmp/",
     );
 
@@ -214,15 +225,46 @@ async fn direct_source_self_hosted_via_replication_protocol() {
     );
 
     // PageWalkSink stats
-    assert!(outcome.page_walk.files_seen > 0);
-    assert!(outcome.page_walk.files_walked > 0);
-    assert!(outcome.page_walk.pages_walked > 0);
     assert!(
-        outcome.page_walk.tuples_emitted >= N_ROWS as u64,
-        "expected >= {N_ROWS} tuples emitted from page walk, got {}",
-        outcome.page_walk.tuples_emitted,
+        outcome
+            .page_walk
+            .files_seen
+            .load(std::sync::atomic::Ordering::Relaxed)
+            > 0
     );
-    assert_eq!(shipped, outcome.page_walk.tuples_emitted);
+    assert!(
+        outcome
+            .page_walk
+            .files_walked
+            .load(std::sync::atomic::Ordering::Relaxed)
+            > 0
+    );
+    assert!(
+        outcome
+            .page_walk
+            .pages_walked
+            .load(std::sync::atomic::Ordering::Relaxed)
+            > 0
+    );
+    assert!(
+        outcome
+            .page_walk
+            .tuples_emitted
+            .load(std::sync::atomic::Ordering::Relaxed)
+            >= N_ROWS as u64,
+        "expected >= {N_ROWS} tuples emitted from page walk, got {}",
+        outcome
+            .page_walk
+            .tuples_emitted
+            .load(std::sync::atomic::Ordering::Relaxed),
+    );
+    assert_eq!(
+        shipped,
+        outcome
+            .page_walk
+            .tuples_emitted
+            .load(std::sync::atomic::Ordering::Relaxed)
+    );
 
     // CommittedTuple shape
     let mut int_ids: HashSet<i32> = HashSet::new();

--- a/tests/bootstrap_gate_ch.rs
+++ b/tests/bootstrap_gate_ch.rs
@@ -147,7 +147,7 @@ async fn dead_and_aborted_tuples_stay_out_of_ch() {
         ensure!(!line.contains("deferred=0"), "nothing deferred: {line}");
         // Fixed-width relation bypasses repair
         ensure!(
-            line.contains("pending_relations=0"),
+            line.contains("unresolved=0"),
             "relation left the walk: {line}"
         );
         Ok(())

--- a/tests/bootstrap_object_store_e2e.rs
+++ b/tests/bootstrap_object_store_e2e.rs
@@ -284,14 +284,25 @@ async fn object_store_source_self_hosted_via_wal_rs_push() {
     // base/<dbid>/ + global/. Use a generous lower bound rather than
     // a tight count: PG version drift changes the exact number.
     assert!(
-        outcome.disk.kept_files > 100,
+        outcome
+            .disk
+            .kept_files
+            .load(std::sync::atomic::Ordering::Relaxed)
+            > 100,
         "expected >100 catalog files landed, got {}; \
          tuned for PG initdb expectations — bump or investigate \
          a regression",
-        outcome.disk.kept_files,
+        outcome
+            .disk
+            .kept_files
+            .load(std::sync::atomic::Ordering::Relaxed),
     );
     assert!(
-        outcome.disk.skipped_denylist > 0,
+        outcome
+            .disk
+            .skipped_denylist
+            .load(std::sync::atomic::Ordering::Relaxed)
+            > 0,
         "no denylist files skipped — expected at least one under pg_replslot/ or pg_stat_tmp/",
     );
 
@@ -325,23 +336,49 @@ async fn object_store_source_self_hosted_via_wal_rs_push() {
 
     // --- PageWalkSink stats ---
     assert!(
-        outcome.page_walk.files_seen > 0,
+        outcome
+            .page_walk
+            .files_seen
+            .load(std::sync::atomic::Ordering::Relaxed)
+            > 0,
         "no user-heap files observed by the tap",
     );
     assert!(
-        outcome.page_walk.files_walked > 0,
+        outcome
+            .page_walk
+            .files_walked
+            .load(std::sync::atomic::Ordering::Relaxed)
+            > 0,
         "no user-heap files walked (filenode mismatch with CatalogMap?)",
     );
-    assert!(outcome.page_walk.pages_walked > 0, "no heap pages walked",);
     assert!(
-        outcome.page_walk.tuples_emitted >= N_ROWS as u64,
+        outcome
+            .page_walk
+            .pages_walked
+            .load(std::sync::atomic::Ordering::Relaxed)
+            > 0,
+        "no heap pages walked",
+    );
+    assert!(
+        outcome
+            .page_walk
+            .tuples_emitted
+            .load(std::sync::atomic::Ordering::Relaxed)
+            >= N_ROWS as u64,
         "expected >= {N_ROWS} tuples emitted from page walk, got {}",
-        outcome.page_walk.tuples_emitted,
+        outcome
+            .page_walk
+            .tuples_emitted
+            .load(std::sync::atomic::Ordering::Relaxed),
     );
 
     // --- Drain delivered every tuple ---
     assert_eq!(
-        shipped, outcome.page_walk.tuples_emitted,
+        shipped,
+        outcome
+            .page_walk
+            .tuples_emitted
+            .load(std::sync::atomic::Ordering::Relaxed),
         "drain count != page walk emit count — channel dropped tuples"
     );
 

--- a/tests/bootstrap_pipeline_ch.rs
+++ b/tests/bootstrap_pipeline_ch.rs
@@ -142,7 +142,7 @@ async fn bootstrap_tail_fans_out_n2() {
     let mut catalog = CatalogMap::new();
     catalog.insert(rel(16400, "foo"));
     catalog.insert(rel(16401, "baz"));
-    let mapping = walshadow::mapping::mapping_handle(cfg.tables.clone());
+    let mapping = std::sync::Arc::new(cfg.tables.clone());
 
     let stats = Arc::new(EmitterStats::default());
     let emitter_ack = Arc::new(Monotone::<EmitterAck>::new(0));
@@ -160,12 +160,12 @@ async fn bootstrap_tail_fans_out_n2() {
     // Feed all foo rows then all baz rows — contiguous per rfn, as
     // PageWalkSink emits. Two seqs, each spanning ~8 budget-sized batches.
     // cap > 2*ROWS_PER_TABLE so the pre-send fits before the drain spawns
-    let (tup_tx, tup_rx) = tokio::sync::mpsc::channel::<BackfillTuple>(128);
+    let (tup_tx, tup_rx) = tokio::sync::mpsc::channel::<Vec<BackfillTuple>>(128);
     for id in 0..ROWS_PER_TABLE {
-        tup_tx.send(tuple(16400, id)).await.unwrap();
+        tup_tx.send(vec![tuple(16400, id)]).await.unwrap();
     }
     for id in 0..ROWS_PER_TABLE {
-        tup_tx.send(tuple(16401, id)).await.unwrap();
+        tup_tx.send(vec![tuple(16401, id)]).await.unwrap();
     }
     drop(tup_tx);
 
@@ -177,10 +177,7 @@ async fn bootstrap_tail_fans_out_n2() {
         ack.clone(),
         stats.clone(),
         ToastResolver::disabled(),
-        walshadow::spool::DeferredSpool::new(
-            std::env::temp_dir().join("ws-bootstrap-ch-unused.bin"),
-            walshadow::spool::DEFERRED_SPOOL_MEM_MAX,
-        ),
+        None,
         Default::default(),
         None,
         ahash::HashSet::default(),

--- a/tests/bootstrap_toast_gate_ch.rs
+++ b/tests/bootstrap_toast_gate_ch.rs
@@ -1,4 +1,4 @@
-//! Verify greenfield repairs TOAST-owning relations and seeds chunk mirror
+//! Verify greenfield repairs external rows and seeds chunk mirror
 //! for later unchanged external pointers
 
 #![cfg(target_os = "linux")]
@@ -150,11 +150,14 @@ async fn dead_and_aborted_external_values_stay_out_of_ch() {
         let stderr = daemon.stderr();
         let line = stderr
             .lines()
-            .find(|l| l.contains("visibility repair read pending relations"))
+            .find(|l| l.contains("bootstrap visibility gate settled"))
             .context("repair never logged its read")?;
-        ensure!(line.contains("relations=1"), "repair read nothing: {line}");
         ensure!(
-            line.contains(&format!("rows={N_LIVE}")),
+            line.contains("unresolved=0"),
+            "unexpected unresolved visibility: {line}"
+        );
+        ensure!(
+            line.contains(&format!("repaired_rows={N_LIVE}")),
             "repair row count off: {line}"
         );
 

--- a/tests/bootstrap_unavailable_extension_e2e.rs
+++ b/tests/bootstrap_unavailable_extension_e2e.rs
@@ -193,14 +193,8 @@ async fn bootstrap_survives_extension_absent_from_oracle() {
     write_autocreate_config(&ch_config, slot.ch_tcp).expect("write ch-config");
 
     let daemon = fx::DaemonRun::prepare(tmp.path(), slot.metrics).expect("prepare daemon");
-    let pgext = fx::pgext_dir();
     let child = daemon
-        .spawn(
-            &source,
-            &ch_config,
-            slot.walsender,
-            &["--bridge-lib-dir", pgext.to_str().unwrap()],
-        )
+        .spawn(&source, &ch_config, slot.walsender, &[])
         .expect("spawn walshadow-stream");
     let guard = fx::ChildGuard::new(child);
 

--- a/tests/bootstrap_window_ch.rs
+++ b/tests/bootstrap_window_ch.rs
@@ -177,7 +177,7 @@ async fn window_writes_reach_ch() {
             .find(|l| l.contains("bootstrap visibility gate settled"))
             .context("no gate summary")?;
         anyhow::ensure!(
-            gate.contains("pending_relations=0"),
+            gate.contains("unresolved=0"),
             "unexpected source repair: {gate}"
         );
         Ok(())

--- a/tests/bootstrap_window_leg_ch.rs
+++ b/tests/bootstrap_window_leg_ch.rs
@@ -107,6 +107,7 @@ async fn partial_transaction_failure_returns_from_live_and_archived_replay() {
     let stats = Arc::new(EmitterStats::default());
     let emitter = emitter(ports.ch_tcp);
     let cfg = WindowLegConfig {
+        wind_down: Duration::from_secs(5),
         mapping: walshadow::mapping::mapping_handle(emitter.tables.clone()),
         emitter,
         config: Arc::new(ResolvedConfig::default()),
@@ -233,6 +234,7 @@ async fn leg_reads_through_end_lsn_inside_its_first_segment() {
         let (stop_tx, stop_rx) = tokio::sync::watch::channel(Some(end_lsn));
         let patch = Arc::new(std::sync::Mutex::new(PgXactPatch::new()));
         let cfg = WindowLegConfig {
+            wind_down: Duration::from_secs(5),
             emitter: emitter(slot.ch_tcp),
             mapping: walshadow::mapping::mapping_handle(emitter(slot.ch_tcp).tables),
             config: Arc::new(ResolvedConfig::default()),
@@ -284,4 +286,195 @@ async fn leg_reads_through_end_lsn_inside_its_first_segment() {
     if let Err(e) = result {
         panic!("{e:#}");
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn ctid_repair_converges_with_updates_deletes_reuse_and_crossing_transaction() {
+    if !fx::requirements_available() {
+        return;
+    }
+    let ports = fx::Ports::alloc();
+    let tmp = tempfile::tempdir().unwrap();
+    let source = fx::make_pg(&tmp, "source", ports.source);
+    source.initdb().unwrap();
+    source.write_base_conf().unwrap();
+    fx::append_source_conf(&source);
+    source.start().unwrap();
+    let _stop = fx::StopOnDrop { sh: &source };
+    source.apply_schema_dump(&format!(
+        "CREATE SCHEMA {SCHEMA};
+         CREATE TABLE {SCHEMA}.t (id int PRIMARY KEY, name text) WITH (autovacuum_enabled=false);
+         INSERT INTO {SCHEMA}.t VALUES (1,'keep'), (2,'old'), (3,'delete'), (4,'reuse'), (5,'before');
+         SELECT pg_switch_wal();"
+    )).unwrap();
+    let ch =
+        fx::ChServer::spawn(tempfile::tempdir().unwrap(), ports.ch_tcp, ports.ch_http).unwrap();
+    ch.query("CREATE DATABASE walshadow_test").unwrap();
+    ch.query(
+        "CREATE TABLE walshadow_test.t (id Int32, name String, _lsn UInt64, _xid UInt32,
+        _commit_ts DateTime64(6, 'UTC'), _is_deleted Bool)
+        ENGINE = ReplacingMergeTree(_lsn, _is_deleted) ORDER BY id",
+    )
+    .unwrap();
+    let pg = fx::pg_cfg(&source, "repair-convergence-test");
+    let sql = open_sql_client(&pg).await.unwrap();
+    let catalog = seed_catalog_from_source(&sql).await.unwrap();
+    let desc = catalog
+        .descriptors()
+        .find(|d| d.rel_name == RelName::new(SCHEMA, "t"))
+        .unwrap();
+    let mut feed = SourceFeed::connect(&pg).await.unwrap();
+    let ident = feed.identify_system().await.unwrap();
+    let tids: Vec<String> = sql
+        .query(
+            &format!("SELECT ctid::text FROM {SCHEMA}.t ORDER BY id"),
+            &[],
+        )
+        .await
+        .unwrap()
+        .iter()
+        .map(|r| r.get(0))
+        .collect();
+    let tuples = tids
+        .iter()
+        .map(|tid| {
+            let (blk, off) = tid.trim_matches(['(', ')']).split_once(',').unwrap();
+            walshadow::backup_page_walk::BackfillTuple {
+                rfn: desc.rfn,
+                xid: 100,
+                xmax: 10,
+                infomask: walshadow::visibility::HEAP_XMIN_COMMITTED
+                    | walshadow::visibility::HEAP_XMAX_IS_MULTI,
+                source_lsn: ident.xlogpos,
+                blkno: blk.parse().unwrap(),
+                offnum: off.parse().unwrap(),
+                columns: Vec::new(),
+            }
+        })
+        .collect::<Vec<_>>();
+    sql.batch_execute(&format!(
+        "UPDATE {SCHEMA}.t SET name='new' WHERE id=2;
+         DELETE FROM {SCHEMA}.t WHERE id IN (3,4)"
+    ))
+    .await
+    .unwrap();
+    sql.batch_execute(&format!("VACUUM {SCHEMA}.t"))
+        .await
+        .unwrap();
+    sql.batch_execute(&format!("INSERT INTO {SCHEMA}.t VALUES (6,'reused')"))
+        .await
+        .unwrap();
+    let reused: String = sql
+        .query_one(
+            &format!("SELECT ctid::text FROM {SCHEMA}.t WHERE id=6"),
+            &[],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    assert!(
+        tids.contains(&reused),
+        "test requires CTID reuse: {reused}, {tids:?}"
+    );
+    let crossing = open_sql_client(&pg).await.unwrap();
+    crossing
+        .batch_execute(&format!(
+            "BEGIN; UPDATE {SCHEMA}.t SET name='cross' WHERE id=5"
+        ))
+        .await
+        .unwrap();
+
+    let emitter = emitter(ports.ch_tcp);
+    let mapping = walshadow::mapping::mapping_handle(emitter.tables.clone());
+    let routes = mapping.snapshot().await;
+    let stats = Arc::new(EmitterStats::default());
+    let tail = walshadow::pipeline::tail::OwnedTail::spawn(
+        &emitter,
+        1,
+        stats.clone(),
+        Fatal::new(),
+        None,
+        None,
+        "repair convergence",
+    )
+    .await
+    .unwrap();
+    let (tx, rx) = tokio::sync::mpsc::channel(1);
+    let (out_tx, out_rx) = tokio::sync::mpsc::channel(1);
+    let repair = tokio::spawn(
+        walshadow::visibility_repair::RowRepair {
+            source: pg,
+            catalog: catalog.clone(),
+            scope: walshadow::visibility_repair::RepairScope::mapped(&catalog, &routes, |_| true),
+            rate: walshadow::copy_backfill::CopyRate::new(None),
+        }
+        .run(rx, out_tx),
+    );
+    let drain = tokio::spawn(walshadow::pipeline::bootstrap::drain(
+        out_rx,
+        catalog.clone(),
+        routes,
+        tail.msg_tx.clone(),
+        tail.ack.clone(),
+        stats.clone(),
+        ToastResolver::disabled(),
+        None,
+        Default::default(),
+        None,
+        Default::default(),
+    ));
+    let mut spool = walshadow::spool::DeferredSpool::new(tmp.path().join("gate"), 0);
+    for t in tuples {
+        spool.push(t).await.unwrap();
+    }
+    let accum = walshadow::visibility::PgXactAccum::new();
+    let patch = PgXactPatch::new();
+    let multi = walshadow::visibility::PgMultiXactAccum::new();
+    let view = walshadow::visibility::PgXactView::new(&accum, &patch).with_multixact(&multi);
+    let mut gate_stats = walshadow::visibility_gate::GateStats::default();
+    walshadow::visibility_gate::resolve_phase(
+        spool,
+        &view,
+        &walshadow::visibility_gate::GateOutput::Repair(&tx),
+        &mut gate_stats,
+    )
+    .await
+    .unwrap();
+    drop(tx);
+    repair.await.unwrap().unwrap();
+    let drained = drain.await.unwrap().unwrap();
+    tail.finish(drained.next_seq).await.unwrap();
+    assert_eq!(gate_stats.unresolved, 5);
+    crossing.batch_execute("COMMIT").await.unwrap();
+    let end = walshadow::pg::current_wal_lsn(&sql).await.unwrap();
+    sql.batch_execute("SELECT pg_switch_wal()").await.unwrap();
+    let (_stop_tx, stop_rx) = tokio::sync::watch::channel(Some(end));
+    let cfg = WindowLegConfig {
+        emitter,
+        mapping,
+        config: Arc::new(ResolvedConfig::default()),
+        stats,
+        resolver: ToastResolver::disabled(),
+        oracle: None,
+        fatal: Fatal::new(),
+        scratch_dir: tmp.path().join("leg"),
+        patch: Arc::new(std::sync::Mutex::new(PgXactPatch::new())),
+        catalog,
+        pg_major: (feed.server_version_num() / 10000) as u32,
+        system_id: ident.sysid,
+        timeline: ident.timeline,
+        wind_down: Duration::ZERO,
+    };
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        stream_window(cfg, &mut feed, ident.xlogpos, stop_rx),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(
+        ch.query("SELECT id, name FROM walshadow_test.t FINAL WHERE NOT _is_deleted ORDER BY id")
+            .unwrap(),
+        "1\tkeep\n2\tnew\n5\tcross\n6\treused"
+    );
 }

--- a/tests/bootstrap_window_wal_not_landed_raw_e2e.rs
+++ b/tests/bootstrap_window_wal_not_landed_raw_e2e.rs
@@ -148,12 +148,7 @@ async fn backup_window_wal_never_materialises_the_shadow() {
             &source,
             &ch_config_path,
             slot.walsender,
-            &[
-                "--bootstrap-max-rate-kib",
-                MAX_RATE_KIB,
-                "--bridge-lib-dir",
-                fx::pgext_dir().to_str().unwrap(),
-            ],
+            &["--bootstrap-max-rate-kib", MAX_RATE_KIB],
         )
         .expect("spawn walshadow-stream");
     let guard = fx::ChildGuard::new(child);

--- a/tests/bridge.rs
+++ b/tests/bridge.rs
@@ -20,7 +20,7 @@ use walshadow::bridge::{
 };
 use walshadow::oracle::{Oracle, OracleCell, OracleColumnBuf, OracleRequestColumn};
 use walshadow::pg::socket_conninfo;
-use walshadow::schema::ReplIdent;
+use walshadow::schema::{NUMERICOID, ReplIdent};
 use walshadow::shadow::{BridgeConf, Shadow, ShadowConfig};
 use walshadow::shadow_catalog::{CatalogError, ShadowCatalog, ShadowCatalogConfig};
 
@@ -56,6 +56,10 @@ impl Drop for StopOnDrop {
 }
 
 fn start_pg(tmp: &tempfile::TempDir, port: u16) -> StopOnDrop {
+    start_pg_with_workers(tmp, port, 1)
+}
+
+fn start_pg_with_workers(tmp: &tempfile::TempDir, port: u16, workers: usize) -> StopOnDrop {
     let lib_dir = pgext_dir();
     let mut cfg = ShadowConfig::new(tmp.path().join("data"), tmp.path().join("filtered"));
     cfg.port = port;
@@ -63,6 +67,7 @@ fn start_pg(tmp: &tempfile::TempDir, port: u16) -> StopOnDrop {
     cfg.ctl_timeout = Duration::from_secs(60);
     let mut bridge = BridgeConf::in_dir(&cfg.socket_dir);
     bridge.library_dir = Some(lib_dir);
+    bridge.workers = workers;
     cfg.bridge = Some(bridge);
     fs::create_dir_all(&cfg.filter_out_dir).unwrap();
     fs::create_dir_all(&cfg.socket_dir).unwrap();
@@ -76,7 +81,7 @@ fn start_pg(tmp: &tempfile::TempDir, port: u16) -> StopOnDrop {
 
 async fn dial(sh: &Shadow) -> Bridge {
     let path = sh.bridge_socket().expect("bridge configured");
-    walshadow::bridge::connect_with_budget(path, Duration::from_secs(20))
+    walshadow::bridge::connect_with_budget(path, 1, Duration::from_secs(20))
         .await
         .unwrap_or_else(|e| panic!("bridge connect on {}: {e}", path.display()))
 }
@@ -115,7 +120,7 @@ async fn open_catalog(sh: &Shadow, bridge: Arc<Bridge>) -> ShadowCatalog {
 async fn open_mirror_catalog(sh: &Shadow, sock: &Path) -> (Arc<Bridge>, ShadowCatalog) {
     spawn_moving_worker(tokio::net::UnixListener::bind(sock).expect("bind stand-in"));
     let bridge = Arc::new(
-        walshadow::bridge::connect_with_budget(sock, Duration::from_secs(5))
+        walshadow::bridge::connect_with_budget(sock, 1, Duration::from_secs(5))
             .await
             .expect("stand-in bridge"),
     );
@@ -183,7 +188,7 @@ async fn bytes_through_oracle(bridge: Arc<Bridge>, items: &[(u32, &[u8])]) -> Ve
     let bufs: Vec<OracleColumnBuf> = items
         .iter()
         .map(|(oid, raw)| {
-            let mut b = OracleColumnBuf::new(*oid, -1);
+            let mut b = OracleColumnBuf::new(*oid, -1, "String");
             b.push(OracleCell::DiskRaw(raw.to_vec()));
             b
         })
@@ -354,7 +359,7 @@ async fn bridge_native_strings_match_typoutput() {
         (2_147_483_647, &[0x00]),
     ];
     for (oid, raw) in bad {
-        let mut b = OracleColumnBuf::new(oid, -1);
+        let mut b = OracleColumnBuf::new(oid, -1, "String");
         b.push(OracleCell::DiskRaw(raw.to_vec()));
         let columns = [OracleRequestColumn {
             ordinal: 0,
@@ -624,7 +629,9 @@ async fn bridge_scans_null_missing_value() {
     let mut expected = baseline.clone();
     let column = expected.iter_mut().find(|a| a.attname == "c").unwrap();
     assert_eq!(column.attrelid, oid_t);
-    assert_eq!(column.attmissingval.as_deref(), Some("{7}"));
+    // Raw bytes, decoded in `bridge_scans_uncommitted_ddl`; here only presence
+    // is the premise the fault removes
+    assert!(column.attmissingval.is_some());
     column.attmissingval = None;
 
     // PostgreSQL DDL updates flag and value together, inject catalog inconsistency
@@ -1138,7 +1145,7 @@ async fn bridge_native_hstore_expander_requires_extension_membership() {
     let oid = oid_of_type(&sql, "hstore").await;
     let bridge = Arc::new(dial(&guard.sh).await);
     let oracle = Oracle::new(bridge.clone());
-    let mut buf = OracleColumnBuf::new(oid, -1);
+    let mut buf = OracleColumnBuf::new(oid, -1, "Map(String, Nullable(String))");
     buf.push(OracleCell::TextInput(br#""a"=>"one", "b"=>NULL"#.to_vec()));
     buf.push(OracleCell::Default);
     let columns = [OracleRequestColumn {
@@ -1332,4 +1339,158 @@ async fn bridge_scan_skips_another_subtransactions_rows() {
     let attrs = scan.parse::<AttributeRow>().expect("attribute rows");
     let cols: Vec<&str> = attrs.iter().map(|a| a.attname.as_str()).collect();
     assert_eq!(cols, ["id"], "answered a column of another tree");
+}
+
+/// `walshadow.bridge_workers = 4` registers four workers on
+/// `socket_path`, `socket_path.1`, `.2`, `.3`. Pooling them is what stops
+/// oracle throughput being one backend's conversion rate.
+///
+/// Asserts routing, not rate: four in-flight `ENCODE_NATIVE`s over four
+/// sockets each get their own answer back. The pooled-vs-single throughput
+/// ratio is hardware-bound (cores cap it) so it is measured by the perf
+/// workload, never asserted here, see
+/// [`plans/performance.md`](../plans/performance.md)
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn bridge_worker_pool_serves_concurrent_requests() {
+    if !pg_available() {
+        eprintln!("skip: no initdb on PATH");
+        return;
+    }
+    const WORKERS: usize = 4;
+    let tmp = tempfile::tempdir().unwrap();
+    let guard = start_pg_with_workers(&tmp, ports::PG_SHADOW_PORT, WORKERS);
+    let path = guard.sh.bridge_socket().expect("bridge configured");
+
+    let pooled = Arc::new(
+        walshadow::bridge::connect_with_budget(path, WORKERS, Duration::from_secs(30))
+            .await
+            .expect("pooled bridge connect"),
+    );
+    // Same shadow, one socket: a budget below the worker count is honoured
+    let single = Arc::new(
+        walshadow::bridge::connect_with_budget(path, 1, Duration::from_secs(30))
+            .await
+            .expect("single bridge connect"),
+    );
+    assert_eq!(pooled.pool_size(), WORKERS, "one socket per worker");
+    assert_eq!(single.pool_size(), 1);
+    // Every slot dialled its own HELLO; a mismatch would have failed connect
+    assert!(pooled.info().is_some());
+
+    // Wide enough that requests are still overlapping when the last one is
+    // dispatched, which is the state a shared slot would have to serialize
+    const ROWS: usize = 10_000;
+    let cells = Arc::new({
+        let mut b = OracleColumnBuf::new(NUMERICOID, -1, "String");
+        for _ in 0..ROWS {
+            b.push(OracleCell::DiskRaw(numeric_42()));
+        }
+        b
+    });
+
+    /// One `ENCODE_NATIVE` per task, all in flight at once
+    async fn race(bridge: &Arc<Bridge>, cells: &Arc<OracleColumnBuf>, tasks: usize) {
+        let mut set = Vec::new();
+        for _ in 0..tasks {
+            let bridge = bridge.clone();
+            let cells = cells.clone();
+            set.push(tokio::spawn(async move {
+                let columns = [OracleRequestColumn {
+                    ordinal: 0,
+                    name: "c0",
+                    target_type: "String",
+                    buf: &cells,
+                }];
+                Oracle::new(bridge)
+                    .encode_batch(
+                        &columns,
+                        cells.cells().len(),
+                        clickhouse_c::Allocator::stdlib(),
+                    )
+                    .await
+                    .expect("oracle answers")
+                    .column(0)
+                    .and_then(|c| c.string())
+                    .expect("string column")
+                    .0
+                    .len()
+            }));
+        }
+        for h in set {
+            assert_eq!(h.await.unwrap(), ROWS, "one offset per row");
+        }
+    }
+
+    race(&pooled, &cells, WORKERS).await;
+    // One socket carrying the same concurrency answers every caller too
+    race(&single, &cells, WORKERS).await;
+
+    // Pool width is operator-visible
+    assert_eq!(
+        pooled
+            .stats
+            .pool_size
+            .load(std::sync::atomic::Ordering::Relaxed),
+        WORKERS as u64,
+    );
+    // Catalog reads stayed on worker 0 whatever the pool width
+    pooled
+        .scan(Catalog::Namespace, 0, &[])
+        .await
+        .expect("scan pinned to slot 0 still answers");
+}
+
+/// Reading a catalog without its lock is licensed only while replay sits at
+/// the position the caller named. When the worker's own sample says replay is
+/// elsewhere, that license is void, and a lock it cannot take is a refusal:
+/// waiting on it is what would deadlock against the caller's withheld WAL
+#[tokio::test(flavor = "current_thread")]
+async fn bridge_scan_refuses_a_locked_catalog_off_the_named_boundary() {
+    if !pg_available() {
+        eprintln!("skip: no initdb on PATH");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let guard = start_pg(&tmp, ports::PG_SHADOW_PORT);
+    let bridge = dial(&guard.sh).await;
+
+    let setup = connect_sql(&guard.sh).await;
+    setup
+        .batch_execute("CREATE TABLE t (id int)")
+        .await
+        .expect("committed setup");
+    let oid_t = oid_of(&setup, "t").await;
+
+    // Not in recovery, so the worker samples replay at 0 and any boundary the
+    // caller names is one replay is not at
+    assert_eq!(bridge.replay_lsn().await.expect("replay_lsn"), 0);
+    const NAMED: u64 = 0x1000;
+
+    let holder = connect_sql(&guard.sh).await;
+    holder
+        .batch_execute("BEGIN; LOCK TABLE pg_catalog.pg_attribute IN ACCESS EXCLUSIVE MODE")
+        .await
+        .expect("hold catalog lock");
+
+    let err = bridge
+        .scan_at(Catalog::Attribute, 0, &[oid_t], NAMED)
+        .await
+        .expect_err("answered a catalog it could neither lock nor read");
+    let BridgeError::Remote(msg) = &err else {
+        panic!("{err:?}");
+    };
+    assert!(
+        msg.contains("is locked and replay is not at the position"),
+        "{msg}"
+    );
+
+    // Refusal, not a broken connection: the same catalog reads back over the
+    // same socket once the lock is gone
+    holder.batch_execute("ROLLBACK").await.expect("release");
+    let scan = bridge
+        .scan(Catalog::Attribute, 0, &[oid_t])
+        .await
+        .expect("scan once the lock is free");
+    let attrs = scan.parse::<AttributeRow>().expect("attribute rows");
+    assert!(attrs.iter().any(|a| a.attname == "id"), "{attrs:#?}");
 }

--- a/tests/catalog_ael_boundary.rs
+++ b/tests/catalog_ael_boundary.rs
@@ -102,16 +102,24 @@ async fn pump_to_lsn(
     Ok(())
 }
 
-/// Drive one catalog boundary through capture. `hold_lock` decides whether a
-/// transaction leaves a recovery-held AEL on `pg_type` straddling it.
-/// Returns how far capture got, or `Err` once the budget expires.
-async fn run_boundary(hold_lock: bool) -> Result<(), String> {
-    run_boundary_ddl(hold_lock, "ALTER TABLE demo ADD COLUMN w int").await
+/// Catalog transaction V leaves a recovery-held AEL on. `None` straddles the
+/// boundary with no lock at all
+type Held<'a> = Option<&'a str>;
+
+/// Read whole, so the scan carries no oid list
+const PG_TYPE: &str = "pg_catalog.pg_type";
+/// Read against the relation oids the boundary names, so the scan is scoped
+const PG_ATTRIBUTE: &str = "pg_catalog.pg_attribute";
+
+/// Drive one catalog boundary through capture. Returns how far capture got,
+/// or `Err` once the budget expires
+async fn run_boundary(held: Held<'_>) -> Result<(), String> {
+    run_boundary_ddl(held, "ALTER TABLE demo ADD COLUMN w int").await
 }
 
 /// `d_ddl`: transaction D's catalog mutation, whose boundary lands between V's
 /// lock and V's commit.
-async fn run_boundary_ddl(hold_lock: bool, d_ddl: &str) -> Result<(), String> {
+async fn run_boundary_ddl(held: Held<'_>, d_ddl: &str) -> Result<(), String> {
     let so = wstest_module();
     let ports = fx::Ports::alloc();
     let tmp = tempfile::tempdir().unwrap();
@@ -119,6 +127,11 @@ async fn run_boundary_ddl(hold_lock: bool, d_ddl: &str) -> Result<(), String> {
     let schema = format!(
         "CREATE TABLE demo (id int primary key, v text);\n\
          INSERT INTO demo VALUES (1, 'a');\n\
+         -- An aborted inserter's pg_attribute row for demo, which a scan\n\
+         -- reading under SnapshotAny has to reject on its own\n\
+         BEGIN;\n\
+         ALTER TABLE demo ADD COLUMN rolled_back int;\n\
+         ROLLBACK;\n\
          CREATE FUNCTION ws_test_lock_unlock_relation(oid) RETURNS void \
          AS '{}', 'ws_test_lock_unlock_relation' LANGUAGE c;\n",
         so.display(),
@@ -164,14 +177,14 @@ async fn run_boundary_ddl(hold_lock: bool, d_ddl: &str) -> Result<(), String> {
     })
     .await;
 
-    // Transaction V: take AEL on pg_type, release it source-side, stay open.
-    // The shadow keeps the replayed lock until V commits.
-    let v = hold_lock.then(|| {
+    // Transaction V: take AEL on the catalog, release it source-side, stay
+    // open. The shadow keeps the replayed lock until V commits.
+    let v = held.map(|catalog| {
         fx::spawn_txn(
             &source,
             &format!(
                 "BEGIN;\n\
-                 SELECT ws_test_lock_unlock_relation('pg_catalog.pg_type'::regclass);\n\
+                 SELECT ws_test_lock_unlock_relation('{catalog}'::regclass);\n\
                  SELECT pg_sleep({HOLD_SECS});\n\
                  COMMIT;\n"
             ),
@@ -180,7 +193,7 @@ async fn run_boundary_ddl(hold_lock: bool, d_ddl: &str) -> Result<(), String> {
 
     // V parks in pg_sleep, so its lock record is written and its commit is
     // not. The source-side lock is already gone, which is what lets D run.
-    if hold_lock {
+    if held.is_some() {
         let deadline = Instant::now() + Duration::from_secs(30);
         loop {
             let parked = source
@@ -247,7 +260,7 @@ async fn boundary_capture_completes_without_held_catalog_lock() {
         eprintln!("skip: missing initdb / pg_basebackup / clickhouse");
         return;
     }
-    run_boundary(false).await.expect("control boundary");
+    run_boundary(None).await.expect("control boundary");
 }
 
 /// Regression: capture must not wait on a lock whose release is in the WAL
@@ -258,7 +271,7 @@ async fn boundary_capture_survives_recovery_held_catalog_lock() {
         eprintln!("skip: missing initdb / pg_basebackup / clickhouse");
         return;
     }
-    if let Err(e) = run_boundary(true).await {
+    if let Err(e) = run_boundary(Some(PG_TYPE)).await {
         panic!(
             "boundary capture wedged behind a recovery-held AccessExclusiveLock \
              on pg_type: {e}"
@@ -275,10 +288,30 @@ async fn boundary_capture_survives_recovery_held_lock_with_fast_default() {
         eprintln!("skip: missing initdb / pg_basebackup / clickhouse");
         return;
     }
-    if let Err(e) = run_boundary_ddl(true, "ALTER TABLE demo ADD COLUMN w int DEFAULT 7").await {
+    if let Err(e) =
+        run_boundary_ddl(Some(PG_TYPE), "ALTER TABLE demo ADD COLUMN w int DEFAULT 7").await
+    {
         panic!(
             "fast-default capture wedged behind a recovery-held AccessExclusiveLock \
              on pg_type (attmissingval formatting must stay lock-free): {e}"
+        );
+    }
+}
+
+/// Scoped sub-case: `pg_class` pins the position first and is not the catalog
+/// under lock, so the `pg_attribute` scan behind it arrives with both an oid
+/// list and a lock it cannot take, the one read that filters rows itself
+/// instead of letting an index do it
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn boundary_capture_survives_recovery_held_lock_on_scoped_catalog() {
+    if !fx::pg_available() || !fx::pg_basebackup_available() || !fx::clickhouse_available() {
+        eprintln!("skip: missing initdb / pg_basebackup / clickhouse");
+        return;
+    }
+    if let Err(e) = run_boundary(Some(PG_ATTRIBUTE)).await {
+        panic!(
+            "boundary capture wedged behind a recovery-held AccessExclusiveLock \
+             on pg_attribute: {e}"
         );
     }
 }

--- a/tests/common/bootstrap_ch_fixture.rs
+++ b/tests/common/bootstrap_ch_fixture.rs
@@ -263,6 +263,8 @@ impl DaemonRun {
                 &ports::PG_SHADOW_PORT.to_string(),
                 "--shadow-user",
                 "postgres",
+                "--bridge-lib-dir",
+                pgext_dir().to_str().unwrap(),
                 "--shadow-dbname",
                 "postgres",
                 "--spill-dir",

--- a/tests/common/inproc_harness.rs
+++ b/tests/common/inproc_harness.rs
@@ -348,9 +348,29 @@ impl Drop for ChServer {
 // ---------------------------------------------------------------------------
 
 pub struct BootstrappedClusters {
-    pub source: Shadow,
-    pub shadow: Shadow,
+    pub source: ClusterGuard,
+    pub shadow: ClusterGuard,
     pub shadow_filter_dir: PathBuf,
+}
+
+/// A started cluster, stopped when the test lets go of it. Nothing else asks
+/// the postmaster to exit, so without this the tempdir is unlinked under a
+/// live one, and the bridge worker's gcov profile, written only at a clean
+/// backend exit, is lost with it
+pub struct ClusterGuard(Shadow);
+
+impl std::ops::Deref for ClusterGuard {
+    type Target = Shadow;
+
+    fn deref(&self) -> &Shadow {
+        &self.0
+    }
+}
+
+impl Drop for ClusterGuard {
+    fn drop(&mut self) {
+        let _ = self.0.stop();
+    }
 }
 
 /// Build tree holding `walshadow.so`, fed to shadow as `dynamic_library_path`.
@@ -495,8 +515,8 @@ async fn bootstrap_clusters_inner(
 
     (
         BootstrappedClusters {
-            source,
-            shadow,
+            source: ClusterGuard(source),
+            shadow: ClusterGuard(shadow),
             shadow_filter_dir,
         },
         shadow_stream_state,
@@ -727,7 +747,7 @@ async fn build_pipeline_inner(
     };
     let bridge_path = shadow.bridge_socket().expect("bridge configured");
     let bridge = Arc::new(
-        walshadow::bridge::connect_with_budget(bridge_path, Duration::from_secs(60))
+        walshadow::bridge::connect_with_budget(bridge_path, 1, Duration::from_secs(60))
             .await
             .unwrap_or_else(|e| panic!("bridge connect on {}: {e}", bridge_path.display())),
     );

--- a/tests/common/pgext.rs
+++ b/tests/common/pgext.rs
@@ -51,7 +51,7 @@ pub fn pgext_dir() -> PathBuf {
 
 const MAGIC: u32 = 0x5753_4831; // "WSH1"
 const MAX_RULES: usize = 16;
-const N_OPS: usize = 10;
+const N_OPS: usize = 11;
 /// magic, generation, rules_parsed, reserved
 const HEADER_WORDS: usize = 4;
 
@@ -68,6 +68,7 @@ pub enum Op {
     Chmod,
     Fcntl,
     Close,
+    Setsockopt,
 }
 
 impl Op {
@@ -83,6 +84,7 @@ impl Op {
             Self::Chmod => "chmod",
             Self::Fcntl => "fcntl",
             Self::Close => "close",
+            Self::Setsockopt => "setsockopt",
         }
     }
 
@@ -98,6 +100,7 @@ impl Op {
             Self::Chmod => 7,
             Self::Fcntl => 8,
             Self::Close => 9,
+            Self::Setsockopt => 10,
         }
     }
 }

--- a/tests/composite_pkey.rs
+++ b/tests/composite_pkey.rs
@@ -11,7 +11,6 @@ use std::time::Duration;
 use walshadow::mapping::ColumnMapping;
 use walshadow::mapping::TableTarget;
 use walshadow::schema::RelName;
-use walshadow::shadow::Shadow;
 
 // walsender must clear ch_http by >1 (CH binds interserver = ch_http + 1).
 
@@ -63,7 +62,7 @@ async fn run_drill(
     slot: fx::Ports,
     app_name: &str,
     workload: &str,
-) -> (Shadow, fx::ChServer, tempfile::TempDir) {
+) -> (fx::ClusterGuard, fx::ChServer, tempfile::TempDir) {
     let tmp = tempfile::tempdir().unwrap();
     let (
         fx::BootstrappedClusters {

--- a/tests/dirty_admission_e2e.rs
+++ b/tests/dirty_admission_e2e.rs
@@ -18,7 +18,6 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use walshadow::mapping::NamespaceMapping;
-use walshadow::shadow::Shadow;
 
 fn skip_gate() -> bool {
     if !fx::requirements_available() {
@@ -28,8 +27,8 @@ fn skip_gate() -> bool {
 }
 
 struct Drill {
-    source: Shadow,
-    shadow: Shadow,
+    source: fx::ClusterGuard,
+    shadow: fx::ClusterGuard,
     ch: fx::ChServer,
     pipeline: fx::Pipeline,
     _tmp: tempfile::TempDir,

--- a/tests/optin_initial_load_none_e2e.rs
+++ b/tests/optin_initial_load_none_e2e.rs
@@ -1,9 +1,8 @@
 //! Greenfield Direct bootstrap must honour `initial_load = "none"` on a
 //! `replicate = true` opt-in table (a `[table.*]` section with no explicit
 //! `columns`, which lands in `table_opt_ins` rather than `table_initial_loads`).
-//! The table's pre-existing rows must NOT be page-walked, but the table is still
-//! created and post-boot CDC still streams. Reproduces a deployment where 10000
-//! rows synced despite `initial_load = "none"`.
+//! Preserve snapshot opt-out while converting array writes during bootstrap
+//! window replay and subsequent CDC
 
 #![cfg(target_os = "linux")]
 
@@ -60,8 +59,8 @@ async fn optin_initial_load_none_skips_snapshot_but_streams_cdc() {
     let _src_stop = fx::StopOnDrop { sh: &source };
     source
         .apply_schema_dump(
-            "CREATE TABLE public.t(id int PRIMARY KEY, name text);\n\
-             INSERT INTO public.t SELECT g, 'pre-'||g FROM generate_series(1, 500) g;\n\
+            "CREATE TABLE public.t(id int PRIMARY KEY, name int[]);\n\
+             INSERT INTO public.t SELECT g, ARRAY[g] FROM generate_series(1, 500) g;\n\
              CHECKPOINT;\nSELECT pg_switch_wal();\n",
         )
         .expect("load pre-boot rows");
@@ -121,6 +120,8 @@ async fn optin_initial_load_none_skips_snapshot_but_streams_cdc() {
             ch_config_path.to_str().unwrap(),
             "--bootstrap-mode",
             "direct",
+            "--bootstrap-max-rate-kib",
+            "32768",
             "--bootstrap-shadow-data-dir",
             bootstrap_shadow_data_dir.to_str().unwrap(),
             "--bootstrap-shadow-replay-timeout",
@@ -150,20 +151,32 @@ async fn optin_initial_load_none_skips_snapshot_but_streams_cdc() {
             }
             std::thread::sleep(Duration::from_millis(250));
         }
-        // Give any (erroneous) snapshot rows time to arrive before asserting 0.
-        std::thread::sleep(Duration::from_secs(3));
-        let boot_n = ch
-            .query("SELECT count() FROM default.t")
-            .unwrap_or_default();
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while source.psql_one("SELECT count(*) FROM pg_stat_progress_basebackup")? == "0" {
+            anyhow::ensure!(
+                Instant::now() < deadline,
+                "bootstrap never opened BASE_BACKUP"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        source.apply_schema_dump(
+            "INSERT INTO public.t VALUES (100000, ARRAY[1,2]); SELECT pg_switch_wal()",
+        )?;
+        fx::wait_for_ch_value(
+            &ch,
+            "SELECT name FROM default.t FINAL WHERE id = 100000",
+            "[1,2]",
+            Duration::from_secs(60),
+        )?;
         anyhow::ensure!(
-            boot_n == "0",
-            "initial_load=none ignored: {boot_n} snapshot rows landed"
+            ch.query("SELECT count() FROM default.t FINAL WHERE id <= 500")? == "0",
+            "initial_load=none loaded snapshot rows"
         );
 
         // CDC still streams: a post-boot insert must appear.
         source
             .apply_schema_dump(
-                "INSERT INTO public.t VALUES (100001, 'cdc');\nSELECT pg_switch_wal();\n",
+                "INSERT INTO public.t VALUES (100001, ARRAY[3,4]);\nSELECT pg_switch_wal();\n",
             )
             .context("post-boot insert")?;
         let deadline = Instant::now() + Duration::from_secs(60);

--- a/tests/oracle.rs
+++ b/tests/oracle.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 use clickhouse_c::Allocator;
 use walshadow::backfill::bootstrap_oracle::BootstrapOracle;
-use walshadow::bridge::{Bridge, BridgeError};
+use walshadow::bridge::{Bridge, BridgeError, FRAME_PREFIX_BYTES, request_frame};
 use walshadow::oracle::{Oracle, OracleCell, OracleColumnBuf, OracleRequestColumn};
 use walshadow::schema::NUMERICOID;
 use walshadow::shadow::{BridgeConf, Shadow, ShadowConfig};
@@ -79,7 +79,7 @@ fn start_pg(tmp: &tempfile::TempDir, port: u16) -> Option<StopOnDrop> {
 
 async fn bridge_on(sh: &Shadow) -> Bridge {
     let path = sh.bridge_socket().expect("bridge configured");
-    walshadow::bridge::connect_with_budget(path, Duration::from_secs(20))
+    walshadow::bridge::connect_with_budget(path, 1, Duration::from_secs(20))
         .await
         .unwrap_or_else(|e| panic!("bridge connect on {}: {e}", path.display()))
 }
@@ -93,7 +93,9 @@ fn alloc() -> Allocator {
 }
 
 fn buf(oid: u32, cells: Vec<OracleCell>) -> OracleColumnBuf {
-    let mut b = OracleColumnBuf::new(oid, -1);
+    // Every request here names its own target; the buffer's copy only steers
+    // local rendering, which these cases ask the worker for regardless
+    let mut b = OracleColumnBuf::new(oid, -1, "String");
     for c in cells {
         b.push(c);
     }
@@ -163,6 +165,7 @@ async fn bootstrap_oracle_preserves_types_and_removes_cluster() {
             conninfo,
             password,
             Some(pgext_dir()),
+            1,
             Duration::from_secs(20),
         )
         .await
@@ -271,6 +274,7 @@ async fn bootstrap_oracle_reports_source_errors() {
             conninfo,
             None,
             Some(pgext_dir()),
+            1,
             Duration::from_secs(20),
         )
         .await
@@ -591,8 +595,16 @@ async fn oracle_fails_whole_request_on_bad_cell() {
     assert_eq!(bridge.stats.reconnects.load(Ordering::Relaxed), 0);
 }
 
+/// Raw payload past the frame prefix, for shapes `native_request` cannot build
+fn framed(payload: &[u8]) -> Vec<u8> {
+    let mut out = request_frame(payload.len());
+    out.extend_from_slice(payload);
+    out
+}
+
 fn native_request(oid: u32, name: &str, ty: &str, cells: &[u8], rows: u32) -> Vec<u8> {
-    let mut out = rows.to_be_bytes().to_vec();
+    let mut out = request_frame(16 + name.len() + ty.len() + cells.len());
+    out.extend_from_slice(&rows.to_be_bytes());
     out.extend_from_slice(&1u32.to_be_bytes());
     out.extend_from_slice(&oid.to_be_bytes());
     out.extend_from_slice(&(-1i32).to_be_bytes());
@@ -624,8 +636,8 @@ async fn worker_refuses_malformed_requests() {
             native_request(23, "c", "Int32", &[0], 0),
             "0 rows and 1 columns",
         ),
-        (vec![0, 0, 0, 1, 0, 0, 0, 0], "1 rows and 0 columns"),
-        (vec![255; 8], "bytes remain"),
+        (framed(&[0, 0, 0, 1, 0, 0, 0, 0]), "1 rows and 0 columns"),
+        (framed(&[255; 8]), "bytes remain"),
         (
             native_request(23, "", "Int32", &[0], 1),
             "empty name or type",
@@ -657,17 +669,19 @@ async fn worker_refuses_malformed_requests() {
             "no default value for ClickHouse type",
         ),
     ];
+    let name_len = FRAME_PREFIX_BYTES + 16;
     let mut bad_name = native_request(23, "c", "Int32", &[0], 1);
-    bad_name[16..20].copy_from_slice(&u32::MAX.to_be_bytes());
+    bad_name[name_len..name_len + 4].copy_from_slice(&u32::MAX.to_be_bytes());
     cases.push((bad_name, "string length 4294967295 past end of request"));
+    let type_len = name_len + 5;
     let mut bad_type = native_request(23, "c", "Int32", &[0], 1);
-    bad_type[21..25].copy_from_slice(&u32::MAX.to_be_bytes());
+    bad_type[type_len..type_len + 4].copy_from_slice(&u32::MAX.to_be_bytes());
     cases.push((bad_type, "string length 4294967295 past end of request"));
     let mut trailing = native_request(23, "c", "String", &[1, 0, 0, 0, 4, 42, 0, 0, 0], 1);
     trailing.push(0);
     cases.push((trailing, "invalid message format"));
     for (payload, expected) in cases {
-        let err = bridge.encode_native(&payload).await.unwrap_err();
+        let err = bridge.encode_native(payload).await.unwrap_err();
         assert!(
             matches!(err, BridgeError::Remote(ref msg) if msg.contains(expected)),
             "{expected}: {err}"

--- a/tests/oracle_types_e2e.rs
+++ b/tests/oracle_types_e2e.rs
@@ -17,7 +17,6 @@ use walshadow::mapping::ColumnMapping;
 use walshadow::mapping::TableTarget;
 use walshadow::oracle::Oracle;
 use walshadow::schema::RelName;
-use walshadow::shadow::Shadow;
 
 fn skip_gate() -> bool {
     if !fx::requirements_available() {
@@ -54,7 +53,7 @@ async fn run_oracle(
     ch_create_sql: &str,
     mappings: Vec<fx::TableMappingSpec>,
     workload: &str,
-) -> (Shadow, fx::ChServer, tempfile::TempDir) {
+) -> (fx::ClusterGuard, fx::ChServer, tempfile::TempDir) {
     let (source, ch, tmp, _oracle) = run_oracle_stats(
         slot,
         app_name,
@@ -74,7 +73,12 @@ async fn run_oracle_stats(
     ch_create_sql: &str,
     mappings: Vec<fx::TableMappingSpec>,
     workload: &str,
-) -> (Shadow, fx::ChServer, tempfile::TempDir, Arc<Oracle>) {
+) -> (
+    fx::ClusterGuard,
+    fx::ChServer,
+    tempfile::TempDir,
+    Arc<Oracle>,
+) {
     let tmp = tempfile::tempdir().unwrap();
     let (
         fx::BootstrappedClusters {
@@ -100,7 +104,7 @@ async fn run_oracle_stats(
 
     // Worker binds only once recovery reaches consistency, so budget the dial
     let socket = shadow.bridge_socket().expect("bridge configured");
-    let bridge = walshadow::bridge::connect_with_budget(socket, Duration::from_secs(30))
+    let bridge = walshadow::bridge::connect_with_budget(socket, 1, Duration::from_secs(30))
         .await
         .expect("bridge connect");
     assert!(

--- a/tests/pending_capture_e2e.rs
+++ b/tests/pending_capture_e2e.rs
@@ -31,7 +31,6 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use walshadow::mapping::NamespaceMapping;
-use walshadow::shadow::Shadow;
 
 fn skip_gate() -> bool {
     if !fx::requirements_available() {
@@ -41,8 +40,8 @@ fn skip_gate() -> bool {
 }
 
 struct Drill {
-    source: Shadow,
-    shadow: Shadow,
+    source: fx::ClusterGuard,
+    shadow: fx::ClusterGuard,
     ch: fx::ChServer,
     pipeline: fx::Pipeline,
     _tmp: tempfile::TempDir,

--- a/tests/pgext_listener.rs
+++ b/tests/pgext_listener.rs
@@ -178,6 +178,10 @@ fn listener_probe_failures_preserve_the_path() {
     // Stale socket, so there is a file whose survival is observable
     drop(UnixListener::bind(&path).expect("stale listener"));
     let stale_inode = fs::metadata(&path).unwrap().ino();
+    // A second link keeps that inode allocated once the path is reclaimed.
+    // Without it the rebind can be handed the number back, as ext4 does, and
+    // the reclaim reads as a survival
+    fs::hard_link(&path, tmp.path().join("stale.pinned")).expect("pin stale inode");
 
     faults.arm(&[
         Rule::fail(Op::Socket, 1, libc::EMFILE), // attempt 1: no probe possible

--- a/tests/pgext_protocol.rs
+++ b/tests/pgext_protocol.rs
@@ -58,9 +58,11 @@ fn cell_overlong(out: &mut Vec<u8>, tag: u8, len: u32) {
     out.extend_from_slice(&len.to_be_bytes());
 }
 
+/// Catalog, top xid, parked replay boundary, then the oid list and its count
 fn scan(cat: u8, top: u32, oids: &[u32]) -> Vec<u8> {
     let mut out = vec![OP_SCAN, cat];
     out.extend_from_slice(&top.to_be_bytes());
+    out.extend_from_slice(&0u64.to_be_bytes());
     out.extend_from_slice(&(oids.len() as u32).to_be_bytes());
     for oid in oids {
         out.extend_from_slice(&oid.to_be_bytes());
@@ -92,13 +94,14 @@ fn scan_rejects_arguments_it_cannot_serve() {
     // Oid list ceiling, checked before anything is allocated for it
     let mut over = vec![OP_SCAN, CAT_CLASS];
     over.extend_from_slice(&0u32.to_be_bytes());
+    over.extend_from_slice(&0u64.to_be_bytes());
     over.extend_from_slice(&65537u32.to_be_bytes());
     let msg = error_of(&mut sock, &over);
     assert!(msg.contains("65537 exceeds 65536"), "{msg}");
 
     // Oid list shorter than its own count
     let mut truncated = scan(CAT_CLASS, 0, &[1259]);
-    truncated[6..10].copy_from_slice(&2u32.to_be_bytes());
+    truncated[14..18].copy_from_slice(&2u32.to_be_bytes());
     let msg = error_of(&mut sock, &truncated);
     assert!(msg.contains("insufficient data"), "{msg}");
 

--- a/tests/pgext_worker.rs
+++ b/tests/pgext_worker.rs
@@ -12,7 +12,7 @@ mod ports;
 use std::io::Write;
 use std::time::{Duration, Instant};
 
-use pgext::{hello, hello_on, wait_until};
+use pgext::{Faults, Op, Rule, hello, hello_on, wait_until};
 
 /// Header of a one byte request frame, first byte only: enough to make the
 /// connection readable, not enough to finish the frame
@@ -236,7 +236,7 @@ fn empty_socket_path_defines_gucs_without_a_worker() {
 
     assert_eq!(
         pg.sql("SELECT count(*)::text FROM pg_settings WHERE name LIKE 'walshadow.%'"),
-        "4"
+        "5"
     );
     assert_eq!(
         pg.sql(
@@ -245,4 +245,29 @@ fn empty_socket_path_defines_gucs_without_a_worker() {
         "0"
     );
     assert!(!pg.bridge_path().exists());
+}
+
+/// Widening an accepted connection's socket buffers is advisory: a kernel that
+/// refuses leaves the defaults, which only costs more waits. The refusal is a
+/// DEBUG1 line and nothing the client can see
+#[test]
+fn worker_serves_a_connection_whose_buffers_cannot_widen() {
+    if !pgext::pg_available() {
+        eprintln!("skip: no initdb on PATH");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let mut pg = pgext::stage(tmp.path(), ports::PG_SHADOW_PORT, Duration::from_secs(30));
+    let faults = Faults::new(tmp.path());
+    // The two directions are set under one `||`, so failing the first covers
+    // the pair
+    faults.arm(&[Rule::fail(Op::Setsockopt, 1, libc::ENOBUFS)]);
+    pg.start(&faults.env());
+    pg.wait_log(0, "walshadow bridge listening");
+
+    let mut conn = hello_on(&pg.bridge_path());
+    faults.wait_consumed();
+    // Both the handshake and the request behind it crossed the connection
+    // whose buffers stayed at the default
+    hello(&mut conn);
 }

--- a/tests/runtime_config_e2e.rs
+++ b/tests/runtime_config_e2e.rs
@@ -470,7 +470,7 @@ async fn opt_in_non_empty_backfills_pre_opt_in_rows() {
     // `meta jsonb` sits outside the local matrix, so the backfill tail needs
     // the same oracle the WAL path uses
     let socket = shadow.bridge_socket().expect("bridge configured");
-    let bridge = walshadow::bridge::connect_with_budget(socket, Duration::from_secs(30))
+    let bridge = walshadow::bridge::connect_with_budget(socket, 1, Duration::from_secs(30))
         .await
         .expect("bridge connect");
     let oracle = Arc::new(walshadow::oracle::Oracle::new(Arc::new(bridge)));

--- a/tests/schema_evolution_cdc.rs
+++ b/tests/schema_evolution_cdc.rs
@@ -9,7 +9,6 @@ mod fx;
 use std::time::Duration;
 
 use walshadow::mapping::NamespaceMapping;
-use walshadow::shadow::Shadow;
 
 fn skip_gate() -> bool {
     if !fx::requirements_available() {
@@ -25,7 +24,12 @@ async fn run(
     schema_sql: &str,
     stmts: Vec<String>,
     segments: u64,
-) -> (Shadow, Shadow, fx::ChServer, tempfile::TempDir) {
+) -> (
+    fx::ClusterGuard,
+    fx::ClusterGuard,
+    fx::ChServer,
+    tempfile::TempDir,
+) {
     let tmp = tempfile::tempdir().unwrap();
     let (
         fx::BootstrappedClusters {

--- a/tests/shadow_catalog.rs
+++ b/tests/shadow_catalog.rs
@@ -81,7 +81,7 @@ async fn open_catalog(shadow: &Shadow, replay_timeout: Duration) -> ShadowCatalo
 async fn open_bridge(shadow: &Shadow) -> Arc<Bridge> {
     let path = shadow.bridge_socket().expect("bridge configured");
     Arc::new(
-        walshadow::bridge::connect_with_budget(path, Duration::from_secs(20))
+        walshadow::bridge::connect_with_budget(path, 1, Duration::from_secs(20))
             .await
             .unwrap_or_else(|e| panic!("bridge connect on {}: {e}", path.display())),
     )

--- a/tests/soft_delete_cdc.rs
+++ b/tests/soft_delete_cdc.rs
@@ -11,7 +11,6 @@ use std::time::Duration;
 use walshadow::mapping::ColumnMapping;
 use walshadow::mapping::TableTarget;
 use walshadow::schema::RelName;
-use walshadow::shadow::Shadow;
 
 // walsender must clear ch_http by >1 (CH binds interserver = ch_http + 1).
 
@@ -57,7 +56,7 @@ async fn run_drill(
     slot: fx::Ports,
     app_name: &str,
     workload: &str,
-) -> (Shadow, fx::ChServer, tempfile::TempDir) {
+) -> (fx::ClusterGuard, fx::ChServer, tempfile::TempDir) {
     run_drill_with(slot, app_name, workload, |_| {}).await
 }
 
@@ -66,7 +65,7 @@ async fn run_drill_with(
     app_name: &str,
     workload: &str,
     tune: impl FnOnce(&mut walshadow::ch_emitter::EmitterConfig),
-) -> (Shadow, fx::ChServer, tempfile::TempDir) {
+) -> (fx::ClusterGuard, fx::ChServer, tempfile::TempDir) {
     let tmp = tempfile::tempdir().unwrap();
     let (
         fx::BootstrappedClusters {

--- a/tests/subxact.rs
+++ b/tests/subxact.rs
@@ -73,7 +73,12 @@ async fn run_drill<F: FnOnce(&Shadow) -> std::thread::JoinHandle<()>>(
     slot: fx::Ports,
     app_name: &str,
     spawn_driver: F,
-) -> (Shadow, fx::ChServer, tempfile::TempDir, tempfile::TempDir) {
+) -> (
+    fx::ClusterGuard,
+    fx::ChServer,
+    tempfile::TempDir,
+    tempfile::TempDir,
+) {
     let tmp = tempfile::tempdir().unwrap();
     let (
         fx::BootstrappedClusters {

--- a/tests/visibility_repair_pg.rs
+++ b/tests/visibility_repair_pg.rs
@@ -6,7 +6,6 @@
 #[path = "common/ports.rs"]
 mod fx;
 
-use ahash::{HashSet, HashSetExt};
 use std::fs;
 use std::io::Write as _;
 use std::process::Command;
@@ -15,9 +14,12 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use walshadow::backfill_bootstrap::seed_catalog_from_source;
 use walshadow::backup_page_walk::{BackfillTuple, CatalogMap};
+use walshadow::copy_backfill::CopyRate;
+use walshadow::heap_decoder::ColumnValue;
+use walshadow::mapping::{TableMapping, TableTarget};
 use walshadow::shadow::{Shadow, ShadowConfig};
 use walshadow::source_feed::open_sql_client;
-use walshadow::visibility_repair::{PendingReason, PendingSet, repair};
+use walshadow::visibility_repair::{RepairBatch, RepairScope, RowRepair};
 
 /// Coverage boundary every baseline row carries
 const S: u64 = 0x0100_0000;
@@ -70,55 +72,109 @@ async fn seed(sh: &Shadow) -> CatalogMap {
     seed_catalog_from_source(&client).await.expect("seed")
 }
 
-async fn drain(mut rx: mpsc::Receiver<BackfillTuple>) -> Vec<BackfillTuple> {
+fn scope(catalog: &CatalogMap, name: &str) -> RepairScope {
+    let d = catalog
+        .descriptors()
+        .find(|d| &*d.rel_name.name == name)
+        .unwrap();
+    let mapping = [(
+        d.rel_name.clone(),
+        TableMapping {
+            target: TableTarget::new("default", name),
+            columns: Vec::new(),
+        },
+    )]
+    .into_iter()
+    .collect::<ahash::HashMap<_, _>>()
+    .into();
+    RepairScope::mapped(catalog, &mapping, |_| true)
+}
+
+async fn requests(sh: &Shadow, catalog: &CatalogMap, name: &str) -> Vec<BackfillTuple> {
+    let d = catalog
+        .descriptors()
+        .find(|d| &*d.rel_name.name == name)
+        .unwrap();
+    let client = open_sql_client(&fx::pg_cfg(sh, APP)).await.unwrap();
+    client
+        .query(
+            &format!(
+                "SELECT ctid::text FROM ONLY {}.{} ORDER BY ctid",
+                walshadow::pg::quote_ident(&d.rel_name.namespace),
+                walshadow::pg::quote_ident(name)
+            ),
+            &[],
+        )
+        .await
+        .unwrap()
+        .iter()
+        .map(|r| {
+            let tid: String = r.get(0);
+            let (blk, off) = tid.trim_matches(['(', ')']).split_once(',').unwrap();
+            BackfillTuple {
+                rfn: d.rfn,
+                xid: 0,
+                xmax: 0,
+                infomask: 0,
+                source_lsn: S,
+                blkno: blk.parse().unwrap(),
+                offnum: off.parse().unwrap(),
+                columns: Vec::new(),
+            }
+        })
+        .collect()
+}
+
+async fn drain(mut rx: mpsc::Receiver<Vec<BackfillTuple>>) -> Vec<BackfillTuple> {
     let mut out = Vec::new();
-    while let Some(t) = rx.recv().await {
-        out.push(t);
+    while let Some(slab) = rx.recv().await {
+        out.extend(slab);
     }
     out
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn inherited_rows_keep_their_physical_relation() {
+async fn unresolved_rows_keep_their_physical_relation() {
     if !pg_available() {
         return;
     }
     let src = start_source(
         "CREATE TABLE parent (id int PRIMARY KEY, body text);
          CREATE TABLE child () INHERITS (parent);
-         INSERT INTO parent VALUES (1, 'parent');
-         INSERT INTO child VALUES (2, 'child');",
+         INSERT INTO parent VALUES (1, 'parent'), (2, 'deleted'), (3, 'unrequested');
+         INSERT INTO child VALUES (4, 'child');",
     );
     let catalog = seed(&src.sh).await;
-    let parent = catalog
-        .descriptors()
-        .find(|d| &*d.rel_name.name == "parent")
+    let rows = requests(&src.sh, &catalog, "parent").await;
+    src.sh
+        .apply_schema_dump("DELETE FROM ONLY parent WHERE id = 2")
         .unwrap();
-    let pending = PendingSet::toast_capable(&catalog).scoped_to(
-        [(parent.rfn.db_node, parent.rfn.rel_node)]
-            .into_iter()
-            .collect(),
-    );
-    let (tx, rx) = mpsc::channel(4);
-    let collect = tokio::spawn(drain(rx));
-    let stats = repair(
-        &pending,
-        &catalog,
-        &HashSet::new(),
-        &fx::pg_cfg(&src.sh, APP),
-        S,
-        &tx,
-    )
+    let scope = scope(&catalog, "parent");
+    let (tx, rx) = mpsc::channel(1);
+    tx.send(RepairBatch {
+        rows: rows[..2].to_vec(),
+        unresolved: true,
+    })
     .await
     .unwrap();
     drop(tx);
+    let (out_tx, out_rx) = mpsc::channel(1);
+    let collect = tokio::spawn(drain(out_rx));
+    let stats = RowRepair {
+        source: fx::pg_cfg(&src.sh, APP),
+        catalog,
+        scope,
+        rate: CopyRate::new(None),
+    }
+    .run(rx, out_tx)
+    .await
+    .unwrap();
     let rows = collect.await.unwrap();
     assert_eq!(stats.rows, 1);
-    assert_eq!(rows[0].rfn, parent.rfn);
-    assert!(matches!(
-        rows[0].columns[0],
-        Some(walshadow::heap_decoder::ColumnValue::Int4(1))
-    ));
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].source_lsn, S);
+    assert!(matches!(rows[0].columns[0], Some(ColumnValue::Int4(1))));
+    assert!(stats.p_hi > S);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -135,167 +191,267 @@ async fn row_security_cannot_silently_filter_repair() {
          CREATE POLICY visible ON t FOR SELECT TO repl USING (id=1);",
     );
     let catalog = seed(&src.sh).await;
-    let pending = PendingSet::toast_capable(&catalog);
-    let mut pg = fx::pg_cfg(&src.sh, APP);
-    pg.user = "repl".into();
-    let (tx, mut rx) = mpsc::channel(4);
-    let err = repair(&pending, &catalog, &HashSet::new(), &pg, S, &tx)
+    let rows = requests(&src.sh, &catalog, "t").await;
+    let scope = scope(&catalog, "t");
+    let mut source = fx::pg_cfg(&src.sh, APP);
+    source.user = "repl".into();
+    let (tx, rx) = mpsc::channel(1);
+    tx.send(RepairBatch {
+        rows,
+        unresolved: true,
+    })
+    .await
+    .unwrap();
+    drop(tx);
+    let (out_tx, mut out_rx) = mpsc::channel(1);
+    let err = RowRepair {
+        source,
+        catalog,
+        scope,
+        rate: CopyRate::new(None),
+    }
+    .run(rx, out_tx)
+    .await
+    .unwrap_err();
+    assert!(format!("{err:#}").contains("row-level security"), "{err:#}");
+    assert!(out_rx.recv().await.is_none());
+}
+
+async fn assert_repair_rejects_after_read(change: &str, expected: &str) {
+    let src = start_source(
+        "CREATE TABLE t (id int PRIMARY KEY, body text); INSERT INTO t VALUES (1, 'a')",
+    );
+    let catalog = seed(&src.sh).await;
+    let rows = requests(&src.sh, &catalog, "t").await;
+    let scope = scope(&catalog, "t");
+    let (tx, rx) = mpsc::channel(1);
+    let (out_tx, mut out_rx) = mpsc::channel(1);
+    let worker = tokio::spawn(
+        RowRepair {
+            source: fx::pg_cfg(&src.sh, APP),
+            catalog,
+            scope,
+            rate: CopyRate::new(None),
+        }
+        .run(rx, out_tx),
+    );
+    tx.send(RepairBatch {
+        rows: rows.clone(),
+        unresolved: true,
+    })
+    .await
+    .unwrap();
+    assert_eq!(out_rx.recv().await.unwrap().len(), 1);
+    src.sh.apply_schema_dump(change).unwrap();
+    tx.send(RepairBatch {
+        rows,
+        unresolved: true,
+    })
+    .await
+    .unwrap();
+    drop(tx);
+    let err = worker.await.unwrap().unwrap_err();
+    assert!(format!("{err:#}").contains(expected), "{err:#}");
+    assert!(out_rx.recv().await.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rewritten_relation_after_first_read_fails() {
+    if !pg_available() {
+        return;
+    }
+    assert_repair_rejects_after_read("VACUUM FULL t", "rewritten inside the backup window").await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn replaced_relation_after_first_read_fails() {
+    if !pg_available() {
+        return;
+    }
+    assert_repair_rejects_after_read("DROP TABLE t; CREATE TABLE t (id int PRIMARY KEY, body text); INSERT INTO t VALUES (99, 'replacement')", "gone from the source").await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn added_column_after_first_read_fails() {
+    if !pg_available() {
+        return;
+    }
+    assert_repair_rejects_after_read(
+        "ALTER TABLE t ADD COLUMN extra int",
+        "changed inside the backup window",
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn repair_holds_relation_lock_through_copy() {
+    if !pg_available() {
+        return;
+    }
+    let src = start_source(
+        "CREATE TABLE t (id int PRIMARY KEY, body text); INSERT INTO t SELECT g, repeat('x', 700000) FROM generate_series(1, 6) g",
+    );
+    let catalog = seed(&src.sh).await;
+    let rows = requests(&src.sh, &catalog, "t").await;
+    let scope = scope(&catalog, "t");
+    let (tx, rx) = mpsc::channel(1);
+    tx.send(RepairBatch {
+        rows,
+        unresolved: true,
+    })
+    .await
+    .unwrap();
+    drop(tx);
+    let (out_tx, out_rx) = mpsc::channel(1);
+    let worker = tokio::spawn(
+        RowRepair {
+            source: fx::pg_cfg(&src.sh, APP),
+            catalog,
+            scope,
+            rate: CopyRate::new(None),
+        }
+        .run(rx, out_tx),
+    );
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while out_rx.is_empty() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+    let client = open_sql_client(&fx::pg_cfg(&src.sh, "repair-ddl-test"))
+        .await
+        .unwrap();
+    client
+        .batch_execute("SET lock_timeout = '100ms'")
+        .await
+        .unwrap();
+    let err = client
+        .batch_execute("ALTER TABLE t ADD COLUMN extra int")
         .await
         .unwrap_err();
-    assert!(format!("{err:#}").contains("row-level security"), "{err:#}");
-    drop(tx);
-    assert!(rx.recv().await.is_none());
-}
-
-/// Read TOAST-owning relation whole through PostgreSQL
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn toast_capable_relation_is_read_whole_at_the_coverage_lsn() {
-    if !pg_available() {
-        eprintln!("skip: no initdb on PATH");
-        return;
-    }
-    let src = start_source(
-        "CREATE TABLE public.t (id int4 PRIMARY KEY, body text NOT NULL) \
-           WITH (autovacuum_enabled = false);\n\
-         ALTER TABLE public.t ALTER COLUMN body SET STORAGE EXTERNAL;\n\
-         INSERT INTO public.t SELECT g, repeat('body-'||g::text||'---', 700) \
-           FROM generate_series(1, 6) g;\n\
-         DELETE FROM public.t WHERE id > 4;\n\
-         CREATE TABLE public.fixed (id int4 PRIMARY KEY, n int8 NOT NULL);\n\
-         INSERT INTO public.fixed SELECT g, g FROM generate_series(1, 3) g;\n",
-    );
-    let catalog = seed(&src.sh).await;
-    let pending = PendingSet::toast_capable(&catalog);
-    // `fixed` has no varlena column, so PostgreSQL gave it no toast relation
     assert_eq!(
-        pending.len(),
-        1,
-        "only the text-bearing relation is pending"
+        err.code(),
+        Some(&tokio_postgres::error::SqlState::LOCK_NOT_AVAILABLE)
     );
-    assert_eq!(pending.count_for(PendingReason::ExternalToast), 1);
-
-    let (tx, rx) = mpsc::channel(64);
-    let collect = tokio::spawn(drain(rx));
-    let stats = repair(
-        &pending,
-        &catalog,
-        &HashSet::new(),
-        &fx::pg_cfg(&src.sh, APP),
-        S,
-        &tx,
-    )
-    .await
-    .expect("repair");
-    drop(tx);
-    let rows = collect.await.unwrap();
-
-    assert_eq!(stats.relations, 1);
-    assert_eq!(stats.rows, 4, "the deleted versions are not visible");
-    assert_eq!(rows.len(), 4);
-    // Baseline uses coverage LSN
-    assert!(rows.iter().all(|r| r.source_lsn == S));
-    assert!(
-        stats.p_hi > S,
-        "p_hi is a frontier, sampled after the reads"
-    );
-    // Bodies came back detoasted, so nothing here consulted a chunk mirror
-    let body = rows[0].columns[1].as_ref().expect("body column");
-    assert!(
-        format!("{body:?}").contains("body-"),
-        "external value arrived inline: {body:?}"
-    );
-}
-
-/// Skip relations excluded from initial load
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn opted_out_relation_is_skipped_not_scanned() {
-    if !pg_available() {
-        eprintln!("skip: no initdb on PATH");
-        return;
-    }
-    let src = start_source(
-        "CREATE TABLE public.t (id int4 PRIMARY KEY, body text NOT NULL);\n\
-         INSERT INTO public.t VALUES (1, 'one');\n",
-    );
-    let catalog = seed(&src.sh).await;
-    let pending = PendingSet::toast_capable(&catalog);
-    let skip: HashSet<_> = catalog.descriptors().map(|d| d.rel_name.clone()).collect();
-
-    let (tx, rx) = mpsc::channel(4);
-    let collect = tokio::spawn(drain(rx));
-    let stats = repair(&pending, &catalog, &skip, &fx::pg_cfg(&src.sh, APP), S, &tx)
+    let rows = drain(out_rx).await;
+    assert_eq!(worker.await.unwrap().unwrap().rows, 6);
+    assert_eq!(rows.len(), 6);
+    client
+        .batch_execute("ALTER TABLE t ADD COLUMN extra int")
         .await
-        .expect("repair");
-    drop(tx);
-
-    assert_eq!(stats.skipped, 1);
-    assert_eq!(stats.relations, 0);
-    assert_eq!(stats.rows, 0);
-    assert!(collect.await.unwrap().is_empty());
+        .unwrap();
 }
 
-/// Seed the catalog off a baseline relation, mutate the source, then require
-/// repair to reject the drift naming every needle in `expected`
-async fn assert_repair_rejects(change: &str, expected: &[&str]) {
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn row_repair_streams_selected_versions_before_input_closes() {
+    if !pg_available() {
+        return;
+    }
+    use walshadow::heap_decoder::{ColumnValue, ToastPointer};
+    use walshadow::mapping::{ColumnMapping, TableMapping, TableTarget};
+
     let src = start_source(
-        "CREATE TABLE public.t (id int4 PRIMARY KEY, body text NOT NULL);\n\
-         INSERT INTO public.t SELECT g, 'row-'||g::text FROM generate_series(1, 4) g;\n",
+        "CREATE TABLE t (id int PRIMARY KEY, body text) WITH (autovacuum_enabled = false);
+         ALTER TABLE t ALTER COLUMN body SET STORAGE EXTERNAL;
+         INSERT INTO t SELECT g, repeat('body-' || g::text, 2000) FROM generate_series(1, 5) g;
+         CREATE TABLE child () INHERITS (t);
+         INSERT INTO child SELECT g, 'child' FROM generate_series(1, 5) g;",
     );
     let catalog = seed(&src.sh).await;
-    let pending = PendingSet::toast_capable(&catalog);
-    src.sh.apply_schema_dump(change).expect("source change");
-
-    let (tx, _rx) = mpsc::channel(4);
-    let err = repair(
-        &pending,
-        &catalog,
-        &HashSet::new(),
-        &fx::pg_cfg(&src.sh, APP),
-        S,
-        &tx,
-    )
+    let desc = catalog
+        .descriptors()
+        .find(|d| &*d.rel_name.name == "t")
+        .unwrap()
+        .clone();
+    let pg = fx::pg_cfg(&src.sh, APP);
+    let client = open_sql_client(&pg).await.unwrap();
+    let tids = client
+        .query(
+            "SELECT ctid::text FROM ONLY t WHERE id BETWEEN 2 AND 4 ORDER BY id",
+            &[],
+        )
+        .await
+        .unwrap();
+    let tuples = tids
+        .iter()
+        .map(|row| {
+            let tid: String = row.get(0);
+            let (blk, off) = tid.trim_matches(['(', ')']).split_once(',').unwrap();
+            BackfillTuple {
+                rfn: desc.rfn,
+                xid: 0,
+                xmax: 0,
+                infomask: 0,
+                source_lsn: S,
+                blkno: blk.parse().unwrap(),
+                offnum: off.parse().unwrap(),
+                columns: vec![
+                    Some(ColumnValue::Int4(0)),
+                    Some(ColumnValue::ExternalToast(ToastPointer {
+                        va_rawsize: 12004,
+                        va_extinfo: 12000,
+                        va_valueid: 1,
+                        va_toastrelid: desc.toast_oid,
+                    })),
+                ],
+            }
+        })
+        .collect();
+    client
+        .batch_execute("UPDATE ONLY t SET id = 30 WHERE id = 3; DELETE FROM ONLY t WHERE id = 4;")
+        .await
+        .unwrap();
+    let mapping = [(
+        desc.rel_name.clone(),
+        TableMapping {
+            target: TableTarget::new("default", "t"),
+            columns: vec![ColumnMapping {
+                src_attnum: 2,
+                target_name: "body".into(),
+                target_type: "String".into(),
+            }],
+        },
+    )]
+    .into_iter()
+    .collect::<ahash::HashMap<_, _>>()
+    .into();
+    let scope = RepairScope::mapped(&catalog, &mapping, |_| true);
+    let (tx, rx) = mpsc::channel(1);
+    let (out_tx, mut out_rx) = mpsc::channel(1);
+    let worker = tokio::spawn(
+        RowRepair {
+            source: pg,
+            catalog,
+            scope,
+            rate: CopyRate::new(None),
+        }
+        .run(rx, out_tx),
+    );
+    tx.send(RepairBatch {
+        rows: tuples,
+        unresolved: false,
+    })
     .await
-    .expect_err("drifted relation is not repairable");
-    let msg = format!("{err:#}");
-    for needle in expected {
-        assert!(msg.contains(needle), "want {needle:?} in {msg}");
-    }
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn rewritten_relation_fails_the_pass() {
-    if !pg_available() {
-        eprintln!("skip: no initdb on PATH");
-        return;
-    }
-    // Rewrite rotates filenode
-    assert_repair_rejects(
-        "VACUUM FULL public.t;\n",
-        &["rewritten inside the backup window"],
-    )
-    .await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn dropped_relation_fails_the_pass() {
-    if !pg_available() {
-        eprintln!("skip: no initdb on PATH");
-        return;
-    }
-    assert_repair_rejects("DROP TABLE public.t;\n", &["gone from the source"]).await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn added_column_fails_the_pass() {
-    if !pg_available() {
-        eprintln!("skip: no initdb on PATH");
-        return;
-    }
-    // No rewrite, so the filenode still matches; the shape does not. The
-    // report names the new column
-    assert_repair_rejects(
-        "ALTER TABLE public.t ADD COLUMN extra int4;\n",
-        &["changed inside the backup window", "extra"],
-    )
-    .await;
+    .unwrap();
+    let rows = tokio::time::timeout(Duration::from_secs(10), out_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        rows.len(),
+        1,
+        "exclude moved, deleted, inherited and unrequested rows"
+    );
+    assert!(matches!(rows[0].columns[0], Some(ColumnValue::Int4(2))));
+    assert!(
+        matches!(&rows[0].columns[1], Some(ColumnValue::Text(body)) if body == &"body-2".repeat(2000))
+    );
+    assert_eq!(rows[0].source_lsn, S);
+    assert!(!worker.is_finished(), "emit before backup EOF");
+    drop(tx);
+    assert!(out_rx.recv().await.is_none());
+    let stats = worker.await.unwrap().unwrap();
+    assert_eq!(stats.rows, 1);
+    assert!(stats.p_hi > S);
 }

--- a/tests/xact_buffer.rs
+++ b/tests/xact_buffer.rs
@@ -95,6 +95,7 @@ async fn open_catalog(shadow: &Shadow) -> ShadowCatalog {
     let bridge = Arc::new(
         walshadow::bridge::connect_with_budget(
             shadow.bridge_socket().expect("bridge configured"),
+            1,
             Duration::from_secs(20),
         )
         .await


### PR DESCRIPTION
1. add support for pgext to have multiple background workers for parallel oracle requests
2. resolver pool between decoder pools & inserter pools to improve concurrency
3. remove bootstrap mutex, tar entries processed in parallel
4. skip decoding pages in bootstrap for unused tables
5. threads track local counters before adding to atomics, reducing contention
6. reduce copies by using slabs, batch tuples to mpsc to reduce contention
7. OracleCell::Literal can be resolved without oracle
8. repair unresolved multixacts through batched CTID COPY, preserving other walked rows
9. lock repair relations through descriptor validation and COPY, reject drift between reads
10. provision bootstrap oracle for window WAL on initial_load=none tables
11. abort bootstrap and inserter pipeline tasks when owners drop
12. remove greenfield TOAST spools, reject mapped external pointers that escape source repair