### PR TITLE
Remove XLOG_FPI and XLOG_FPI_FOR_HINT from the logs sent to shadow pg

### DIFF
--- a/src/backfill/backfill_bootstrap.rs
+++ b/src/backfill/backfill_bootstrap.rs
@@ -66,8 +66,8 @@ impl BootstrapConfig {
         }
     }
 
-    pub fn with_catalog_filenodes(mut self, c: CatalogFilenodes) -> Self {
-        self.catalog_filenodes = c;
+    pub fn with_catalog_filenodes(mut self, c: impl IntoIterator<Item = (Oid, Oid)>) -> Self {
+        self.catalog_filenodes = c.into_iter().collect();
         self
     }
 
@@ -404,7 +404,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let cfg = BootstrapConfig::new(tmp.path().to_path_buf());
         assert!(cfg.catalog_filenodes.is_empty());
-        let cfg = cfg.with_catalog_filenodes(CatalogFilenodes::from_iter([(5, 50000), (0, 99999)]));
+        let cfg = cfg.with_catalog_filenodes([(5, 50000), (0, 99999)]);
         assert_eq!(cfg.catalog_filenodes.len(), 2);
         assert!(cfg.catalog_filenodes.is_catalog(5, 50000));
     }

--- a/src/backfill/mod.rs
+++ b/src/backfill/mod.rs
@@ -16,4 +16,5 @@ pub mod pg_path;
 pub mod spool;
 pub mod visibility_gate;
 pub mod visibility_repair;
+pub mod wal_landing;
 pub mod wal_replay;

--- a/src/backfill/wal_landing.rs
+++ b/src/backfill/wal_landing.rs
@@ -1,0 +1,290 @@
+//! Filter the WAL bootstrap landed in the shadow's `pg_wal/`.
+//!
+//! `BASE_BACKUP` with `wal = true` bundles source WAL in the tar, and the
+//! object-store leg hydrates the same range from the archive. Neither passes
+//! through [`Filter`](crate::filter::Filter): the bytes land raw and the
+//! shadow's own recovery replays them before walshadow's walsender exists, so
+//! user-heap records and their page images redo into `base/` — files the
+//! landing deliberately skipped, which redo then re-creates and zero-extends.
+//!
+//! Rewrite them once, through the same [`WalStream`] the live path uses, after
+//! the backup-window leg has read the raw bytes and before the shadow starts.
+
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+
+use anyhow::{Context, Result, bail};
+use walrus::pg::wal::segment::{SegmentName, is_wal_filename};
+
+use crate::filter::catalog_tracker::CatalogTracker;
+use crate::filter::manifest::Manifest;
+use crate::record::{Record, RecordSink, SegmentSink, SinkError, WAL_SEG_SIZE};
+use crate::source::wal_stream::WalStream;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct LandedWalStats {
+    pub segments: u64,
+    /// Segments wholly above the backup end, blanked rather than filtered
+    pub segments_blanked: u64,
+    pub kept: u64,
+    pub dropped: u64,
+    pub dropped_bytes: u64,
+}
+
+/// Rewrite every WAL segment in `pg_wal` in place, dropping user-relation
+/// records to `XLOG_NOOP`, and zero everything above `end_lsn`.
+///
+/// `tracker` carries the source's catalog filenodes so rotated catalogs
+/// (`VACUUM FULL` / `REINDEX`, filenode >= 16384) stay kept — it must be the
+/// same seed the landing's `CatalogFilenodes` used, or the two disagree and
+/// redo re-creates a heap file the landing skipped.
+pub async fn filter_landed_wal(
+    pg_wal: &Path,
+    timeline: u32,
+    end_lsn: u64,
+    tracker: CatalogTracker,
+) -> Result<LandedWalStats> {
+    let segments = segments_on_disk(pg_wal, timeline).await?;
+    let in_window = segments
+        .iter()
+        .take_while(|s| s.start_lsn(WAL_SEG_SIZE) < end_lsn)
+        .count();
+    let Some(first) = segments.first().copied().filter(|_| in_window > 0) else {
+        return Ok(LandedWalStats::default());
+    };
+
+    let mut stream = WalStream::new(timeline, WAL_SEG_SIZE, first.start_lsn(WAL_SEG_SIZE))
+        .map_err(|e| anyhow::anyhow!("wal_landing: WalStream: {e}"))?;
+    *stream.filter_mut().tracker_mut() = tracker;
+
+    let mut records = DropRecords;
+    let mut writer = WriteBack {
+        dir: pg_wal.to_path_buf(),
+        written: 0,
+    };
+    for seg in &segments[..in_window] {
+        let start = seg.start_lsn(WAL_SEG_SIZE);
+        let mut bytes = read_segment(pg_wal, *seg).await?;
+        // A recycled segment still holds its previous occupant's records
+        // above `end_lsn`. Walking them parses garbage, and leaving them lets
+        // the shadow replay unfiltered WAL past the consistency point; zeros
+        // are what a freshly initialised segment carries there.
+        let usable = end_lsn.saturating_sub(start).min(WAL_SEG_SIZE) as usize;
+        bytes[usable..].fill(0);
+        stream
+            .push(start, &bytes, &mut records, &mut writer)
+            .await
+            .map_err(|e| anyhow::anyhow!("wal_landing: {}: {e}", seg.format()))?;
+    }
+    if writer.written != in_window as u64 {
+        bail!(
+            "wal_landing: rewrote {} of {in_window} in-window segments",
+            writer.written,
+        );
+    }
+
+    let blanked = &segments[in_window..];
+    for seg in blanked {
+        write_segment(pg_wal, *seg, &vec![0u8; WAL_SEG_SIZE as usize])
+            .await
+            .with_context(|| format!("wal_landing: blank {}", seg.format()))?;
+    }
+    sync_dir(pg_wal).await?;
+
+    let stats = stream.filter().stats();
+    Ok(LandedWalStats {
+        segments: writer.written,
+        segments_blanked: blanked.len() as u64,
+        kept: stats.kept,
+        dropped: stats.dropped,
+        dropped_bytes: stats.dropped_bytes,
+    })
+}
+
+/// Segment files present, ascending. Rejects a gap or a foreign timeline:
+/// the shadow's recovery cannot cross either, and a fresh [`WalStream`] per
+/// run would drop the catalog state the previous run learned.
+async fn segments_on_disk(pg_wal: &Path, timeline: u32) -> Result<Vec<SegmentName>> {
+    let mut dir = match tokio::fs::read_dir(pg_wal).await {
+        Ok(d) => d,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e).with_context(|| format!("wal_landing: read {}", pg_wal.display())),
+    };
+    let mut found = Vec::new();
+    while let Some(entry) = dir
+        .next_entry()
+        .await
+        .with_context(|| format!("wal_landing: scan {}", pg_wal.display()))?
+    {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !is_wal_filename(name) {
+            continue;
+        }
+        let seg = SegmentName::parse(name)
+            .map_err(|e| anyhow::anyhow!("wal_landing: segment name {name}: {e}"))?;
+        if seg.timeline != timeline {
+            bail!(
+                "wal_landing: {name} sits on timeline {} but bootstrap ran on {timeline}",
+                seg.timeline,
+            );
+        }
+        found.push(seg);
+    }
+    found.sort_unstable();
+    for pair in found.windows(2) {
+        let (prev, next) = (pair[0], pair[1]);
+        if prev.next(WAL_SEG_SIZE) != next {
+            bail!(
+                "wal_landing: gap in {} between {} and {}",
+                pg_wal.display(),
+                prev.format(),
+                next.format(),
+            );
+        }
+    }
+    Ok(found)
+}
+
+async fn read_segment(dir: &Path, seg: SegmentName) -> Result<Vec<u8>> {
+    let path = dir.join(seg.format());
+    let bytes = tokio::fs::read(&path)
+        .await
+        .with_context(|| format!("wal_landing: read {}", path.display()))?;
+    if bytes.len() as u64 != WAL_SEG_SIZE {
+        bail!(
+            "wal_landing: {} is {} bytes, expected a {WAL_SEG_SIZE}-byte segment",
+            path.display(),
+            bytes.len(),
+        );
+    }
+    Ok(bytes)
+}
+
+/// Replaces a segment through a sibling temp file: a crash mid-write must not
+/// leave the shadow a half-rewritten segment it would then replay.
+async fn write_segment(dir: &Path, seg: SegmentName, bytes: &[u8]) -> std::io::Result<()> {
+    let name = seg.format();
+    let tmp = dir.join(format!("{name}.walshadow-filtering"));
+    let mut f = tokio::fs::File::create(&tmp).await?;
+    tokio::io::AsyncWriteExt::write_all(&mut f, bytes).await?;
+    f.sync_all().await?;
+    drop(f);
+    tokio::fs::rename(&tmp, dir.join(&name)).await
+}
+
+async fn sync_dir(dir: &Path) -> Result<()> {
+    let handle = tokio::fs::File::open(dir)
+        .await
+        .with_context(|| format!("wal_landing: open {}", dir.display()))?;
+    handle
+        .sync_all()
+        .await
+        .with_context(|| format!("wal_landing: fsync {}", dir.display()))
+}
+
+struct DropRecords;
+
+impl RecordSink for DropRecords {
+    fn on_record<'a>(
+        &'a mut self,
+        _record: &'a Record<'a>,
+    ) -> Pin<Box<dyn Future<Output = std::result::Result<(), SinkError>> + Send + 'a>> {
+        Box::pin(std::future::ready(Ok(())))
+    }
+}
+
+struct WriteBack {
+    dir: PathBuf,
+    written: u64,
+}
+
+impl SegmentSink for WriteBack {
+    fn on_segment<'a>(
+        &'a mut self,
+        seg: SegmentName,
+        bytes: &'a [u8],
+        _manifest: &'a Manifest,
+    ) -> Pin<Box<dyn Future<Output = std::result::Result<(), SinkError>> + Send + 'a>> {
+        Box::pin(async move {
+            write_segment(&self.dir, seg, bytes).await?;
+            self.written += 1;
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seg(seg_no: u32) -> SegmentName {
+        SegmentName {
+            timeline: 1,
+            log_id: 0,
+            seg_no,
+        }
+    }
+
+    async fn touch(dir: &Path, name: &str) {
+        tokio::fs::write(dir.join(name), b"").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn scan_orders_segments_and_ignores_aux_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        for n in [3u32, 1, 2] {
+            touch(tmp.path(), &seg(n).format()).await;
+        }
+        touch(tmp.path(), "00000002.history").await;
+        touch(tmp.path(), "000000010000000000000009.partial").await;
+        tokio::fs::create_dir(tmp.path().join("archive_status"))
+            .await
+            .unwrap();
+
+        let got = segments_on_disk(tmp.path(), 1).await.unwrap();
+        assert_eq!(got, vec![seg(1), seg(2), seg(3)]);
+    }
+
+    #[tokio::test]
+    async fn scan_refuses_a_gap() {
+        let tmp = tempfile::tempdir().unwrap();
+        touch(tmp.path(), &seg(1).format()).await;
+        touch(tmp.path(), &seg(3).format()).await;
+        let err = segments_on_disk(tmp.path(), 1).await.unwrap_err();
+        assert!(err.to_string().contains("gap"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn scan_refuses_a_foreign_timeline() {
+        let tmp = tempfile::tempdir().unwrap();
+        touch(tmp.path(), &seg(1).format()).await;
+        touch(
+            tmp.path(),
+            &SegmentName {
+                timeline: 2,
+                log_id: 0,
+                seg_no: 2,
+            }
+            .format(),
+        )
+        .await;
+        let err = segments_on_disk(tmp.path(), 1).await.unwrap_err();
+        assert!(err.to_string().contains("timeline"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn missing_pg_wal_is_not_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stats = filter_landed_wal(
+            &tmp.path().join("absent"),
+            1,
+            WAL_SEG_SIZE,
+            CatalogTracker::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(stats, LandedWalStats::default());
+    }
+}

--- a/src/bin/stream.rs
+++ b/src/bin/stream.rs
@@ -4237,9 +4237,19 @@ async fn run_bootstrap(
     let catalog_map = seed_in_snapshot(sql_client)
         .await
         .context("bootstrap: seed_in_snapshot")?;
+    // One seed, two consumers that must agree: the landing decides which
+    // relation files reach the shadow, `filter_landed_wal` decides which
+    // records may redo onto them. Disagreement re-creates a skipped file.
+    let mut landing_tracker = walshadow::catalog_tracker::CatalogTracker::new();
+    landing_tracker
+        .seed_from_source(sql_client)
+        .await
+        .context("bootstrap: seed catalog filenodes")?;
+    let catalog_filenodes: Vec<_> = landing_tracker.nodes().collect();
     tracing::info!(
         target: "walshadow::bootstrap",
         relations = catalog_map.len(),
+        catalog_filenodes = catalog_filenodes.len(),
         mode = ?plan.mode,
         shadow_data_dir = %shadow_data_dir.display(),
         "catalog map seeded",
@@ -4379,7 +4389,9 @@ async fn run_bootstrap(
         .context("bootstrap: sample source write head for the window leg")?;
     let source_major = (feed.server_version_num() / 10000) as u32;
 
-    let cfg = BootstrapConfig::new(shadow_data_dir.clone()).with_skip_filenodes(walk_skip);
+    let cfg = BootstrapConfig::new(shadow_data_dir.clone())
+        .with_skip_filenodes(walk_skip)
+        .with_catalog_filenodes(catalog_filenodes);
     let (rx, pump) = spawn_greenfield_bootstrap(cfg, source, catalog_map, store_toast);
 
     // Keep oracle alive through live or file window replay
@@ -4718,6 +4730,26 @@ async fn run_bootstrap(
         );
     }
     tokio::fs::remove_dir_all(&window_scratch).await.ok();
+
+    // The backup's WAL landed raw. Everything that needed the raw bytes has
+    // read them by now; rewrite before the shadow's recovery gets a look.
+    let landed = walshadow::backfill::wal_landing::filter_landed_wal(
+        &shadow_data_dir.join("pg_wal"),
+        outcome.start.timeline,
+        outcome.end.end_lsn,
+        landing_tracker,
+    )
+    .await
+    .context("bootstrap: filter landed WAL")?;
+    tracing::info!(
+        target: "walshadow::bootstrap",
+        segments = landed.segments,
+        segments_blanked = landed.segments_blanked,
+        kept = landed.kept,
+        dropped = landed.dropped,
+        dropped_bytes = landed.dropped_bytes,
+        "landed WAL filtered",
+    );
 
     // Resolve deferred tuples after window transaction overlay is complete
     if let Some(pending) = pending_gate {

--- a/src/filter/catalog_tracker.rs
+++ b/src/filter/catalog_tracker.rs
@@ -180,6 +180,12 @@ impl CatalogTracker {
         self.nodes.insert((db_node, rel_node));
     }
 
+    /// Known catalog `(db_node, rel_node)` pairs, for consumers that classify
+    /// off the same seed without carrying the tracker
+    pub fn nodes(&self) -> impl Iterator<Item = (u32, u32)> + '_ {
+        self.nodes.iter().copied()
+    }
+
     /// `rel < FIRST_NORMAL_OBJECT_ID` is the bootstrap rule; relmap
     /// updates add post-rewrite filenumbers. `db_node == 0` (shared:
     /// pg_database, pg_authid, …) consulted for any db.

--- a/src/filter/classify.rs
+++ b/src/filter/classify.rs
@@ -48,12 +48,22 @@ pub fn rmgr_is_special(rm: u8) -> bool {
     )
 }
 
+/// `XLOG_FPI_FOR_HINT` / `XLOG_FPI` info bytes (PG `access/xlog_internal.h`)
+pub const XLOG_FPI_FOR_HINT: u8 = 0xA0;
+pub const XLOG_FPI: u8 = 0xB0;
+
+/// Xlog-rmgr record carrying a page image rather than recovery plumbing.
+pub fn is_page_image(record: &XLogRecord) -> bool {
+    record.header.resource_manager_id == RmId::Xlog as u8
+        && matches!(record.header.info & 0xF0, XLOG_FPI | XLOG_FPI_FOR_HINT)
+}
+
 pub fn is_catalog_relnode(rel_node: u32) -> bool {
     rel_node != 0 && rel_node < FIRST_NORMAL_OBJECT_ID
 }
 
 pub fn classify(record: &XLogRecord) -> Class {
-    if rmgr_is_special(record.header.resource_manager_id) {
+    if rmgr_is_special(record.header.resource_manager_id) && !is_page_image(record) {
         return Class::Special;
     }
     if record.blocks.is_empty() {
@@ -207,6 +217,42 @@ mod tests {
     fn xlog_record_classifies_special_even_with_blocks() {
         let r = record_with(RmId::Xlog, &[16500]);
         assert_eq!(classify(&r), Class::Special);
+    }
+
+    fn fpi_record(info: u8, rel_nodes: &[u32]) -> XLogRecord<'_> {
+        let mut r = record_with(RmId::Xlog, rel_nodes);
+        r.header.info = info;
+        r
+    }
+
+    #[test]
+    fn fpi_for_hint_on_user_relation_is_dropped() {
+        let r = fpi_record(XLOG_FPI_FOR_HINT, &[16500]);
+        assert!(is_page_image(&r));
+        assert_eq!(classify(&r), Class::User);
+    }
+
+    #[test]
+    fn fpi_on_user_relation_is_dropped() {
+        assert_eq!(classify(&fpi_record(XLOG_FPI, &[16500])), Class::User);
+    }
+
+    #[test]
+    fn fpi_on_catalog_relation_still_replays() {
+        assert_eq!(classify(&fpi_record(XLOG_FPI, &[1259])), Class::Catalog);
+        assert_eq!(
+            classify(&fpi_record(XLOG_FPI_FOR_HINT, &[1259])),
+            Class::Catalog
+        );
+    }
+
+    #[test]
+    fn non_image_xlog_records_stay_special() {
+        for info in [0x00, 0x10, 0x40, 0x60, 0x90] {
+            let r = fpi_record(info, &[16500]);
+            assert!(!is_page_image(&r), "info {info:#04x}");
+            assert_eq!(classify(&r), Class::Special, "info {info:#04x}");
+        }
     }
 
     #[test]

--- a/tests/bootstrap_window_wal_not_landed_raw_e2e.rs
+++ b/tests/bootstrap_window_wal_not_landed_raw_e2e.rs
@@ -1,0 +1,246 @@
+//! WAL the `BASE_BACKUP` tar carries must not reach the shadow unfiltered.
+//!
+//! `tests/shadow_stays_catalog_scale_e2e.rs` proves the streaming filter keeps
+//! the shadow catalog-scale, but it leaves the source quiescent while the
+//! backup runs, so its tar carries almost no WAL. Direct mode requests
+//! `wal = true`, those segments land in the shadow's `pg_wal/` verbatim, and
+//! the shadow's own recovery replays them to reach consistency — before
+//! walshadow's walsender exists and without passing the filter. Every
+//! user-heap record in the backup window then redoes into `base/`, which is
+//! how a deployed shadow grows without a single record reaching the filter.
+//!
+//! Writes throughout the backup window, then asserts the user relation is
+//! still absent from the shadow and the landed-WAL pass actually had records
+//! to drop.
+
+#![cfg(target_os = "linux")]
+
+#[path = "common/bootstrap_ch_fixture.rs"]
+mod fx;
+
+use std::fs;
+use std::io::Write as _;
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use walshadow::shadow::Shadow;
+
+const ROWS: i32 = 30_000;
+/// 4 MB/s holds the backup open long enough to write a real window
+const MAX_RATE_KIB: &str = "4096";
+
+/// `Shadow::initdb` plus `-k`: checksums make every hint-bit set log a page
+/// image, the deployed source's configuration
+fn initdb_with_checksums(sh: &Shadow) {
+    let cfg = sh.config();
+    fs::create_dir_all(cfg.data_dir.parent().unwrap()).unwrap();
+    fs::create_dir_all(&cfg.socket_dir).unwrap();
+    let out = Command::new("initdb")
+        .args([
+            "-D",
+            cfg.data_dir.to_str().unwrap(),
+            "-U",
+            cfg.user.as_str(),
+            "--auth=trust",
+            "--encoding=UTF8",
+            "--locale=C",
+            "--no-instructions",
+            "-k",
+        ])
+        .output()
+        .expect("spawn initdb");
+    assert!(
+        out.status.success(),
+        "initdb -k: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn append_hint_conf(sh: &Shadow) {
+    let path = sh.config().data_dir.join("postgresql.conf");
+    let mut f = fs::OpenOptions::new().append(true).open(&path).unwrap();
+    writeln!(f, "\nwal_keep_size = 2GB").unwrap();
+}
+
+fn scalar(sh: &Shadow, sql: &str) -> u32 {
+    sh.psql_one(sql)
+        .unwrap_or_else(|e| panic!("{sql}: {e}"))
+        .trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("{sql}: not an integer: {e}"))
+}
+
+/// Bytes the shadow holds for `node`, across every segment and fork
+fn shadow_bytes(shadow_data: &Path, db: u32, node: u32) -> u64 {
+    let dir = shadow_data.join("base").join(db.to_string());
+    let Ok(rd) = fs::read_dir(&dir) else {
+        return 0;
+    };
+    let want = node.to_string();
+    rd.flatten()
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            name.split(['.', '_']).next() == Some(want.as_str())
+        })
+        .map(|e| e.metadata().map(|m| m.len()).unwrap_or(0))
+        .sum()
+}
+
+/// `dropped=N` off the daemon's `landed WAL filtered` line
+fn dropped_from_log(log: &str) -> Option<u64> {
+    let line = log.lines().find(|l| l.contains("landed WAL filtered"))?;
+    let rest = line.split("dropped=").nth(1)?;
+    rest.split(|c: char| !c.is_ascii_digit())
+        .next()?
+        .parse()
+        .ok()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn backup_window_wal_never_materialises_the_shadow() {
+    if !fx::requirements_available() {
+        return;
+    }
+
+    let slot = fx::Ports::alloc();
+    let tmp = tempfile::tempdir().unwrap();
+
+    let source = fx::make_source(&tmp);
+    initdb_with_checksums(&source);
+    source.write_base_conf().expect("source base conf");
+    fx::append_source_conf(&source).expect("append source conf");
+    append_hint_conf(&source);
+    source.start().expect("start source");
+    let _src_stop = fx::StopOnDrop { sh: &source };
+    source
+        .apply_schema_dump(&format!(
+            "CREATE TABLE public.big(id int PRIMARY KEY, payload text);\n\
+             INSERT INTO public.big SELECT g, repeat('x', 300) FROM generate_series(1, {ROWS}) g;\n\
+             CHECKPOINT;\nSELECT pg_switch_wal();\n"
+        ))
+        .expect("load pre-boot rows");
+
+    let db = scalar(
+        &source,
+        "SELECT oid::int8 FROM pg_database WHERE datname = current_database()",
+    );
+    let node = scalar(&source, "SELECT pg_relation_filenode('public.big')::int8");
+
+    let ch_tmp = tempfile::tempdir().unwrap();
+    let ch = fx::ChServer::spawn(ch_tmp, slot.ch_tcp, slot.ch_http).expect("spawn ch");
+    let ch_config_path = tmp.path().join("ch-config.toml");
+    fs::write(
+        &ch_config_path,
+        format!(
+            "[ch]\nhost = \"127.0.0.1\"\nport = {}\ndatabase = \"default\"\n\
+             compression = \"lz4\"\n\n\
+             [table.\"public\".\"big\"]\nreplicate = true\n",
+            slot.ch_tcp
+        ),
+    )
+    .expect("write ch-config");
+
+    let daemon = fx::DaemonRun::prepare(tmp.path(), slot.metrics).expect("daemon layout");
+    let child = daemon
+        .spawn(
+            &source,
+            &ch_config_path,
+            slot.walsender,
+            &[
+                "--bootstrap-max-rate-kib",
+                MAX_RATE_KIB,
+                "--bridge-lib-dir",
+                fx::pgext_dir().to_str().unwrap(),
+            ],
+        )
+        .expect("spawn walshadow-stream");
+    let guard = fx::ChildGuard::new(child);
+
+    let result = (|| -> Result<()> {
+        fx::wait_for_backup_streaming(&source, Duration::from_secs(120))
+            .context("BASE_BACKUP never opened")?;
+
+        // Dirty distinct heap pages for as long as the backup runs. With
+        // checksums on, each first touch since the checkpoint carries a page
+        // image, so this is the exact WAL shape that re-materialises a shadow.
+        let mut round = 0i32;
+        while fx::backup_in_progress(&source) {
+            let from = (round * 500) % ROWS + 1;
+            source
+                .apply_schema_dump(&format!(
+                    "UPDATE public.big SET payload = repeat('z', 300) \
+                       WHERE id BETWEEN {from} AND {};\n",
+                    from + 499,
+                ))
+                .context("in-window writes")?;
+            round += 1;
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        anyhow::ensure!(
+            round > 0,
+            "backup closed before a single in-window write landed; nothing to prove"
+        );
+
+        source
+            .apply_schema_dump(
+                "INSERT INTO public.big VALUES (2000001, 'marker');\n\
+                 SELECT pg_switch_wal();\n",
+            )
+            .context("post-window marker")?;
+
+        fx::wait_for_listen(daemon.metrics_addr, Duration::from_secs(120))
+            .context("daemon metrics endpoint never came up")?;
+        // The marker proves the pipeline consumed past the window, so the
+        // byte assertions below are about a bootstrap that actually finished
+        fx::wait_for_ch_value(
+            &ch,
+            "SELECT count() FROM default.big FINAL WHERE id = 2000001",
+            "1",
+            Duration::from_secs(180),
+        )
+        .context("post-window marker never reached CH")?;
+        let src_count = source
+            .psql_one("SELECT count(*) FROM public.big")
+            .context("source count")?;
+        fx::wait_for_ch_value(
+            &ch,
+            "SELECT count() FROM default.big FINAL WHERE _is_deleted = 0",
+            src_count.trim(),
+            Duration::from_secs(180),
+        )
+        .context("CH never matched the source row count")?;
+
+        daemon
+            .wait_for_log("landed WAL filtered", Duration::from_secs(30))
+            .context("bootstrap never ran the landed-WAL pass")?;
+        let dropped = dropped_from_log(&daemon.stderr())
+            .context("landed WAL filtered line carries no dropped= count")?;
+        anyhow::ensure!(
+            dropped > 0,
+            "the backup's WAL held no droppable records, so a clean shadow \
+             proves nothing about filtering it"
+        );
+
+        // Positive control: the same measurement over a catalog must be
+        // nonzero, or a zero for the user relation distinguishes nothing
+        let catalog_node = scalar(&source, "SELECT pg_relation_filenode('pg_class')::int8");
+        let catalog_bytes = shadow_bytes(&daemon.shadow_data_dir, db, catalog_node);
+        anyhow::ensure!(
+            catalog_bytes > 0,
+            "pg_class (relfilenode {catalog_node}) reads 0 bytes on the shadow"
+        );
+
+        let bytes = shadow_bytes(&daemon.shadow_data_dir, db, node);
+        anyhow::ensure!(
+            bytes == 0,
+            "relfilenode {node} materialised {bytes} bytes ({} pages) on the shadow; \
+             redo replayed backup-window WAL naming its blocks",
+            bytes / 8192,
+        );
+        Ok(())
+    })();
+
+    fx::finish_daemon(guard, &daemon, result);
+}

--- a/tests/fpi_user_pages.rs
+++ b/tests/fpi_user_pages.rs
@@ -1,0 +1,293 @@
+//! A full-page image of a user relation must not replay on the shadow.
+//!
+//! `XLOG_FPI` / `XLOG_FPI_FOR_HINT` ride the Xlog resource manager, which is
+//! otherwise recovery plumbing the shadow needs unconditionally. Their payload
+//! is an 8 KiB page of an arbitrary relation, so keeping them writes user pages
+//! into the shadow's `base/` — and because redo extends a relation to whatever
+//! block an image names, the shadow grows toward the source relation's whole
+//! size rather than the volume of changes. `data_checksums = on` makes every
+//! hint-bit set emit one, so a single scan of a freshly loaded table is enough.
+//!
+//! `wal_log_hints = on` produces the same records without needing `initdb -k`.
+
+#![cfg(target_os = "linux")]
+
+#[path = "common/inproc_harness.rs"]
+mod h;
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Write as _;
+use std::pin::Pin;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use walrus::pg::replication::conn::PgConfig;
+use walrus::pg::replication::tls::{SslMode, TlsParams};
+use walshadow::record::{Record, RecordSink, Route, SinkError, WAL_SEG_SIZE, rmgr_label};
+use walshadow::schema::FIRST_NORMAL_OBJECT_ID;
+use walshadow::segment_sink::DirSegmentSink;
+use walshadow::shadow::{Shadow, ShadowConfig};
+use walshadow::source_feed::{SourceEvent, SourceFeed, StandbyStatus};
+use walshadow::wal_stream::WalStream;
+
+fn pg_available() -> bool {
+    Command::new("initdb")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn make_source(tmp: &tempfile::TempDir) -> Shadow {
+    let mut cfg = ShadowConfig::new(tmp.path().join("source-data"), tmp.path().join("filtered"));
+    cfg.port = h::PG_SOURCE_PORT;
+    cfg.socket_dir = tmp.path().join("sock");
+    cfg.ctl_timeout = Duration::from_secs(60);
+    fs::create_dir_all(&cfg.filter_out_dir).unwrap();
+    fs::create_dir_all(&cfg.socket_dir).unwrap();
+    Shadow::new(cfg)
+}
+
+fn append_source_conf(sh: &Shadow) {
+    let path = sh.config().data_dir.join("postgresql.conf");
+    let mut f = fs::OpenOptions::new().append(true).open(&path).unwrap();
+    writeln!(f, "\nwal_level = logical").unwrap();
+    writeln!(f, "max_wal_senders = 4").unwrap();
+    writeln!(f, "autovacuum = off").unwrap();
+    // Stands in for data_checksums = on: makes hint-bit sets WAL-logged
+    writeln!(f, "wal_log_hints = on").unwrap();
+    // VACUUM FULL checkpoints, which would recycle the slotless pump's segments
+    writeln!(f, "wal_keep_size = 2GB").unwrap();
+    writeln!(f, "fsync = off").unwrap();
+}
+
+struct StopOnDrop<'a> {
+    sh: &'a Shadow,
+}
+
+impl Drop for StopOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.sh.stop();
+    }
+}
+
+#[derive(Default)]
+struct ImageCensus {
+    max_next_lsn: u64,
+    user_images_to_shadow: u64,
+    user_images_dropped: u64,
+    catalog_images_to_shadow: u64,
+    catalog_images_dropped: u64,
+    leaked_by_op: BTreeMap<String, u64>,
+}
+
+impl ImageCensus {
+    fn observe(&mut self, record: &Record<'_>) {
+        self.max_next_lsn = self.max_next_lsn.max(record.next_lsn);
+        for blk in &record.parsed.blocks {
+            if !blk.header.has_image() {
+                continue;
+            }
+            let rel = blk.header.location.rel.rel_node;
+            if rel == 0 {
+                continue;
+            }
+            let user = rel >= FIRST_NORMAL_OBJECT_ID;
+            match (user, record.route) {
+                (true, Route::ToShadow) => {
+                    self.user_images_to_shadow += 1;
+                    let h = &record.parsed.header;
+                    *self
+                        .leaked_by_op
+                        .entry(format!(
+                            "{}/{:#04X}",
+                            rmgr_label(h.resource_manager_id),
+                            h.info & 0xF0
+                        ))
+                        .or_default() += 1;
+                }
+                (true, Route::ToDecoder) => self.user_images_dropped += 1,
+                (false, Route::ToShadow) => self.catalog_images_to_shadow += 1,
+                (false, Route::ToDecoder) => self.catalog_images_dropped += 1,
+            }
+        }
+    }
+}
+
+impl RecordSink for ImageCensus {
+    fn on_record<'a>(
+        &'a mut self,
+        record: &'a Record<'a>,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<(), SinkError>> + Send + 'a>> {
+        Box::pin(async move {
+            self.observe(record);
+            Ok(())
+        })
+    }
+}
+
+fn current_db_oid(sh: &Shadow) -> u32 {
+    sh.psql_one("SELECT oid::int8 FROM pg_database WHERE datname = current_database()")
+        .expect("db oid")
+        .parse()
+        .expect("integer")
+}
+
+fn wal_insert_lsn(sh: &Shadow) -> u64 {
+    let s = sh
+        .psql_one("SELECT pg_current_wal_insert_lsn()")
+        .expect("lsn");
+    walshadow::pg::parse_pg_lsn(&s).expect("parse lsn")
+}
+
+async fn attach(source: &Shadow) -> (SourceFeed, WalStream) {
+    let cfg = source.config();
+    let pgcfg = PgConfig {
+        host: cfg.socket_dir.to_string_lossy().into_owned(),
+        port: cfg.port,
+        user: "postgres".into(),
+        password: None,
+        database: "postgres".into(),
+        application_name: "fpi-user-pages".into(),
+        sslmode: SslMode::Disable,
+        tls: TlsParams::default(),
+    };
+    let mut feed = SourceFeed::connect(&pgcfg)
+        .await
+        .expect("feed connect")
+        .with_status_interval(Duration::from_millis(500));
+    let ident = feed.identify_system().await.expect("IDENTIFY_SYSTEM");
+    let aligned = WalStream::align_down(ident.xlogpos, WAL_SEG_SIZE);
+    let mut stream = WalStream::new(ident.timeline, WAL_SEG_SIZE, aligned).unwrap();
+    stream.filter_mut().set_target_db(current_db_oid(source));
+    {
+        let sql_client = feed.sql_client().await.expect("sql client");
+        stream
+            .filter_mut()
+            .tracker_mut()
+            .seed_from_source(sql_client)
+            .await
+            .expect("seed_from_source");
+        stream
+            .filter_mut()
+            .seed_observed_from_source(sql_client)
+            .await
+            .expect("seed observed-from xid");
+    }
+    feed.start_physical_replication(None, aligned, ident.timeline)
+        .await
+        .expect("START_REPLICATION");
+    (feed, stream)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_page_images_never_reach_the_shadow() {
+    if !pg_available() {
+        eprintln!("skip: no initdb on PATH");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let source = make_source(&tmp);
+    source.initdb().expect("initdb");
+    source.write_base_conf().expect("base conf");
+    append_source_conf(&source);
+    source.start().expect("start");
+    let _stop = StopOnDrop { sh: &source };
+
+    source
+        .apply_schema_dump(
+            "CREATE TABLE big (id bigint primary key, payload text);\n\
+             INSERT INTO big SELECT g, repeat('x', 300) FROM generate_series(1, 40000) g;\n",
+        )
+        .expect("seed schema");
+
+    let (mut feed, mut stream) = attach(&source).await;
+    let mut segs = DirSegmentSink::new(tmp.path().join("out")).expect("out dir");
+    let mut buf = Vec::with_capacity(64 * 1024);
+    let mut census = ImageCensus::default();
+
+    // Checkpoint first so the pages are clean: the next hint-bit set on each
+    // is what emits the image. The seq scan sets them across the whole table,
+    // and touching a catalog the same way keeps the positive control honest.
+    let mut ddl = String::new();
+    for i in 0..40 {
+        ddl.push_str(&format!("CREATE TABLE churn_{i}(a int, b text);\n"));
+    }
+    ddl.push_str("CHECKPOINT;\n");
+    source.apply_schema_dump(&ddl).expect("catalog churn");
+
+    // Fresh backend, so relcache builds from the on-disk catalogs and sets
+    // hint bits on the rows the DDL above just committed. Every page whose
+    // last write predates that CHECKPOINT emits an image on first hint-bit set.
+    //
+    // VACUUM and VACUUM FULL are the paths seen re-materialising a relation on
+    // a deployed shadow: the first freezes/prunes and sets the visibility map,
+    // the second rewrites into a fresh relfilenode through log_newpage.
+    source
+        .apply_schema_dump(
+            "SELECT count(*) FROM big;\n\
+             SELECT count(*) FROM pg_class;\n\
+             SELECT count(*) FROM pg_attribute;\n\
+             UPDATE big SET payload = repeat('y', 300) WHERE id % 4 = 0;\n\
+             DELETE FROM big WHERE id % 7 = 0;\n\
+             CHECKPOINT;\n\
+             VACUUM (FREEZE) big;\n\
+             VACUUM FULL big;\n\
+             SELECT pg_switch_wal();\n",
+        )
+        .expect("dirty hint bits and vacuum");
+    let target = wal_insert_lsn(&source);
+
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while census.max_next_lsn < target && Instant::now() < deadline {
+        let next = tokio::time::timeout(
+            Duration::from_secs(2),
+            feed.next_event(StandbyStatus::collapsed(stream.dispatched_lsn()), &mut buf),
+        )
+        .await;
+        let chunk = match next {
+            Ok(Ok(SourceEvent::Wal(c))) => c,
+            Ok(Ok(_)) => break,
+            Ok(Err(e)) => panic!("source feed: {e:#}"),
+            Err(_) => continue,
+        };
+        stream
+            .push(chunk.start_lsn, chunk.data, &mut census, &mut segs)
+            .await
+            .expect("push");
+    }
+    assert!(
+        census.max_next_lsn >= target,
+        "drained to {:#X}, target {target:#X}",
+        census.max_next_lsn,
+    );
+
+    // Vacuous unless the workload actually produced user page images
+    assert!(
+        census.user_images_dropped > 0,
+        "workload produced no user page images; wal_log_hints ineffective?",
+    );
+    assert_eq!(
+        census.user_images_to_shadow, 0,
+        "user page images routed to the shadow: {} kept, {} dropped, by op {:?}",
+        census.user_images_to_shadow, census.user_images_dropped, census.leaked_by_op,
+    );
+    assert!(
+        census.catalog_images_to_shadow > 0,
+        "workload produced no catalog page images, so the keep-side assertion \
+         below would pass vacuously",
+    );
+    assert_eq!(
+        census.catalog_images_dropped, 0,
+        "catalog page images must still replay ({} dropped, {} kept)",
+        census.catalog_images_dropped, census.catalog_images_to_shadow,
+    );
+    eprintln!(
+        "user images: {} dropped / {} kept; catalog images: {} kept / {} dropped",
+        census.user_images_dropped,
+        census.user_images_to_shadow,
+        census.catalog_images_to_shadow,
+        census.catalog_images_dropped,
+    );
+}

--- a/tests/shadow_stays_catalog_scale_e2e.rs
+++ b/tests/shadow_stays_catalog_scale_e2e.rs
@@ -1,0 +1,323 @@
+//! The shadow's data dir must stay catalog-scale while a user relation churns.
+//!
+//! Routing assertions are not enough. `tests/fpi_user_pages.rs` proves user page
+//! images are classified away from the shadow, but it runs no shadow, so it
+//! cannot see redo materialise a relation. Anything the shadow replays that
+//! names a high block of a user relation extends that relation's file out to
+//! that block and zero-fills the gap, so one such record is worth gigabytes on
+//! a real table — which is why routing being correct does not settle the
+//! question.
+//!
+//! Drives the real daemon against a real shadow and asserts the outcome: after a
+//! hint-bit scan, a VACUUM and a VACUUM FULL on the source, the user relation's
+//! files on the shadow are still absent or empty.
+//!
+//! Mirrors the deployment that keeps re-materialising: the source runs with
+//! `data_checksums = on` (so every hint-bit set logs a page image) and the
+//! table opts into `initial_load = "base_backup"`, which backfills through a
+//! separate pass rather than the bootstrap page walk.
+
+#![cfg(target_os = "linux")]
+
+#[path = "common/bootstrap_ch_fixture.rs"]
+mod fx;
+
+use std::fs;
+use std::io::Write as _;
+use std::net::SocketAddr;
+use std::os::unix::process::CommandExt;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use walshadow::shadow::{Shadow, ShadowConfig};
+
+const ROWS: i32 = 20_000;
+
+fn make_source(tmp: &tempfile::TempDir) -> Shadow {
+    let mut cfg = ShadowConfig::new(
+        tmp.path().join("source-data"),
+        tmp.path().join("source-filtered"),
+    );
+    cfg.port = fx::PG_SOURCE_PORT;
+    cfg.socket_dir = tmp.path().join("source-sock");
+    cfg.ctl_timeout = Duration::from_secs(60);
+    fs::create_dir_all(&cfg.filter_out_dir).unwrap();
+    fs::create_dir_all(&cfg.socket_dir).unwrap();
+    Shadow::new(cfg)
+}
+
+/// `Shadow::initdb` plus `-k`: checksums are what make hint-bit sets emit page
+/// images on the deployed source, and the shadow inherits them via base backup
+fn initdb_with_checksums(sh: &Shadow) {
+    let cfg = sh.config();
+    fs::create_dir_all(cfg.data_dir.parent().unwrap()).unwrap();
+    fs::create_dir_all(&cfg.socket_dir).unwrap();
+    let out = Command::new("initdb")
+        .args([
+            "-D",
+            cfg.data_dir.to_str().unwrap(),
+            "-U",
+            cfg.user.as_str(),
+            "--auth=trust",
+            "--encoding=UTF8",
+            "--locale=C",
+            "--no-instructions",
+            "-k",
+        ])
+        .output()
+        .expect("spawn initdb");
+    assert!(
+        out.status.success(),
+        "initdb -k: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The retention floor keeps VACUUM FULL's checkpoint from recycling the
+/// slotless pump's segments
+fn append_hint_conf(sh: &Shadow) {
+    let path = sh.config().data_dir.join("postgresql.conf");
+    let mut f = fs::OpenOptions::new().append(true).open(&path).unwrap();
+    writeln!(f, "\nwal_keep_size = 2GB").unwrap();
+}
+
+fn scalar(sh: &Shadow, sql: &str) -> u32 {
+    sh.psql_one(sql)
+        .unwrap_or_else(|e| panic!("{sql}: {e}"))
+        .trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("{sql}: not an integer: {e}"))
+}
+
+/// Bytes the shadow holds for `node`, across every segment and fork
+fn shadow_bytes(shadow_data: &Path, db: u32, node: u32) -> u64 {
+    let dir = shadow_data.join("base").join(db.to_string());
+    let Ok(rd) = fs::read_dir(&dir) else {
+        return 0;
+    };
+    let want = node.to_string();
+    rd.flatten()
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            name.split(['.', '_']).next() == Some(want.as_str())
+        })
+        .map(|e| e.metadata().map(|m| m.len()).unwrap_or(0))
+        .sum()
+}
+
+fn write_config(path: &Path, ch_port: u16) -> Result<()> {
+    let body = format!(
+        "[ch]\nhost = \"127.0.0.1\"\nport = {ch_port}\ndatabase = \"default\"\n\
+         compression = \"lz4\"\n\n\
+         [table.\"public\".\"big\"]\nreplicate = true\ninitial_load = \"base_backup\"\n"
+    );
+    fs::write(path, body).context("write ch-config")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn user_relation_never_materialises_on_the_shadow() {
+    if !fx::pg_available() || !fx::pg_basebackup_available() || !fx::clickhouse_available() {
+        eprintln!("skip: missing initdb / pg_basebackup / clickhouse");
+        return;
+    }
+
+    let slot = fx::Ports::alloc();
+    let tmp = tempfile::tempdir().unwrap();
+
+    let source = make_source(&tmp);
+    initdb_with_checksums(&source);
+    source.write_base_conf().expect("source base conf");
+    fx::append_source_conf(&source).expect("append source conf");
+    append_hint_conf(&source);
+    source.start().expect("start source");
+    let _src_stop = fx::StopOnDrop { sh: &source };
+    source
+        .apply_schema_dump(&format!(
+            "CREATE TABLE public.big(id int PRIMARY KEY, payload text);\n\
+             INSERT INTO public.big SELECT g, repeat('x', 300) FROM generate_series(1, {ROWS}) g;\n\
+             CHECKPOINT;\nSELECT pg_switch_wal();\n"
+        ))
+        .expect("load pre-boot rows");
+
+    let db = scalar(
+        &source,
+        "SELECT oid::int8 FROM pg_database WHERE datname = current_database()",
+    );
+    let node_before = scalar(&source, "SELECT pg_relation_filenode('public.big')::int8");
+
+    let ch_tmp = tempfile::tempdir().unwrap();
+    let ch = fx::ChServer::spawn(ch_tmp, slot.ch_tcp, slot.ch_http).expect("spawn ch");
+    let ch_config_path = tmp.path().join("ch-config.toml");
+    write_config(&ch_config_path, slot.ch_tcp).expect("write ch-config");
+
+    let bootstrap_shadow_data_dir = tmp.path().join("shadow-data");
+    let shadow_sock = tmp.path().join("shadow-sock");
+    fs::create_dir_all(&shadow_sock).unwrap();
+    let shadow_filter_dir = tmp.path().join("filtered");
+    fs::create_dir_all(&shadow_filter_dir).unwrap();
+    let spill_dir = tmp.path().join("spill");
+    fs::create_dir_all(&spill_dir).unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_walshadow-stream");
+    let stderr_path = tmp.path().join("daemon.stderr.log");
+    let stderr_file = fs::File::create(&stderr_path).expect("open daemon stderr log");
+    let metrics_addr: SocketAddr = format!("127.0.0.1:{}", slot.metrics).parse().unwrap();
+    let child = Command::new(bin)
+        .args([
+            "--host",
+            source.config().socket_dir.to_str().unwrap(),
+            "--port",
+            &fx::PG_SOURCE_PORT.to_string(),
+            "--user",
+            "postgres",
+            "--dbname",
+            "postgres",
+            "--sslmode",
+            "disable",
+            "--out-dir",
+            shadow_filter_dir.to_str().unwrap(),
+            "--shadow-socket-dir",
+            shadow_sock.to_str().unwrap(),
+            "--shadow-port",
+            &fx::PG_SHADOW_PORT.to_string(),
+            "--shadow-user",
+            "postgres",
+            "--bridge-lib-dir",
+            fx::pgext_dir().to_str().unwrap(),
+            "--spill-dir",
+            spill_dir.to_str().unwrap(),
+            "--status-interval",
+            "1",
+            "--metrics-bind",
+            &metrics_addr.to_string(),
+            "--walsender-bind",
+            &format!("127.0.0.1:{}", slot.walsender),
+            "--retention-bytes",
+            "0",
+            "--ch-config",
+            ch_config_path.to_str().unwrap(),
+            "--bootstrap-mode",
+            "direct",
+            "--bootstrap-shadow-data-dir",
+            bootstrap_shadow_data_dir.to_str().unwrap(),
+            "--bootstrap-shadow-replay-timeout",
+            "120",
+        ])
+        .env("RUST_LOG", "warn,walshadow=info")
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr_file))
+        .process_group(0)
+        .spawn()
+        .expect("spawn walshadow-stream");
+    let guard = fx::ChildGuard::new(child);
+
+    let result = (|| -> Result<()> {
+        fx::wait_for_listen(metrics_addr, Duration::from_secs(120))
+            .context("daemon never bound its metrics endpoint")?;
+
+        // Bootstrap page-walked the rows to CH without landing the heap
+        let deadline = Instant::now() + Duration::from_secs(180);
+        loop {
+            let n = ch
+                .query("SELECT count() FROM default.big")
+                .unwrap_or_default();
+            if n == ROWS.to_string() {
+                break;
+            }
+            anyhow::ensure!(
+                Instant::now() < deadline,
+                "bootstrap rows never reached CH (count={n:?})"
+            );
+            std::thread::sleep(Duration::from_millis(250));
+        }
+        // Positive control: the same measurement over a catalog must be
+        // nonzero, or a zero for the user relation proves nothing
+        let catalog_node = scalar(&source, "SELECT pg_relation_filenode('pg_class')::int8");
+        let catalog_bytes = shadow_bytes(&bootstrap_shadow_data_dir, db, catalog_node);
+        anyhow::ensure!(
+            catalog_bytes > 0,
+            "pg_class (relfilenode {catalog_node}) reads 0 bytes on the shadow, so the \
+             user-relation assertions below cannot distinguish anything"
+        );
+
+        let after_boot = shadow_bytes(&bootstrap_shadow_data_dir, db, node_before);
+        anyhow::ensure!(
+            after_boot == 0,
+            "bootstrap landed {after_boot} bytes of the user relation on the shadow"
+        );
+
+        // Hint bits, then the two vacuum shapes seen re-materialising a
+        // deployed shadow. VACUUM FULL rewrites into a fresh relfilenode.
+        source
+            .apply_schema_dump(
+                "CHECKPOINT;\n\
+                 SELECT count(*) FROM public.big;\n\
+                 UPDATE public.big SET payload = repeat('y', 300) WHERE id % 4 = 0;\n\
+                 DELETE FROM public.big WHERE id % 7 = 0;\n\
+                 CHECKPOINT;\n\
+                 VACUUM (FREEZE) public.big;\n\
+                 VACUUM FULL public.big;\n\
+                 INSERT INTO public.big VALUES (2000001, 'marker');\n\
+                 SELECT pg_switch_wal();\n",
+            )
+            .context("churn workload")?;
+        let node_after = scalar(&source, "SELECT pg_relation_filenode('public.big')::int8");
+
+        // The marker proves the pipeline consumed past the vacuums, so the
+        // byte assertions below are about a stream that actually arrived
+        let deadline = Instant::now() + Duration::from_secs(180);
+        loop {
+            let n = ch
+                .query("SELECT count() FROM default.big FINAL WHERE id = 2000001")
+                .unwrap_or_default();
+            if n == "1" {
+                break;
+            }
+            anyhow::ensure!(
+                Instant::now() < deadline,
+                "post-vacuum marker never reached CH (count={n:?})"
+            );
+            std::thread::sleep(Duration::from_millis(250));
+        }
+
+        for (label, node) in [("pre-vacuum", node_before), ("post-vacuum", node_after)] {
+            let bytes = shadow_bytes(&bootstrap_shadow_data_dir, db, node);
+            anyhow::ensure!(
+                bytes == 0,
+                "{label} relfilenode {node} materialised {bytes} bytes on the shadow \
+                 ({} pages); redo replayed something naming its blocks",
+                bytes / 8192,
+            );
+        }
+        Ok(())
+    })();
+
+    let _ = guard.into_inner().map(|mut c| {
+        let _ = c.kill();
+        let _ = c.wait();
+    });
+    if bootstrap_shadow_data_dir.join("postmaster.pid").exists() {
+        let mut shadow_cfg =
+            ShadowConfig::new(bootstrap_shadow_data_dir.clone(), shadow_filter_dir.clone());
+        shadow_cfg.port = fx::PG_SHADOW_PORT;
+        shadow_cfg.socket_dir = shadow_sock.clone();
+        shadow_cfg.ctl_timeout = Duration::from_secs(60);
+        let _ = Shadow::new(shadow_cfg).stop();
+    }
+    let _ = &ch;
+
+    if let Err(e) = result {
+        if let Ok(keep) = std::env::var("WS_KEEP_ARTIFACTS") {
+            let _ = fs::create_dir_all(&keep);
+            let _ = Command::new("cp")
+                .args(["-a", shadow_filter_dir.to_str().unwrap(), &keep])
+                .status();
+            let _ = fs::copy(&stderr_path, Path::new(&keep).join("daemon.stderr.log"));
+            eprintln!("artifacts kept in {keep}");
+        }
+        let stderr = fs::read_to_string(&stderr_path).unwrap_or_default();
+        panic!("{e:#}\n--- daemon stderr ---\n{stderr}");
+    }
+}


### PR DESCRIPTION
XLOG_FPI ends up sending entire 8KB blocks to the shadow pg, causing the shadow-data to bloat up. 
Also fixes #132 